### PR TITLE
store: add export for 'addRecurringJobToQueue'

### DIFF
--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -34,7 +34,11 @@ export {
 
 export { FileCache } from "./src/file-cache.js";
 
-export { JobQueueWorker, addJobToQueue } from "./src/queue.js";
+export {
+  JobQueueWorker,
+  addJobToQueue,
+  addRecurringJobToQueue,
+} from "./src/queue.js";
 
 export { newSessionStore } from "./src/sessions.js";
 

--- a/packages/store/src/queue.js
+++ b/packages/store/src/queue.js
@@ -265,7 +265,7 @@ export class JobQueueWorker {
 }
 
 /**
- *Add a new item to the job queue
+ * Add a new item to the job queue
  *
  * @param {Postgres} sql
  * @param {JobInput} job


### PR DESCRIPTION
The store package did not export the `addRecurringJobToQueue` method in release 0.0.81

~Also tests are missing for recurring jobs :$~