### PR TITLE
store: remove FileStoreContext out of files

### DIFF
--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -28,10 +28,7 @@ export {
 export {
   createOrUpdateFile,
   copyFile,
-  getFileById,
   getFileStream,
-  newFileStoreContext,
-  deleteFile,
   syncDeletedFiles,
 } from "./src/files.js";
 


### PR DESCRIPTION
This allows the user to easily use transactions across file saving them selves. Also removes 'useless' deleteFile and getFileById calls.

Closes #304