### PR TITLE
stdlib: improve perf of uuid

### DIFF
--- a/packages/cli/src/benchmarking/printer.js
+++ b/packages/cli/src/benchmarking/printer.js
@@ -11,8 +11,6 @@ export function printBenchResults() {
     }
   }
 
-  benchLogger.info(state);
-
   const result = [];
 
   result.push("");


### PR DESCRIPTION
Utilize a pool for rng. Improves throughput approx 6 times.
This fix is brought by upstream uuidjs/uuid#513