### PR TITLE
stdlib: resolve camelToSnakeCase issue with long strings

### DIFF
--- a/packages/stdlib/src/lodash.js
+++ b/packages/stdlib/src/lodash.js
@@ -80,7 +80,8 @@ export function unFlatten(data) {
  */
 export function camelToSnakeCase(input) {
   return input
-    .replace(/(.)([A-Z][a-z]+)/, "$1_$2")
-    .replace(/([a-z0-9])([A-Z])/, "$1_$2")
-    .toLowerCase();
+    .replace(/(.)([A-Z][a-z]+)/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .trim();
 }

--- a/packages/stdlib/src/lodash.test.js
+++ b/packages/stdlib/src/lodash.test.js
@@ -118,9 +118,21 @@ test("stdlib/lodash", (t) => {
   });
 
   t.test("camelToSnakeCase", () => {
+    // minimal
     t.equal(camelToSnakeCase("thisISCool"), "this_is_cool");
     t.equal(camelToSnakeCase("fileStore"), "file_store");
     t.equal(camelToSnakeCase("FileStore"), "file_store");
+
+    // very long (check global replace)
+    t.equal(
+      camelToSnakeCase("fileStoreBucketUnitCollectionClusterDatacenter"),
+      "file_store_bucket_unit_collection_cluster_datacenter",
+    );
+
+    t.equal(
+      camelToSnakeCase("FileStoreBucketUnitCollectionClusterDatacenter"),
+      "file_store_bucket_unit_collection_cluster_datacenter",
+    );
 
     t.end();
   });


### PR DESCRIPTION
Add global flag to replace regexes, so longer strings are transformed correctly 

<img width="278" alt="Screenshot 2020-06-24 at 10 31 42" src="https://user-images.githubusercontent.com/2414721/85522457-f9303800-b605-11ea-946c-e387b2b9ce08.png">

Results;

<img width="539" alt="Screenshot 2020-06-24 at 10 31 37" src="https://user-images.githubusercontent.com/2414721/85522476-fe8d8280-b605-11ea-891b-a27c290c1416.png">
