### PR TITLE
code-gen: generate cancel token support in browser environments

### DIFF
--- a/packages/code-gen/src/generators/apiClient/templates/apiClientFn.tmpl
+++ b/packages/code-gen/src/generators/apiClient/templates/apiClientFn.tmpl
@@ -17,6 +17,9 @@
 {{ if (item.files) { }}
  * @param { {{= buildTypeQualifier(getItem(item.files), true) }} } files
 {{ } }}
+{{ if (options.isBrowser) { }}
+ * @param { { cancelToken?: CancelToken } } [options]
+{{ } }}
 {{ if (item.response) { }}
  * @returns {Promise<{{= buildTypeQualifier(getItem(item.response), false) }}>}
 {{ } else { }}
@@ -36,6 +39,9 @@ body,
 {{ } }}
 {{ if (item.files) { }}
 files,
+{{ } }}
+{{ if (options.isBrowser) { }}
+options = {},
 {{ } }}
 ) {
     {{ if (!options.isBrowser) { }}
@@ -69,6 +75,9 @@ files,
       {{ } }}
       {{ if (item.response && getItem(item.response).type === "file") { }}
       responseType: "{{= options.isNode ? "stream" : "blob" }}",
+      {{ } }}
+      {{ if (options.isBrowser) { }}
+      cancelToken: options?.cancelToken,
       {{ } }}
     });
 

--- a/packages/code-gen/src/generators/reactQuery/templates/reactQueryFile.tmpl
+++ b/packages/code-gen/src/generators/reactQuery/templates/reactQueryFile.tmpl
@@ -1,12 +1,12 @@
 {{= options.fileHeader }}
 ((newline))
 
-import { AxiosError } from "axios";
+import { AxiosError, CancelTokenSource } from "axios";
 import React from "react";
 import {
   MutationConfig,
   MutationResultPair,
-  QueryConfig,
+  QueryConfig as ReactQueryConfig,
   QueryResult,
   useMutation,
   useQuery,
@@ -48,6 +48,8 @@ type AppErrorResponse = AxiosError<{
     [key: string]: any;
   };
 }>;
+
+type QueryConfig<Response, Error> = ReactQueryConfig<Response, Error> & { cancelToken?: CancelTokenSource };
 
 {{ for (const groupName of Object.keys(structure)) { }}
   {{ for (const itemName of Object.keys(structure[groupName])) { }}

--- a/packages/code-gen/src/generators/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generators/reactQuery/templates/reactQueryFn.tmpl
@@ -66,10 +66,19 @@ options: QueryConfig<{{=  responseType }}, AppErrorResponse> = {},
     {{ if (item.query) { }}
     query: T.{{= item.query.reference.uniqueName }}_Input,
     {{ } }}
-    ) => {{= item.group }}.{{= item.name }}(
-      {{= item.params ? "params, " : ""}}
-      {{= item.query ? "query, " : "" }}
-    ),
+    ) => {
+      const promise = {{= item.group }}.{{= item.name }}(
+        {{= item.params ? "params, " : ""}}
+        {{= item.query ? "query, " : "" }}
+        { cancelToken: options?.cancelToken?.token },
+      );
+
+      if (options?.cancelToken) {
+        promise.cancel = () => options.cancelToken.cancel();
+      }
+
+      return promise;
+    },
     options,
   );
 }


### PR DESCRIPTION
We optional accept a `CancelToken.source()` in the generated `useQuery` hooks. We then automatically add `promise.cancel` and provide the token to the api client function. The apiClient now accepts optional `cancelToken`, which is only enabled currently in browser environments.

This still keeps the request cancellation manual, but provides greater flexibility, like cancelling multiple in flight requests with a single source, and doesn't create too many unnecessary / unreadable wraps in the apiClient

Closes #344