### PR TITLE
store: initial job queue implemenation

### DIFF
--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -13,3 +13,4 @@ depends on postgres and Minio and provides the following abstractions.
 
 - [Postgres migrations](./postgres-migrations.md)
 - [File store](./file-store.md)
+- [JobQueue](./queue.md)

--- a/docs/store/queue.md
+++ b/docs/store/queue.md
@@ -1,0 +1,74 @@
+# Job Queue
+
+@lbu/store also comes with a Postgres backed queue implementation. The queue
+supports the following:
+
+- First In, First Out job handling
+- Prioritize jobs
+- Schedule jobs for execution in the future
+- Run workers for specific jobs
+
+Example usage:
+
+```ecmascript 6
+mainFn(import.meta, log, main);
+
+async function main() {
+  const sql = await newPostgresConnection();
+
+  const jobHandler = async (sql, data) => {
+    console.log(data.name); // "myJob"
+
+    // simulate work
+    await new Promise(r => setTimeout(r, 100));
+  }
+
+  // parallelCount shouldn't be higher than Postgres pool size
+  const queueWorker = new JobQueueWorker(sql, "myJob", { parallelCount: 5, pollInterval: 1500 });
+
+  // Start queue
+  queueWorker.start();
+
+  setInterval(() => {
+    // Get current queue size
+    queueWorker.pendingQueueSize().then(({ pendingCount, scheduledCount }) => {
+      log.info({ pendingCount, scheduledCount });
+    });
+  }, 1500);
+
+  setTimeout(() => {
+    // running jobs are not cancelled
+    // but no new job is started
+    queueWorker.stop();
+  }, 5000);
+
+
+  // By default uses "myJob" as name
+  await queueWorker.addJob({ data: {} });
+
+  // Items with a lower priority value are prioritized, defaults to 0
+  await queueWorker.addJob({ priority: 5, data: {} });
+
+  // Add job with a different name
+  await queueWorker.addJob({ name: "otherJob", data: {} });
+
+  // Add job with scheduled time to run, defaults to immediately
+  const scheduledAt = new Date();
+  scheduledAt.setDate(scheduledAt.getDate() + 1); // Tomorrow
+  await queueWorker.addJob({ scheduledAt, data: {} });
+
+  // Returns a job id, so you can use it as a tracking id / use it as a foreign key
+  const jobId = await queueWorker.addJob({ data: {} });
+
+
+  // The same api is available in separate exported function, so you don't have to pass the queueWorker around
+  const otherJobId = await addJobToQueue(sql, { name: "myJob", data: {} });
+
+  // Get the average time to completion for jobs
+  const start = new Date();
+  start.setDate(start.getDate() - 1);
+  const end = new Date();
+  const average = await queueWorker.averageTimeToCompletion(start, end);
+}
+
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,6 @@
+- Test queue, finish up some docs
+- Fix template issues
+  - also add queue example
+- Add graphql middleware
+- Add file download middleware
+- Design sql generator plugin

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -8,16 +8,20 @@ export {
   listObjects,
   removeBucketAndObjectsInBucket,
 } from "./src/minio.js";
+
 export { newPostgresConnection, postgres } from "./src/postgres.js";
+
 export {
   cleanupTestPostgresDatabase,
   createTestPostgresDatabase,
 } from "./src/testing.js";
+
 export {
   newMigrateContext,
   getMigrationsToBeApplied,
   runMigrations,
 } from "./src/migrations.js";
+
 export {
   createFile,
   copyFile,
@@ -27,6 +31,9 @@ export {
   deleteFile,
   syncDeletedFiles,
 } from "./src/files.js";
+
+export { JobQueueWorker, addJobToQueue } from "./src/queue.js";
+
 export { newSessionStore } from "./src/sessions.js";
 
 export const migrations = dirnameForModule(import.meta) + "/migrations";

--- a/packages/store/migrations/004-queue.sql
+++ b/packages/store/migrations/004-queue.sql
@@ -1,0 +1,15 @@
+CREATE TABLE job_queue
+(
+  id           BIGSERIAL PRIMARY KEY,
+  is_complete  BOOL        DEFAULT FALSE,
+  priority     INT         NOT NULL,
+  scheduled_at TIMESTAMPTZ NOT NULL,
+  created_at   TIMESTAMPTZ DEFAULT now(),
+  updated_at   TIMESTAMPTZ,
+  name         VARCHAR     NOT NULL,
+  data         JSONB       NOT NULL
+);
+
+CREATE INDEX job_queue_search_idx ON job_queue (is_complete, scheduled_at);
+CREATE INDEX job_queue_name_idx ON job_queue (name);
+CREATE INDEX job_queue_updated_at ON job_queue (updated_at);

--- a/packages/store/src/migrations.test.js
+++ b/packages/store/src/migrations.test.js
@@ -30,7 +30,7 @@ test("store/migrations", (t) => {
     );
 
     t.deepEqual(mc.namespaces, ["@lbu/store", process.env.APP_NAME]);
-    t.equal(mc.files.length, 6);
+    t.equal(mc.files.length, 7);
 
     const list = getMigrationsToBeApplied(mc);
     t.equal(list.length, 3);

--- a/packages/store/src/queue.js
+++ b/packages/store/src/queue.js
@@ -1,0 +1,365 @@
+const queries = {
+  insertJob: (sql, name, data, priority, scheduled_at) =>
+    sql`INSERT INTO job_queue ${sql(
+      { name, data, priority, scheduled_at },
+      "name",
+      "data",
+      "priority",
+      "scheduled_at",
+    )} RETURNING id`,
+
+  getJobById: (sql, id) =>
+    sql`SELECT id, created_at, scheduled_at, name, data FROM job_queue WHERE id = ${id}`,
+
+  // Should only run in a transaction
+  getAnyJob: (sql) => sql`UPDATE job_queue
+                          SET is_complete = TRUE,
+                              updated_at  = now()
+                          WHERE id = (SELECT id
+                                      FROM job_queue
+                                      WHERE NOT is_complete
+                                        AND scheduled_at < now()
+                                      ORDER BY scheduled_at, priority
+                                        FOR UPDATE SKIP LOCKED
+                                      LIMIT 1)
+                          RETURNING id`,
+
+  // Should only run in a transaction
+  getJobByName: (name, sql) => sql`UPDATE job_queue
+                            SET is_complete = TRUE,
+                                updated_at  = now()
+                            WHERE id = (SELECT id
+                                        FROM job_queue
+                                        WHERE NOT is_complete
+                                          AND scheduled_at < now()
+                                          AND name = ${name}
+                                        ORDER BY scheduled_at, priority 
+                                        FOR UPDATE SKIP LOCKED
+                                        LIMIT 1)
+                            RETURNING id`,
+
+  // Alternatively use COUNT with a WHERE and UNION all to calculate the same
+  getPendingQueueSize: (
+    sql,
+  ) => sql`SELECT sum(CASE WHEN scheduled_at < now() THEN 1 ELSE 0 END) AS  pending_count,
+                                            sum(CASE WHEN scheduled_at >= now() THEN 1 ELSE 0 END) AS scheduled_count
+                                     FROM job_queue
+                                     WHERE NOT is_complete`,
+
+  // Alternatively use COUNT with a WHERE and UNION all to calculate the same
+  getPendingQueueSizeForName: (
+    sql,
+    name,
+  ) => sql`SELECT sum(CASE WHEN scheduled_at < now() THEN 1 ELSE 0 END) AS  pending_count,
+                                            sum(CASE WHEN scheduled_at >= now() THEN 1 ELSE 0 END) AS scheduled_count
+                                     FROM job_queue
+                                     WHERE NOT is_complete AND name = ${name}`,
+
+  // Returns time in milliseconds
+  getAverageJobTime: (sql, dateStart, dateEnd) =>
+    sql`SELECT avg((EXTRACT(EPOCH FROM updated_at AT TIME ZONE 'UTC') * 1000) - (EXTRACT(EPOCH FROM scheduled_at AT TIME ZONE 'UTC') * 1000)) AS completion_time FROM job_queue WHERE is_complete AND updated_at > ${dateStart} AND updated_at <= ${dateEnd};`,
+
+  // Returns time in milliseconds
+  getAverageJobTimeForName: (sql, name, dateStart, dateEnd) =>
+    sql`SELECT avg((EXTRACT(EPOCH FROM updated_at AT TIME ZONE 'UTC') * 1000) - (EXTRACT(EPOCH FROM scheduled_at AT TIME ZONE 'UTC') * 1000)) AS completion_time FROM job_queue WHERE is_complete AND name = ${name} AND updated_at > ${dateStart} AND updated_at <= ${dateEnd};`,
+};
+
+/**
+ * @name JobData
+ * @typedef {object}
+ * @property {number} id
+ * @property {Date} created_at
+ * @property {Date} scheduled_at
+ * @property {string} name
+ * @property {object} data
+ */
+
+/**
+ * @name JobInput
+ * @typedef {object}
+ * @property {number} [priority=0]
+ * @property {object} [data={}]
+ * @property {Date} [scheduledAt]
+ * @property {string} [name]
+ */
+
+/**
+ * @name JobQueueWorkerOptions
+ * @typedef {object}
+ * @property {function(sql: *, data: JobData): (void|Promise<void>)} handler
+ * @property {number} [pollInterval] Determine the poll interval in milliseconds if the
+ *   queue was empty. Defaults to 1500 ms
+ * @property {number} [parallelCount] Set the amount of parallel jobs to process.
+ *   Defaults to 1
+ */
+
+export class JobQueueWorker {
+  /**
+   * Create a new JobQueueWorker
+   * @param sql
+   * @param {string|JobQueueWorkerOptions} nameOrOptions
+   * @param {JobQueueWorkerOptions} [options]
+   */
+  constructor(sql, nameOrOptions, options) {
+    this.sql = sql;
+
+    // Default query ignores name
+    this.newJobQuery = queries.getAnyJob.bind(undefined);
+
+    if (typeof nameOrOptions === "string") {
+      // Use the name query and bind the name already, else we would have to use this
+      // when executing the query
+      this.newJobQuery = queries.getJobByName.bind(undefined, nameOrOptions);
+      this.name = nameOrOptions;
+    } else {
+      options = nameOrOptions;
+    }
+
+    this.pollInterval = options?.pollInterval ?? 1500;
+
+    // Setup the worker array, each value is either undefined or a running Promise
+    this.workers = Array(options?.parallelCount ?? 1).fill(undefined);
+
+    this.timeout = undefined;
+    this.isStarted = false;
+
+    this.jobHandler = options?.handler;
+  }
+
+  /**
+   * @public
+   * Start the JobQueueWorker
+   */
+  start() {
+    if (this.isStarted) {
+      return;
+    }
+
+    if (this.jobHandler === undefined) {
+      throw new Error(
+        "Can't start JobQueueWorker. Please specify a handler in the constructor options",
+      );
+    }
+
+    this.isStarted = true;
+    this.run();
+  }
+
+  /**
+   * @public
+   * Stop the JobQueueWorker
+   * Running jobs will continue to run, but no new jobs are fetched
+   */
+  stop() {
+    if (!this.isStarted) {
+      return;
+    }
+
+    clearTimeout(this.timeout);
+    this.timeout = undefined;
+    this.isStarted = false;
+  }
+
+  /**
+   * @public
+   * Get the number of jobs that need to run
+   * @return {Promise<{pending_count: number, scheduled_count: number}|undefined>}
+   */
+  pendingQueueSize() {
+    if (this.name) {
+      return getPendingQueueSizeForName(this.sql);
+    }
+    return getPendingQueueSize(this.sql);
+  }
+
+  /**
+   * @public
+   * Return the average time between scheduled and completed for jobs completed in the
+   * provided time range in milliseconds
+   * @param {Date} startDate
+   * @param {Date} endDate
+   * @return {Promise<number>}
+   */
+  averageTimeToCompletion(startDate, endDate) {
+    if (this.name) {
+      return getAverageTimeToJobCompletionForName(
+        this.sql,
+        this.name,
+        startDate,
+        endDate,
+      );
+    }
+
+    return getAverageTimeToJobCompletion(this.sql, startDate, endDate);
+  }
+
+  /**
+   * @public
+   * Uses this queue name and connection to add a job to the queue
+   * @param {JobInput} job
+   * @return {Promise<number>}
+   */
+  addJob(job) {
+    if (this.name && !job.name) {
+      // If this JobQueueWorker has a name, and the job input doesn't use that name.
+      job.name = this.name;
+    }
+
+    return addJobToQueue(this.sql, job);
+  }
+
+  /**
+   * @private
+   */
+  run() {
+    if (!this.isStarted) {
+      // Ignore this call since we should stop;
+      return;
+    }
+
+    if (this.timeout !== undefined) {
+      clearTimeout(this.timeout);
+      this.timeout = undefined;
+    }
+
+    for (let i = 0; i < this.workers.length; ++i) {
+      if (this.workers[i] !== undefined) {
+        // worker has a pending promise
+        continue;
+      }
+
+      this.handleJob(i);
+    }
+
+    this.timeout = setTimeout(() => this.run(), this.pollInterval);
+  }
+
+  /**
+   * @private
+   * @param {number} idx
+   */
+  handleJob(idx) {
+    this.workers[idx] = this.sql
+      .begin(async (sql) => {
+        // run in transaction
+
+        const [job] = await this.newJobQuery(sql);
+        if (job === undefined || job.id === undefined) {
+          // reset this 'worker'
+          this.workers[idx] = undefined;
+          return;
+        }
+
+        const [jobData] = await queries.getJobById(sql, job.id);
+
+        // We need to catch errors to be able to reset the worker.
+        // We throw this error afterwards, so the Postgres library
+        // will automatically call ROLLBACK for us.
+        let error = undefined;
+
+        try {
+          await this.jobHandler(sql, jobData);
+        } catch (err) {
+          error = err;
+        } finally {
+          this.workers[idx] = undefined;
+        }
+
+        if (error) {
+          throw error;
+        } else {
+          // Run again as soon as possible
+          setImmediate(this.run.bind(this));
+        }
+      })
+      .catch((e) => {
+        console.error(e);
+      }); // user should have handled error already, so ignore it
+  }
+}
+
+/**
+ *Add a new item to the job queue
+ * @param sql
+ * @param {JobInput} job
+ * @return {Promise<number>}
+ */
+export async function addJobToQueue(sql, job) {
+  const [result] = await queries.insertJob(
+    sql,
+    job.name ?? process.env.APP_NAME,
+    JSON.stringify(job.data ?? {}),
+    job.priority ?? 0,
+    job.scheduledAt ?? new Date(),
+  );
+  return result?.id;
+}
+
+/**
+ * Get the number of jobs that need to run
+ * @param sql
+ * @return {Promise<{pendingCount: number, scheduledCount: number}>}
+ */
+async function getPendingQueueSize(sql) {
+  const [result] = await queries.getPendingQueueSize(sql);
+
+  // sql returns 'null' if no rows match, so coalesce in to '0'
+  return {
+    pendingCount: result?.pending_count ?? 0,
+    scheduledCount: result?.scheduled_count ?? 0,
+  };
+}
+
+/**
+ * Get the number of jobs that need to run for specified job name
+ * @param sql
+ * @param {string} name
+ * @return {Promise<{pendingCount: number, scheduledCount: number}>}
+ */
+async function getPendingQueueSizeForName(sql, name) {
+  const [result] = await queries.getPendingQueueSizeForName(sql, name);
+
+  // sql returns 'null' if no rows match, so coalesce in to '0'
+  return {
+    pendingCount: result?.pending_count ?? 0,
+    scheduledCount: result?.scheduled_count ?? 0,
+  };
+}
+
+/**
+ * Return the average time between scheduled and completed for jobs completed in the
+ * provided time range
+ * @param sql
+ * @param {Date} startDate
+ * @param {Date} endDate
+ * @return {Promise<number>}
+ */
+async function getAverageTimeToJobCompletion(sql, startDate, endDate) {
+  const [result] = await queries.getAverageJobTime(sql, startDate, endDate);
+
+  return result?.completion_time ?? 0;
+}
+
+/**
+ * Return the average time between scheduled and completed for jobs completed in the
+ * provided time range
+ * @param sql
+ * @param {string} name
+ * @param {Date} startDate
+ * @param {Date} endDate
+ * @return {Promise<number>}
+ */
+async function getAverageTimeToJobCompletionForName(
+  sql,
+  name,
+  startDate,
+  endDate,
+) {
+  const [result] = await queries.getAverageJobTimeForName(
+    sql,
+    name,
+    startDate,
+    endDate,
+  );
+  return result?.completion_time ?? 0;
+}

--- a/packages/store/src/queue.test.js
+++ b/packages/store/src/queue.test.js
@@ -1,0 +1,109 @@
+import { log } from "@lbu/insight";
+import { isNil, mainFn } from "@lbu/stdlib";
+import test from "tape";
+import { JobQueueWorker } from "./queue.js";
+import {
+  cleanupTestPostgresDatabase,
+  createTestPostgresDatabase,
+} from "./testing.js";
+
+mainFn(import.meta, log, () => {});
+
+test("store/queue", async (t) => {
+  let sql = undefined;
+
+  t.test("create a test db", async (t) => {
+    sql = await createTestPostgresDatabase();
+    t.ok(!!sql);
+
+    let result = await sql`SELECT 1 + 2 AS sum`;
+    t.equal(result[0].sum, 3);
+  });
+
+  /** @type {JobQueueWorker|undefined} */
+  let qw = undefined;
+  const handlerCalls = [];
+  const handler = (sql, data) => {
+    handlerCalls.push(data);
+  };
+
+  t.test("create a JobQueueWorker", async (t) => {
+    qw = new JobQueueWorker(sql, {
+      parallelCount: 1,
+      pollInterval: 10,
+      handler,
+    });
+
+    t.equal(handlerCalls.length, 0);
+  });
+
+  t.test("empty queue to start with", async (t) => {
+    t.deepEqual(await qw.pendingQueueSize(), {
+      pendingCount: 0,
+      scheduledCount: 0,
+    });
+  });
+
+  t.test("add normal job returns id", async (t) => {
+    const id = await qw.addJob({ name: "job1" });
+    t.ok(!isNil(id));
+  });
+
+  t.test("single job pending", async (t) => {
+    t.deepEqual(await qw.pendingQueueSize(), {
+      pendingCount: 1,
+      scheduledCount: 0,
+    });
+  });
+
+  t.test("add scheduled job returns id", async (t) => {
+    const d = new Date();
+    d.setSeconds(d.getSeconds() + 1);
+
+    const id = await qw.addJob({ name: "job1", scheduledAt: d });
+    t.ok(!isNil(id));
+  });
+
+  t.test("single job pending and single job scheduled", async (t) => {
+    t.deepEqual(await qw.pendingQueueSize(), {
+      pendingCount: 1,
+      scheduledCount: 1,
+    });
+  });
+
+  t.test("average time to job completion should be 0", async (t) => {
+    const start = new Date();
+    const end = new Date();
+    start.setHours(start.getHours() - 1);
+
+    t.equal(await qw.averageTimeToCompletion(start, end), 0);
+  });
+
+  t.test("quick start / stop sequence", async (t) => {
+    qw.start();
+    await new Promise((r) => setTimeout(r, 15));
+    qw.stop();
+    t.ok(!qw.isStarted);
+  });
+
+  t.test("single scheduled job pending", async (t) => {
+    t.equal(handlerCalls.length, 1);
+    t.deepEqual(await qw.pendingQueueSize(), {
+      pendingCount: 0,
+      scheduledCount: 1,
+    });
+  });
+
+  t.test("average time to job completion should be over 0", async (t) => {
+    const start = new Date();
+    const end = new Date();
+    start.setHours(start.getHours() - 1);
+
+    t.ok((await qw.averageTimeToCompletion(start, end)) > 0);
+  });
+
+  t.test("destroy test db", async (t) => {
+    await cleanupTestPostgresDatabase(sql);
+    t.ok(true, "closed postgres connection");
+  });
+});


### PR DESCRIPTION
No tests yet.

Supports the following:

- First In, First Out job handling
- Prioritize jobs
- Schedule jobs for execution in the future
- Run workers for specific jobs
- Configurable amount of workers

TODO: 
- [x] Add tests
- [x] Cleanup internal run()
- [x] Some more docs