### PR TITLE
Fix setting headers in form-data upload

### DIFF
--- a/packages/code-gen/src/generators/apiClient/templates/apiClientFn.tmpl
+++ b/packages/code-gen/src/generators/apiClient/templates/apiClientFn.tmpl
@@ -61,7 +61,7 @@ files,
       params: {{ if (model.query) { }}query{{ } else { }}{}{{ } }},
       data: {{ if (model.body || model.files) { }}data{{ } else { }}{}{{ } }},
       {{ if (model.files) { }}
-      headers: data.getHeaders(),
+      headers: {{ if (options.enabledGenerators.indexOf("router") !== -1) { }}data.getHeaders(){{ } else { }}{ "Content-Type": undefined }{{ } }},
       {{ } }}
     });
 


### PR DESCRIPTION
.getHeaders() is not a method of browser's [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData).
[This](https://stackoverflow.com/a/39281156) seems to be a workaround for non-axios clients
axios deletes content type altogether and lets browser to set it: [here](https://github.com/axios/axios/blob/503418718f669fcc674719fd862b355605d7b41f/lib/adapters/xhr.js#L15-L17), so, if I understand correctly, [this](https://github.com/form-data/form-data/blob/master/lib/form_data.js#L295) will be useless anyway