### PR TITLE
code-gen: always quote object keys on mock objects

### DIFF
--- a/packages/code-gen/src/types/object/mock.tmpl
+++ b/packages/code-gen/src/types/object/mock.tmpl
@@ -1,6 +1,6 @@
 {
 {{ for (const key of Object.keys(model.keys)) { }}
   {{ const v = model.keys[key]; }}
-  {{= key }}: {{= mockExec({ type: v.type, model: v, isInputType }).trim() }},
+  "{{= key }}": {{= mockExec({ type: v.type, model: v, isInputType }).trim() }},
 {{ } }}
 },


### PR DESCRIPTION
Prettier strips unnecessary quotes, so output still looks clean. 

example;
```js
{
  /**
   * Generated mock for AppItems
   * @returns { AppItems}
   */
  items: () => {
    return _mocker.pickone([
      {
        id: _mocker.pickone([_mocker.guid({ version: 4 })]),
        userId: _mocker.pickone([
          _mocker.pickone([_mocker.guid({ version: 4 })]),
        ]),
        name: _mocker.pickone([_mocker.word({})]),
        count: _mocker.pickone([_mocker.integer({ fixed: 3 })]),
        createdAt: _mocker.pickone([_mocker.date(), new Date()]),
        updatedAt: _mocker.pickone([_mocker.date()]),
   -->  "this.is.a.test": _mocker.pickone([_mocker.word({})]),
      },
    ]);
  },
}
```