### PR TITLE
store: add setupTestDatabase function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -240,6 +240,8 @@ Available assertions and the option of doing nested tests
 - [deepEqual](#deepequal)
 - [equal](#equal)
 - [fail](#fail)
+- [notEqual](#notequal)
+- [notOk](#notok)
 - [ok](#ok)
 - [pass](#pass)
 - [test](#test)
@@ -313,6 +315,41 @@ try {
 
 | Name       | Type   |
 | ---------- | ------ |
+| `message?` | string |
+
+**Returns:** _void_
+
+---
+
+##### notEqual
+
+▸ **notEqual**(`actual?`: any, `expected?`: any, `message?`: string): _void_
+
+Expect actual to not triple equal expected
+
+**Parameters:**
+
+| Name        | Type   |
+| ----------- | ------ |
+| `actual?`   | any    |
+| `expected?` | any    |
+| `message?`  | string |
+
+**Returns:** _void_
+
+---
+
+##### notOk
+
+▸ **notOk**(`value`: any, `message?`: string): _void_
+
+Expect value to be falsey
+
+**Parameters:**
+
+| Name       | Type   |
+| ---------- | ------ |
+| `value`    | any    |
 | `message?` | string |
 
 **Returns:** _void_
@@ -8402,6 +8439,7 @@ case-insensitive.
 - [removeBucket](#removebucket)
 - [removeBucketAndObjectsInBucket](#removebucketandobjectsinbucket)
 - [runMigrations](#runmigrations)
+- [setupTestDatabase](#setuptestdatabase)
 - [syncDeletedFiles](#syncdeletedfiles)
 
 ### Type aliases
@@ -8810,6 +8848,31 @@ Run the migrations, as returned by `getMigrationsToBeApplied`
 | Name | Type                                               |
 | ---- | -------------------------------------------------- |
 | `mc` | [MigrateContext](#storeinterfacesmigratecontextmd) |
+
+**Returns:** _Promise‹void›_
+
+---
+
+#### setupTestDatabase
+
+▸ **setupTestDatabase**(`callback?`: function): _Promise‹void›_
+
+Setup a test database once Copies the current app database Calls callback, so
+seeding is possible, then reuses this as a template. Make sure to call this
+before any other call to createTestPostgresDatabase. It is safe to call this
+multiple times, the callback will only be executed once.
+
+**Parameters:**
+
+▪`Optional` **callback**: _function_
+
+▸ (`sql`: [Postgres](#postgres)): _Promise‹void›_
+
+**Parameters:**
+
+| Name  | Type                  |
+| ----- | --------------------- |
+| `sql` | [Postgres](#postgres) |
 
 **Returns:** _Promise‹void›_
 

--- a/packages/cli/src/testing/printer.js
+++ b/packages/cli/src/testing/printer.js
@@ -69,9 +69,7 @@ function printFailedResults(state, result, indentCount) {
     if (state.caughtException) {
       const stack = state.caughtException.stack
         .split("\n")
-        .map((it, idx) => indent + (idx !== 0 ? "  " : "") + it.trim())
-        .filter((it) => it.indexOf("cli/src/testing/") === -1)
-        .slice(1);
+        .map((it, idx) => indent + (idx !== 0 ? "  " : "") + it.trim());
 
       if (AppError.instanceOf(state.caughtException)) {
         result.push(

--- a/packages/store/index.d.ts
+++ b/packages/store/index.d.ts
@@ -75,6 +75,17 @@ export function newPostgresConnection(
 ): Promise<postgresVendor.Sql<{}>>;
 
 /**
+ * Setup a test database once
+ * Copies the current app database
+ * Calls callback, so seeding is possible, then reuses this as a template.
+ * Make sure to call this before any other call to createTestPostgresDatabase.
+ * It is safe to call this multiple times, the callback will only be executed once.
+ */
+export function setupTestDatabase(
+  callback?: (sql: Postgres) => Promise<void>,
+): Promise<void>;
+
+/**
  * Drops connections to 'normal' database and creates a new one based on the 'normal' database.
  * It will truncate all tables and return a connection to the new database.
  */

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -14,6 +14,7 @@ export { newPostgresConnection, postgres } from "./src/postgres.js";
 export {
   cleanupTestPostgresDatabase,
   createTestPostgresDatabase,
+  setupTestDatabase,
 } from "./src/testing.js";
 
 export {

--- a/packages/store/src/testing.js
+++ b/packages/store/src/testing.js
@@ -1,51 +1,106 @@
 import { log } from "@lbu/insight";
-import { uuid } from "@lbu/stdlib";
+import { isNil, uuid } from "@lbu/stdlib";
 import {
   createDatabaseIfNotExists,
   newPostgresConnection,
 } from "./postgres.js";
 
 /**
- * @param verboseSql
+ * This database is reused in in setupTestDatabase
+ * @type {string|undefined}
  */
-export async function createTestPostgresDatabase(verboseSql = false) {
-  const name = process.env.APP_NAME + uuid().substring(0, 7);
+let testDatabaseName = undefined;
 
+/**
+ * Setup a test database once
+ * Copies the current app database
+ * Calls callback, so seeding is possible, then reuses this as a template
+ *
+ * @param {function(Postgres): Promise<void>} callback
+ * @returns {Promise<void>}
+ */
+export async function setupTestDatabase(callback) {
+  if (testDatabaseName !== undefined) {
+    return;
+  }
+
+  testDatabaseName = process.env.APP_NAME + uuid().substring(0, 7);
+
+  // Open connection to default database
   const creationSql = await createDatabaseIfNotExists(
     undefined,
     process.env.APP_NAME,
   );
 
-  // Drop all connections to the database, this is required before it is usable as a template
-  await creationSql`SELECT pg_terminate_backend(pg_stat_activity.pid)
+  // Drop all connections to the database, this is required before it is usable as a
+  // template
+  await creationSql`
+SELECT pg_terminate_backend(pg_stat_activity.pid)
 FROM pg_stat_activity
 WHERE pg_stat_activity.datname = ${process.env.APP_NAME}
-  AND pid <> pg_backend_pid();`;
+  AND pid <> pg_backend_pid()
+  `;
 
-  await createDatabaseIfNotExists(creationSql, name, process.env.APP_NAME);
+  // Create testDatabase based on the default app database
+  await createDatabaseIfNotExists(
+    creationSql,
+    testDatabaseName,
+    process.env.APP_NAME,
+  );
+
+  const sql = await newPostgresConnection({
+    database: testDatabaseName,
+  });
+
+  // List all tables
+  const tables = await sql`SELECT table_name
+                             FROM information_schema.tables
+                             WHERE table_schema = 'public' AND table_name != 'migrations'`;
+
+  if (tables.length > 0) {
+    await sql.unsafe(
+      `TRUNCATE ${tables.map((it) => `"${it.table_name}"`).join(", ")} CASCADE`,
+    );
+  } else {
+    // Just a query to initialize the connection
+    await sql`SELECT 1 + 1 AS sum;`;
+  }
+
+  if (!isNil(callback) && typeof callback === "function") {
+    // Call user seeder
+    await callback(sql);
+  }
+
+  // Cleanup connections
+  await Promise.all([
+    creationSql.end({ timeout: 0.01 }),
+    sql.end({ timeout: 0.01 }),
+  ]);
+}
+
+/**
+ * @param verboseSql
+ */
+export async function createTestPostgresDatabase(verboseSql = false) {
+  const name = process.env.APP_NAME + uuid().substring(0, 7);
+  await setupTestDatabase(() => {});
+
+  const creationSql = await createDatabaseIfNotExists(
+    undefined,
+    name,
+    testDatabaseName,
+  );
 
   const sql = await newPostgresConnection({
     database: name,
     debug: verboseSql ? log.error : undefined,
   });
 
-  const schemas = await sql`SELECT table_name
-                            FROM information_schema.tables
-                            WHERE table_schema = 'public'`;
-
-  // removes migrations
-  const tableNames = schemas
-    .filter((it) => it.table_name !== "migrations")
-    .map((it) => `"${it.table_name}"`);
-
-  if (tableNames.length > 0) {
-    await sql.unsafe(`TRUNCATE ${tableNames.join(", ")} CASCADE`);
-  } else {
-    // Just a query to initialize the connection
-    await sql`SELECT 1 + 1 AS sum;`;
-  }
-
-  creationSql.end({});
+  // Initialize new connection and kill old connection
+  await Promise.all([
+    creationSql.end({ timeout: 0.01 }),
+    sql`SELECT 1 + 1 as sum`,
+  ]);
 
   return sql;
 }
@@ -55,10 +110,10 @@ WHERE pg_stat_activity.datname = ${process.env.APP_NAME}
  */
 export async function cleanupTestPostgresDatabase(sql) {
   const dbName = sql.options.database;
-  await sql.end({ timeout: 0.1 });
+  await sql.end({ timeout: 0.01 });
 
   const deletionSql = await newPostgresConnection({});
   // language=PostgreSQL
   await deletionSql.unsafe(`DROP DATABASE ${dbName}`);
-  await deletionSql.end({ timeout: 0.1 });
+  await deletionSql.end({ timeout: 0.01 });
 }


### PR DESCRIPTION
Keeps a database name globablly, that will be setup once. This enables the user to seed once, use everywhere