### PR TITLE
chore: fix generated query function promise type

### DIFF
--- a/packages/code-gen/src/generators/reactQuery/templates/reactQueryFile.tmpl
+++ b/packages/code-gen/src/generators/reactQuery/templates/reactQueryFile.tmpl
@@ -15,6 +15,10 @@ import { newApiClient } from "./apiClient.js";
 import * as T from "./types";
 ((newline))
 
+interface CancellablePromise<T> extends Promise<T> {
+  cancel?: () => void;
+}
+
 const ApiContext = React.createContext<ReturnType<typeof newApiClient> | undefined>(undefined);
 
 export function ApiProvider<T extends ReturnType<typeof newApiClient>>({

--- a/packages/code-gen/src/generators/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generators/reactQuery/templates/reactQueryFn.tmpl
@@ -67,14 +67,14 @@ options: QueryConfig<{{=  responseType }}, AppErrorResponse> = {},
     query: T.{{= item.query.reference.uniqueName }}_Input,
     {{ } }}
     ) => {
-      const promise = {{= item.group }}.{{= item.name }}(
+      const promise: CancellablePromise<{{= responseType }}> = {{= item.group }}.{{= item.name }}(
         {{= item.params ? "params, " : ""}}
         {{= item.query ? "query, " : "" }}
         { cancelToken: options?.cancelToken?.token },
       );
 
       if (options?.cancelToken) {
-        promise.cancel = () => options.cancelToken.cancel();
+        promise.cancel = () => options?.cancelToken?.cancel();
       }
 
       return promise;


### PR DESCRIPTION
This fixes TypeScript errors complaining about assigning to `Promise#cancel`. I chose for a specific `CancellablePromise<T>` type instead of extending the `globalThis` promise.