### PR TITLE
insight: improve performance of ndjson logging

### DIFF
--- a/packages/insight/index.d.ts
+++ b/packages/insight/index.d.ts
@@ -58,15 +58,6 @@ export function newLogger<T extends LoggerContext>(
 ): Logger;
 
 /**
- * Bind a context object to the logger functions and returns a new Logger
- * The context is always printed
- */
-export function bindLoggerContext<T extends LoggerContext>(
-  logger: Logger,
-  ctx: T,
-): Logger;
-
-/**
  * Format bytes, with up to 2 digits after the decimal point, in a more human readable way
  * Support up to a pebibyte
  */

--- a/packages/insight/index.js
+++ b/packages/insight/index.js
@@ -1,7 +1,7 @@
 import { newLogger } from "./src/logger/logger.js";
 
 export { bytesToHumanReadable, printProcessMemoryUsage } from "./src/memory.js";
-export { newLogger, bindLoggerContext } from "./src/logger/logger.js";
+export { newLogger } from "./src/logger/logger.js";
 
 export {
   newEvent,

--- a/packages/insight/src/logger/logger.js
+++ b/packages/insight/src/logger/logger.js
@@ -13,47 +13,23 @@ export function newLogger(options) {
     ? wrapWriter(writeNDJSON)
     : wrapWriter(writePretty);
 
-  if (options?.ctx === undefined) {
-    return {
-      isProduction: () => isProduction,
-      info: logFn.bind(undefined, stream, "info"),
-      error: logFn.bind(undefined, stream, "error"),
-    };
-  }
+  const context = isProduction
+    ? JSON.stringify(options?.ctx ?? {})
+    : options?.ctx ?? {};
+
   return {
     isProduction: () => isProduction,
-    info: logFn.bind(undefined, stream, "info", options.ctx),
-    error: logFn.bind(undefined, stream, "error", options.ctx),
-  };
-}
-
-/**
- * @param {Logger} logger
- * @param {LoggerContext} ctx
- * @returns {Logger}
- */
-export function bindLoggerContext(logger, ctx) {
-  const isProd = logger.isProduction();
-  return {
-    isProduction: () => isProd,
-    info: logger.info.bind(undefined, ctx),
-    error: logger.error.bind(undefined, ctx),
+    info: logFn.bind(undefined, stream, "info", context),
+    error: logFn.bind(undefined, stream, "error", context),
   };
 }
 
 /**
  * Wrap provided writer function to be used in the Logger
- *
- * @param fn
- * @returns {log}
  */
 function wrapWriter(fn) {
-  return function log(stream, level, context, message) {
+  return (stream, level, context, message) => {
     const timestamp = new Date();
-    if (!message) {
-      message = context;
-      context = {};
-    }
-    fn(stream, level, timestamp, context, message);
+    fn(stream, level, timestamp, context, message ?? {});
   };
 }

--- a/packages/insight/src/logger/writer.js
+++ b/packages/insight/src/logger/writer.js
@@ -9,14 +9,10 @@ import { inspect } from "util";
  */
 export function writeNDJSON(stream, level, timestamp, context, message) {
   stream.write(
-    JSON.stringify({
-      level,
-      ...context,
-      timestamp: timestamp.toISOString(),
-      message: message,
-    }),
+    `{"level": "${level}", "timestamp": "${timestamp.toISOString()}", "context": ${context}, "message": ${JSON.stringify(
+      message,
+    )}}\n`,
   );
-  stream.write("\n");
 }
 
 /**
@@ -27,9 +23,9 @@ export function writeNDJSON(stream, level, timestamp, context, message) {
  * @param message
  */
 export function writePretty(stream, level, timestamp, context, message) {
-  stream.write(formatDate(timestamp));
-  stream.write(" ");
-  stream.write(formatLevelAndType(level, context?.type));
+  stream.write(
+    `${formatDate(timestamp)} ${formatLevelAndType(level, context?.type)}`,
+  );
 
   if (message) {
     stream.write(" ");
@@ -43,8 +39,7 @@ export function writePretty(stream, level, timestamp, context, message) {
       }
 
       if (Object.keys(context).length > keyCount) {
-        stream.write(formatMessagePretty(context));
-        stream.write(" ");
+        stream.write(`${formatMessagePretty(context)} `);
       }
       stream.write(formatMessagePretty(message));
     }

--- a/packages/insight/src/logger/writer.test.js
+++ b/packages/insight/src/logger/writer.test.js
@@ -15,10 +15,12 @@ test("insight/writer", (t) => {
 
     writePretty(mock, "info", now, {}, {});
 
-    t.equal(result.length, 6);
-    t.ok(result[0].match(/\d{2}:\d{2}:\d{2}.\d{3}/));
-    t.equal(result[1].trim(), "");
-    t.ok(result[2].indexOf("info") !== -1, "should print log level");
+    t.equal(result.length, 4);
+
+    const [timestamp, level] = result[0].split(" ");
+
+    t.ok(timestamp.match(/\d{2}:\d{2}:\d{2}.\d{3}/), "print time");
+    t.ok(level.indexOf("info") !== -1, "print level");
 
     result = [];
     writePretty(
@@ -31,8 +33,8 @@ test("insight/writer", (t) => {
       },
     );
 
-    t.equal(result.length, 6);
-    t.ok(result[2].indexOf("foo") !== -1, "should print log type");
+    t.equal(result.length, 4);
+    t.ok(result[0].indexOf("foo") !== -1, "should print log type");
   });
 
   t.test("writeNDJSON", (t) => {
@@ -44,28 +46,31 @@ test("insight/writer", (t) => {
       },
     };
 
-    writeNDJSON(mock, "info", now, {}, {});
+    writeNDJSON(mock, "info", now, "{}", {});
 
-    t.equal(result.length, 2);
+    t.equal(result.length, 1);
     t.equal(
       JSON.parse(result[0]).level,
       "info",
       "log output can be parsed by json",
     );
-    t.equal(result[1].trim(), "");
 
     result = [];
     writeNDJSON(
       mock,
       "info",
       now,
-      {
+      JSON.stringify({
         type: "foo",
-      },
+      }),
       { foo: { bar: { baz: "quix" } } },
     );
 
-    t.equal(result.length, 2);
-    t.equal(JSON.parse(result[0])?.type, "foo", "should print log type");
+    t.equal(result.length, 1);
+    t.equal(
+      JSON.parse(result[0])?.context?.type,
+      "foo",
+      "should print log type",
+    );
   });
 });

--- a/packages/server/src/middleware/log.js
+++ b/packages/server/src/middleware/log.js
@@ -1,19 +1,11 @@
 import { Transform } from "stream";
-import {
-  bindLoggerContext,
-  eventStart,
-  eventStop,
-  newEvent,
-  newLogger,
-} from "@lbu/insight";
+import { eventStart, eventStop, newEvent, newLogger } from "@lbu/insight";
 import { isNil, uuid } from "@lbu/stdlib";
 
 /**
  * Log basic request and response information
  */
 export function logMiddleware() {
-  const logger = newLogger({});
-
   return async (ctx, next) => {
     const startTime = process.hrtime.bigint();
 
@@ -23,9 +15,11 @@ export function logMiddleware() {
     }
     ctx.set("x-request-id", requestId);
 
-    ctx.log = bindLoggerContext(logger, {
-      type: "http",
-      requestId,
+    ctx.log = newLogger({
+      ctx: {
+        type: "http",
+        requestId,
+      },
     });
     ctx.event = newEvent(ctx.log);
     eventStart(ctx.event, `${ctx.method}.${ctx.path}`);

--- a/packages/store/src/file-cache.test.js
+++ b/packages/store/src/file-cache.test.js
@@ -2,7 +2,7 @@ import { existsSync, lstatSync, mkdirSync, writeFileSync } from "fs";
 import { pipeline as pipelineCallback } from "stream";
 import { promisify } from "util";
 import { mainTestFn, test } from "@lbu/cli";
-import { log, printProcessMemoryUsage } from "@lbu/insight";
+import { printProcessMemoryUsage } from "@lbu/insight";
 import { gc, pathJoin, uuid } from "@lbu/stdlib";
 import { FileCache } from "./file-cache.js";
 import { createOrUpdateFile } from "./files.js";
@@ -184,8 +184,8 @@ test("store/file-cache check memory usage", async (t) => {
   let cache = undefined;
 
   const logMemory = (t) => {
-    t.test("print memory usage", () => {
-      printProcessMemoryUsage(log);
+    t.test("print memory usage", (t) => {
+      printProcessMemoryUsage(t.log);
     });
   };
 


### PR DESCRIPTION
We get some improvements by formatting the context once on logger creation.
Another small bump came from not creating extra objects, but doing the top level `JSON.stringify` inline.
The last improvement was to only call `stream.write` once, and probably the most notable improvement.

BREAKING CHANGE: The context is now nested in stead of spread on the top level log line. We also default to an empty object if the context is not specified.