### PR TITLE
cli: remove concurrent test support

### DIFF
--- a/packages/cli/src/testing/runner.js
+++ b/packages/cli/src/testing/runner.js
@@ -1,33 +1,6 @@
 import { AssertionError, deepStrictEqual } from "assert";
-import { cpus } from "os";
 import { isNil } from "@lbu/stdlib";
 import { setTestTimeout, state, testLogger, timeout } from "./state.js";
-
-/**
- * @param {TestState} testState
- * @returns {Promise<void>}
- */
-export async function runTestChildrenInParallel(testState) {
-  // This only provides a reasonable default of concurrency mostly useful in synchronous testing
-  // We actually still use a single Node.js process and thus CPU bound to a single core.
-  const maxParallel = Math.min(cpus().length, testState.children.length, 6);
-  let testIndex = 0;
-  const schedule = async () => {
-    if (testIndex >= testState.children.length) {
-      return;
-    }
-
-    const idx = testIndex;
-    testIndex++;
-
-    await runTestsRecursively(testState.children[idx]);
-
-    return schedule();
-  };
-
-  const promiseArray = Array.from({ length: maxParallel }, () => schedule());
-  await Promise.all(promiseArray);
-}
 
 /**
  * @param {TestState} testState

--- a/packages/cli/src/testing/utils.js
+++ b/packages/cli/src/testing/utils.js
@@ -1,7 +1,7 @@
 import { mainFn } from "@lbu/stdlib";
 import { loadTestConfig } from "./config.js";
 import { printTestResults } from "./printer.js";
-import { runTestChildrenInParallel } from "./runner.js";
+import { runTestsRecursively } from "./runner.js";
 import {
   areTestsRunning,
   setAreTestRunning,
@@ -34,7 +34,7 @@ export function mainTestFn(meta) {
       await config.setup();
     }
 
-    await runTestChildrenInParallel(state);
+    await runTestsRecursively(state);
 
     if (typeof config?.teardown === "function") {
       await config.teardown();


### PR DESCRIPTION
We can't do it this way, since we encourage the pattern of ES live bindings, i.e globals.

So we would have to spawn sub processes to support this feature at some point.