### PR TITLE
stdlib,cli,server: add and use AppError.format

### DIFF
--- a/packages/cli/src/benchmarking/printer.js
+++ b/packages/cli/src/benchmarking/printer.js
@@ -1,4 +1,5 @@
 import { writeFileSync } from "fs";
+import { inspect } from "util";
 import { AppError, isNil, pathJoin } from "@lbu/stdlib";
 import { benchLogger, state } from "./state.js";
 
@@ -106,21 +107,18 @@ function printErrorResults(result, state) {
     result.push(bench.name);
 
     const indent = "  ";
-    const stack = bench.caughtException.stack
-      .split("\n")
-      .map((it, idx) => indent + (idx !== 0 ? "  " : "") + it.trim());
+    const exception = AppError.format(bench.caughtException);
+
+    const stack = exception.stack.map((it) => `${indent}  ${it.trim()}`);
 
     if (AppError.instanceOf(bench.caughtException)) {
-      result.push(
-        `${indent}AppError: ${bench.caughtException.key} - ${bench.caughtException.status}`,
-      );
+      result.push(`${indent}AppError: ${exception.key} - ${exception.status}`);
 
       // Pretty print info object
-      const infoObject = JSON.stringify(
-        bench.caughtException.info,
-        null,
-        2,
-      ).split("\n");
+      const infoObject = inspect(exception.info, {
+        depth: null,
+        colors: true,
+      }).split("\n");
 
       for (const it of infoObject) {
         result.push(`${indent}  ${it}`);

--- a/packages/code-gen/test/e2e.test.js
+++ b/packages/code-gen/test/e2e.test.js
@@ -106,6 +106,17 @@ test(name, async (t) => {
     t.deepEqual(serverImports.router.appTags.create, []);
   });
 
+  t.test("apiClient - caught server error", async (t) => {
+    try {
+      await serverImports.apiClient.appApi.serverError();
+    } catch (e) {
+      t.ok(AppError.instanceOf(e));
+      t.equal(e.key, "server.error");
+      t.equal(e.status, 499);
+      t.equal(e.originalError.isAxiosError, true);
+    }
+  });
+
   t.test("Cleanup server", async () => {
     await closeTestApp(app);
   });
@@ -139,6 +150,8 @@ function applyServerStructure(app) {
     R.get("/invalid-response", "invalidResponse").response({
       id: T.string(),
     }),
+
+    R.post("/server-error", "serverError").response({}),
   );
 
   return {
@@ -191,6 +204,12 @@ function buildTestApp(serverImports) {
     };
 
     return next();
+  };
+
+  serverImports.router.appHandlers.serverError = () => {
+    throw new AppError("server.error", 499, {
+      test: "X",
+    });
   };
 
   serverImports.validator.validatorSetError(AppError.validationError);

--- a/packages/server/src/middleware/error.js
+++ b/packages/server/src/middleware/error.js
@@ -42,31 +42,15 @@ export function errorHandler({ onAppError, onError, leakError }) {
       ctx.status = err.status;
       ctx.body = onAppError(ctx, err.key, err.info);
 
-      let originalError = undefined;
-      if (err.originalError) {
-        originalError = {
-          name: err.originalError.name,
-          message: err.originalError.message,
-          stack: err.originalError.stack.split("\n"),
-        };
-
-        if (AppError.instanceOf(err.originalError)) {
-          originalError.key = err.originalError.key;
-          originalError.info = err.originalError.info;
-        }
-      }
-
+      const formatted = AppError.format(error);
       log({
         type: "API_ERROR",
-        status: err.status,
-        key: err.key,
-        info: err.info,
-        originalError,
+        ...formatted,
       });
 
       if (!isNil(err.originalError) && leakError) {
         ctx.body.info = ctx.body.info || {};
-        ctx.body.info._error = originalError;
+        ctx.body.info._error = formatted;
       }
     }
   };

--- a/packages/stdlib/index.d.ts
+++ b/packages/stdlib/index.d.ts
@@ -91,6 +91,22 @@ export class AppError<T extends any> extends Error {
     info?: T,
     error?: Error,
   ): AppError<T>;
+
+  /**
+   * Format errors recursively
+   */
+  static format<T extends any>(
+    e: AppError<T> | Error,
+    skipStack?: boolean,
+  ):
+    | {
+        key: string;
+        status: number;
+        info: T;
+        originalError: any;
+        stack: string[];
+      }
+    | { name: string; message: string; stack: string[] };
 }
 
 /**

--- a/packages/stdlib/src/error.js
+++ b/packages/stdlib/src/error.js
@@ -84,4 +84,38 @@ export class AppError extends Error {
   static validationError(key, info = {}, error = undefined) {
     return new AppError(key, 400, info, error);
   }
+
+  /**
+   * Format any error skipping the stack automatically for nested errors
+   *
+   * @param {AppError|Error} e
+   * @param {boolean} [skipStack=false]
+   * @returns {{ name: string, message: string, stack: string[] }|{ key: string, status:
+   *   number, info: *, stack: string[], originalError: object }}
+   */
+  static format(e, skipStack = false) {
+    const stack = e.stack.split("\n").map((it) => it.trim());
+    // Remove first element as this is the Error name
+    stack.shift();
+
+    if (AppError.instanceOf(e)) {
+      return {
+        key: e.key,
+        status: e.status,
+        info: e.info,
+        stack: skipStack ? [] : stack,
+        originalError: e.originalError
+          ? typeof e.originalError.toJSON === "function"
+            ? e.originalError.toJSON()
+            : AppError.format(e, true)
+          : undefined,
+      };
+    }
+
+    return {
+      name: e.name,
+      message: e.message,
+      stack: skipStack ? [] : stack,
+    };
+  }
 }


### PR DESCRIPTION
Consistent formatting of an AppError to an object.

Closes #283