### PR TITLE
insight: add application name to context

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -28,8 +28,9 @@ the project root, so other programs can use this more easily.
 
 **APP_NAME**
 
-Used for database creation and selection, default s3 bucket name. In general
-this environment variable is required.
+Used for database creation and selection, default s3 bucket name. Also, when
+running in production this value is printed under `context.application`. In
+general this environment variable is required.
 
 **APP_KEYS**
 

--- a/packages/insight/src/logger/logger.js
+++ b/packages/insight/src/logger/logger.js
@@ -5,6 +5,7 @@ import { writeNDJSON, writePretty } from "./writer.js";
  * @returns {Logger}
  */
 export function newLogger(options) {
+  const app = process.env.APP_NAME;
   const isProduction =
     options?.pretty === false || process.env.NODE_ENV === "production";
   const stream = options?.stream ?? process.stdout;
@@ -13,9 +14,13 @@ export function newLogger(options) {
     ? wrapWriter(writeNDJSON)
     : wrapWriter(writePretty);
 
-  const context = isProduction
-    ? JSON.stringify(options?.ctx ?? {})
-    : options?.ctx ?? {};
+  let context = options?.ctx ?? {};
+  if (isProduction) {
+    if (app) {
+      context.application = app;
+    }
+    context = JSON.stringify(context);
+  }
 
   return {
     isProduction: () => isProduction,

--- a/packages/insight/src/logger/writer.test.js
+++ b/packages/insight/src/logger/writer.test.js
@@ -62,6 +62,7 @@ test("insight/writer", (t) => {
       now,
       JSON.stringify({
         type: "foo",
+        application: "lbu",
       }),
       { foo: { bar: { baz: "quix" } } },
     );
@@ -71,6 +72,11 @@ test("insight/writer", (t) => {
       JSON.parse(result[0])?.context?.type,
       "foo",
       "should print log type",
+    );
+    t.equal(
+      JSON.parse(result[0])?.context?.application,
+      "lbu",
+      "should print application type",
     );
   });
 });


### PR DESCRIPTION
This allows you to put all log streams to a single destination and then aggregate per application.