### PR TITLE
insight: add basic event system

### DIFF
--- a/packages/insight/index.d.ts
+++ b/packages/insight/index.d.ts
@@ -85,6 +85,68 @@ export function printProcessMemoryUsage(logger: Logger): void;
 export const log: Logger;
 
 /**
+ * Basic timing and call information
+ */
+export type EventCall =
+  | {
+      type: "start" | "stop";
+      name: string;
+
+      /**
+       * Time in milliseconds since some kind of epoch, this may be unix epoch or process start
+       */
+      time: number;
+    }
+  | EventCall[];
+
+/**
+ * Encapsulate the base information needed to dispatch events
+ */
+export interface Event {
+  log: Logger;
+
+  /**
+   * If event is first event dispatched in chain
+   */
+  root: boolean;
+
+  name?: string;
+
+  callStack: EventCall[];
+}
+
+/**
+ * Create a new event from a single logger
+ */
+export function newEvent(logger: Logger): Event;
+
+/**
+ * Create a 'child' event, reuses the logger, adds callstack to the passed event
+ */
+export function newEventFromEvent(event: Event): Event;
+
+/**
+ * Track event start times and set a name
+ */
+export function eventStart(event: Event, name: string): void;
+
+/**
+ * Rename event, can only be done if `eventStop` is not called yet.
+ */
+export function eventRename(event: Event, name: string): void;
+
+/**
+ * Track event stop, and log callStack if event#root === true
+ */
+export function eventStop(event: Event): void;
+
+/**
+ * Create a test event.
+ * event.log.info is a noop by default, but can be enabled via the passed in options.
+ */
+export function newTestEvent(options?: { enabledLogs?: boolean }): Event;
+
+/**
  * Get the disk size (in bytes) and estimated row count for all tables and views.
  * To improve accuracy, run sql`ANALYZE` before this query, however make sure to read the
  * Postgres documentation for implications.

--- a/packages/insight/index.js
+++ b/packages/insight/index.js
@@ -3,6 +3,14 @@ import { newLogger } from "./src/logger/logger.js";
 export { bytesToHumanReadable, printProcessMemoryUsage } from "./src/memory.js";
 export { newLogger, bindLoggerContext } from "./src/logger/logger.js";
 
+export {
+  newEvent,
+  eventStart,
+  eventRename,
+  eventStop,
+  newTestEvent,
+  newEventFromEvent,
+} from "./src/events.js";
 export { postgresTableSizes } from "./src/postgres.js";
 
 /**

--- a/packages/insight/src/events.js
+++ b/packages/insight/src/events.js
@@ -1,0 +1,103 @@
+import { newLogger } from "@lbu/insight";
+
+/**
+ * Create a new event from a single logger
+ *
+ * @param {Logger} logger Logger should have a context, like the default `ctx.log`
+ * @returns {Event}
+ */
+export function newEvent(logger) {
+  return {
+    log: logger,
+    root: true,
+    name: undefined,
+    callStack: [],
+  };
+}
+
+/**
+ * Create a 'child' event, reuses the logger, adds callstack to the passed event
+ *
+ * @param {Event} event
+ * @returns {Event}
+ */
+export function newEventFromEvent(event) {
+  const callStack = [];
+  event.callStack.push(callStack);
+  return {
+    log: event.log,
+    root: false,
+    name: undefined,
+    callStack,
+  };
+}
+
+/**
+ * Track event start times
+ *
+ * @param {Event} event
+ * @param {string} name
+ */
+export function eventStart(event, name) {
+  event.name = name;
+
+  event.callStack.push({
+    type: "start",
+    name,
+    time: Date.now(),
+  });
+}
+
+/**
+ * Rename an event, can only be done if `eventStop` is not called yet.
+ *
+ * @param {Event} event
+ * @param {string} name
+ */
+export function eventRename(event, name) {
+  event.name = name;
+  event.callStack[0].name = name;
+}
+
+/**
+ * Track event end times and log if necessary
+ *
+ * @param {Event} event
+ */
+export function eventStop(event) {
+  event.callStack.push({
+    type: "stop",
+    name: event.name,
+    time: Date.now(),
+  });
+
+  if (event.root) {
+    event.log.info({
+      type: "EVENT_CALLSTACK",
+      callStack: event.callStack,
+    });
+  }
+}
+
+/**
+ * Create a new test event
+ * @param {{ enableLogs?: boolean }} [options={}]
+ * @return {Event}
+ */
+export function newTestEvent(options = {}) {
+  const log = newLogger({ ctx: { type: "test-event" } });
+
+  options.enableLogs = options.enableLogs ?? false;
+
+  // Disable logging by default
+  if (!options.enableLogs) {
+    log.info = () => {};
+  }
+
+  return {
+    log,
+    root: true,
+    name: undefined,
+    callStack: [],
+  };
+}

--- a/packages/insight/src/events.test.js
+++ b/packages/insight/src/events.test.js
@@ -1,0 +1,74 @@
+import { mainTestFn, test } from "@lbu/cli";
+import { newLogger } from "../index.js";
+import {
+  eventRename,
+  eventStart,
+  eventStop,
+  newEvent,
+  newEventFromEvent,
+  newTestEvent,
+} from "./events.js";
+
+mainTestFn(import.meta);
+
+test("insight/events", (t) => {
+  const log = newLogger();
+
+  t.test("create root event", (t) => {
+    const event = newEvent(log);
+    t.equal(event.root, true);
+    t.equal(event.callStack.length, 0);
+  });
+
+  t.test("create event from event", (t) => {
+    const event = newEvent(log);
+    const child = newEventFromEvent(event);
+
+    t.equal(child.root, false);
+    t.equal(child.callStack.length, 0);
+    t.equal(event.callStack.length, 1);
+    t.equal(event.callStack[0], child.callStack);
+  });
+
+  t.test("event start adds name", (t) => {
+    const event = newEvent(newTestEvent().log);
+    eventStart(event, "test");
+    t.equal(event.name, "test");
+  });
+
+  t.test("event start adds callStack item", (t) => {
+    const event = newEvent(newTestEvent().log);
+    t.equal(event.callStack.length, 0);
+    eventStart(event, "test");
+    t.equal(event.callStack.length, 1);
+    t.equal(event.callStack[0].type, "start");
+  });
+
+  t.test("event stop adds callStack item", (t) => {
+    const event = newEvent(newTestEvent().log);
+    t.equal(event.callStack.length, 0);
+    eventStop(event);
+    t.equal(event.callStack.length, 1);
+    t.equal(event.callStack[0].type, "stop");
+  });
+
+  t.test("test event exposes callstack", (t) => {
+    const event = newTestEvent();
+
+    t.equal(event.callStack.length, 0);
+    eventStart(event, "test");
+    eventStop(event);
+    t.equal(event.callStack.length, 2);
+  });
+
+  t.test("rename an event", (t) => {
+    const event = newTestEvent();
+    eventStart(event, "foo");
+    t.equal(event.name, "foo");
+    t.equal(event.callStack[0].name, "foo");
+    eventRename(event, "bar");
+
+    t.equal(event.name, "bar");
+    t.equal(event.callStack[0].name, "bar");
+  });
+});


### PR DESCRIPTION
Consists of manually calling eventStart, eventStop, ..., and by design controlled by the event implementation and not by the caller.

Closes #328 

@tjonger main difference with the existing implementation:
- Removed slow logging
- Accept options in `newTestEvent`
- Add `eventRename`