### PR TITLE
stdlib: cache environment variables

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,6 @@ Let's start with the imports:
 
 ```javascript
 import { App, generators, loadFromRemote } from "@lbu/code-gen";
-import { log } from "@lbu/insight";
 import { mainFn } from "@lbu/stdlib";
 ```
 

--- a/packages/cli/scripts/lint.js
+++ b/packages/cli/scripts/lint.js
@@ -1,4 +1,4 @@
-import { mainFn, spawn } from "@lbu/stdlib";
+import { mainFn, spawn, environment } from "@lbu/stdlib";
 
 mainFn(import.meta, async () => {
   const { exitCode: lint } = await spawn("./node_modules/.bin/eslint", [
@@ -9,7 +9,7 @@ mainFn(import.meta, async () => {
   ]);
 
   const prettierCommand =
-    process.env.CI === "true" ? ["--check"] : ["--write", "--list-different"];
+    environment.CI === "true" ? ["--check"] : ["--write", "--list-different"];
 
   const { exitCode: pretty } = await spawn("./node_modules/.bin/prettier", [
     ...prettierCommand,

--- a/packages/cli/src/benchmarking/printer.js
+++ b/packages/cli/src/benchmarking/printer.js
@@ -1,6 +1,6 @@
 import { writeFileSync } from "fs";
 import { inspect } from "util";
-import { AppError, isNil, pathJoin } from "@lbu/stdlib";
+import { AppError, environment, isNil, pathJoin } from "@lbu/stdlib";
 import { benchLogger, state } from "./state.js";
 
 export function printBenchResults() {
@@ -40,7 +40,7 @@ export function printBenchResults() {
 
   logFn(result.join("\n"));
 
-  if (process.env.CI === "true") {
+  if (environment.CI === "true") {
     // Write output to a file so it can be used in other actions
     // Add some point we may want to do some pretty printing to format as a table or
     // something

--- a/packages/cli/src/commands/docker.js
+++ b/packages/cli/src/commands/docker.js
@@ -1,4 +1,4 @@
-import { exec, spawn } from "@lbu/stdlib";
+import { environment, exec, spawn } from "@lbu/stdlib";
 
 const SUB_COMMANDS = ["up", "down", "clean", "reset"];
 
@@ -200,7 +200,7 @@ async function resetDatabase(logger, containerInfo) {
     return startExitCode;
   }
 
-  const name = process.env.APP_NAME;
+  const name = environment.APP_NAME;
 
   logger.info(`Resetting ${name} database`);
   const { exitCode: postgresExit } = await spawn(`sh`, [
@@ -253,5 +253,5 @@ async function getKnownContainers() {
 }
 
 function getPostgresVersion() {
-  return Number(process.env.POSTGRES_VERSION ?? "12");
+  return Number(environment.POSTGRES_VERSION ?? "12");
 }

--- a/packages/cli/src/commands/proxy.js
+++ b/packages/cli/src/commands/proxy.js
@@ -1,5 +1,5 @@
 import { createServer } from "http";
-import { isNil } from "@lbu/stdlib";
+import { environment, isNil } from "@lbu/stdlib";
 import proxy from "http-proxy";
 
 /**
@@ -8,7 +8,7 @@ import proxy from "http-proxy";
  */
 export async function proxyCommand(logger) {
   const port = parseInt(
-    (process.env.API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? "")
+    (environment.API_URL ?? environment.NEXT_PUBLIC_API_URL ?? "")
       .split(":")
       .pop(),
   );
@@ -19,7 +19,7 @@ export async function proxyCommand(logger) {
     );
     process.exit(1);
   }
-  if ((process.env.PROXY_URL ?? "").length === 0) {
+  if ((environment.PROXY_URL ?? "").length === 0) {
     logger.error("Please set the `PROXY_URL` environment variable");
     process.exit(1);
   }
@@ -39,7 +39,7 @@ export async function proxyCommand(logger) {
 
   const allowMethods = "GET,PUT,POST,PATCH,DELETE,HEAD,OPTIONS";
   const options = {
-    target: process.env.PROXY_URL,
+    target: environment.PROXY_URL,
     changeOrigin: true,
     cookieDomainRewrite: "",
   };

--- a/packages/cli/template/scripts/api.js
+++ b/packages/cli/template/scripts/api.js
@@ -1,4 +1,4 @@
-import { mainFn, isProduction, isStaging } from "@lbu/stdlib";
+import { mainFn, isProduction, isStaging, environment } from "@lbu/stdlib";
 import { constructApp } from "../src/api.js";
 import { injectServices } from "../src/service.js";
 import { app } from "../src/services/index.js";
@@ -12,7 +12,7 @@ async function main(logger) {
   await injectServices();
   await constructApp();
 
-  const port = process.env.PORT || 3000;
+  const port = environment.PORT || 3000;
   app.listen(port, () => {
     logger.info({
       msg: "Listening",

--- a/packages/cli/template/src/service.js
+++ b/packages/cli/template/src/service.js
@@ -1,6 +1,6 @@
 import { newLogger } from "@lbu/insight";
 import { createBodyParsers, session } from "@lbu/server";
-import { isStaging } from "@lbu/stdlib";
+import { environment, isStaging } from "@lbu/stdlib";
 import {
   FileCache,
   newMinioClient,
@@ -40,7 +40,7 @@ export async function injectServices() {
       createIfNotExists: isStaging(),
     }),
   );
-  setAppBucket(process.env.APP_NAME);
+  setAppBucket(environment.APP_NAME);
   setMinio(newMinioClient({}));
   setSessionStore(newSessionStore(sql));
   setFileCache(new FileCache(sql, minio, appBucket));

--- a/packages/code-gen/src/open-api-importer.js
+++ b/packages/code-gen/src/open-api-importer.js
@@ -1,4 +1,4 @@
-import { log } from "@lbu/insight";
+import { newLogger } from "@lbu/insight";
 import { isNil } from "@lbu/stdlib";
 import {
   AnyOfType,
@@ -45,6 +45,7 @@ export function convertOpenAPISpec(defaultGroup, data) {
    * openAPIReferences to resolve $ref's in the document
    */
   const context = {
+    logger: newLogger(),
     result,
     defaultGroup: lowerCaseFirst(defaultGroup),
     data,
@@ -399,7 +400,7 @@ function convertSchema(context, schema) {
       result.values = convertSchema(context, schema.additionalProperties);
 
       if (!isNil(schema.minProperties) || !isNil(schema.maxProperties)) {
-        log.info(
+        context.logger.info(
           "object#minProperties and object#maxProperties are not supported",
         );
       }
@@ -451,7 +452,7 @@ function convertSchema(context, schema) {
       result.validator.max = schema.maximum;
     }
     if (!isNil(schema.exclusiveMinimum) || !isNil(schema.exclusiveMaximum)) {
-      log.info(
+      context.logger.info(
         "number#exclusiveMinimum and number#exclusiveMaximum are not supported",
       );
     }
@@ -480,7 +481,9 @@ function convertSchema(context, schema) {
     assignBaseData();
 
     if (!schema.$ref.startsWith("#/")) {
-      log.info(`Only local references supported. Found ${schema.$ref}`);
+      context.logger.info(
+        `Only local references supported. Found ${schema.$ref}`,
+      );
     } else {
       result.reference = {
         group: context.defaultGroup,

--- a/packages/insight/index.d.ts
+++ b/packages/insight/index.d.ts
@@ -71,11 +71,6 @@ export function bytesToHumanReadable(bytes?: number): string;
 export function printProcessMemoryUsage(logger: Logger): void;
 
 /**
- * Standard log instance
- */
-export const log: Logger;
-
-/**
  * Basic timing and call information
  */
 export type EventCall =

--- a/packages/insight/index.js
+++ b/packages/insight/index.js
@@ -1,7 +1,6 @@
-import { newLogger } from "./src/logger/logger.js";
+export { newLogger } from "./src/logger/logger.js";
 
 export { bytesToHumanReadable, printProcessMemoryUsage } from "./src/memory.js";
-export { newLogger } from "./src/logger/logger.js";
 
 export {
   newEvent,
@@ -11,9 +10,5 @@ export {
   newTestEvent,
   newEventFromEvent,
 } from "./src/events.js";
-export { postgresTableSizes } from "./src/postgres.js";
 
-/**
- * @type {Logger}
- */
-export const log = newLogger({});
+export { postgresTableSizes } from "./src/postgres.js";

--- a/packages/insight/package.json
+++ b/packages/insight/package.json
@@ -12,6 +12,9 @@
     "logger"
   ],
   "license": "MIT",
+  "dependencies": {
+    "@lbu/stdlib": "0.0.91"
+  },
   "maintainers": [
     {
       "name": "Dirk de Visser",

--- a/packages/insight/src/logger/logger.js
+++ b/packages/insight/src/logger/logger.js
@@ -1,3 +1,4 @@
+import { environment } from "@lbu/stdlib";
 import { writeNDJSON, writePretty } from "./writer.js";
 
 /**
@@ -5,9 +6,9 @@ import { writeNDJSON, writePretty } from "./writer.js";
  * @returns {Logger}
  */
 export function newLogger(options) {
-  const app = process.env.APP_NAME;
+  const app = environment.APP_NAME;
   const isProduction =
-    options?.pretty === false || process.env.NODE_ENV === "production";
+    options?.pretty === false || environment.NODE_ENV === "production";
   const stream = options?.stream ?? process.stdout;
 
   const logFn = isProduction

--- a/packages/server/src/middleware/cors.js
+++ b/packages/server/src/middleware/cors.js
@@ -1,4 +1,4 @@
-import { isStaging } from "@lbu/stdlib";
+import { environment, isStaging } from "@lbu/stdlib";
 
 /*
  Original copy from: https://github.com/zadzbw/koa2-cors/commit/45b6de0de6c4816b93d49335490b81995d450191
@@ -62,11 +62,11 @@ export function cors(options = {}) {
   if (typeof options.origin === "function") {
     originFn = options.origin;
   } else if (
-    process.env.CORS_URL !== undefined &&
-    process.env.CORS_URL.length > 0
+    environment.CORS_URL !== undefined &&
+    environment.CORS_URL.length > 0
   ) {
     // Use CORS_URL array provided via environment variables
-    const allowedOrigins = (process.env.CORS_URL || "").split(",");
+    const allowedOrigins = (environment.CORS_URL || "").split(",");
     const localhostRegex = /^http:\/\/localhost:\d{1,6}$/gi;
 
     if (isStaging()) {

--- a/packages/server/src/middleware/session.js
+++ b/packages/server/src/middleware/session.js
@@ -1,4 +1,4 @@
-import { isNil, isProduction, merge, uuid } from "@lbu/stdlib";
+import { environment, isNil, isProduction, merge, uuid } from "@lbu/stdlib";
 import KeyGrip from "keygrip";
 import koaSession from "koa-session";
 
@@ -17,11 +17,11 @@ export function session(app, opts) {
   const options = merge(
     {},
     {
-      key: `${process.env.APP_NAME.toLowerCase()}.sess`,
+      key: `${environment.APP_NAME.toLowerCase()}.sess`,
       maxAge: 6 * 24 * 60 * 60 * 1000,
       renew: true,
       secure: isProduction(),
-      domain: !isProduction() ? undefined : process.env.COOKIE_URL,
+      domain: !isProduction() ? undefined : environment.COOKIE_URL,
       sameSite: "lax",
       overwrite: true,
       httpOnly: true,
@@ -44,14 +44,14 @@ export function session(app, opts) {
  */
 function getKeys() {
   if (!isProduction()) {
-    return [process.env.APP_NAME];
+    return [environment.APP_NAME];
   }
 
-  if (isNil(process.env.APP_KEYS) || process.env.APP_KEYS.length < 20) {
+  if (isNil(environment.APP_KEYS) || environment.APP_KEYS.length < 20) {
     throw new Error("Missing APP_KEYS in environment or generate a longer key");
   }
 
-  const keys = process.env.APP_KEYS.split(",");
+  const keys = environment.APP_KEYS.split(",");
   return new KeyGrip(keys, "sha256");
 }
 

--- a/packages/stdlib/index.d.ts
+++ b/packages/stdlib/index.d.ts
@@ -310,6 +310,27 @@ export function filenameForModule(meta: ImportMeta): string;
 export function dirnameForModule(meta: ImportMeta): string;
 
 /**
+ * Cached environment, set by `refreshEnvironmentCache()`
+ */
+export const environment: typeof process.env;
+
+/**
+ * Repopulate the cached environment copy.
+ * This should only be necessary when you or a sub package mutates the environment.
+ * The `mainFn` / `mainTestFn` / `mainBenchFn` / ... will call this function by default
+ * after loading your `.env` file.
+ *
+ * Accessing process.env.XXX is relatively slow in Node.js.
+ * Benchmark of a plain object property access and accessing process.env.NODE_ENV:
+ *
+ * property access       500000000  iterations     0  ns/op
+ * process.env access      5000000  iterations   246  ns/op
+ *
+ * See this thread: https://github.com/nodejs/node/issues/3104
+ */
+export function refreshEnvironmentCache(): void;
+
+/**
  * Returns whether NODE_ENV === "production"
  */
 export function isProduction(): boolean;

--- a/packages/stdlib/index.js
+++ b/packages/stdlib/index.js
@@ -1,5 +1,14 @@
 export { uuid } from "./src/datatypes.js";
+
 export { AppError } from "./src/error.js";
+
+export {
+  isProduction,
+  isStaging,
+  environment,
+  refreshEnvironmentCache,
+} from "./src/env.js";
+
 export {
   isNil,
   isPlainObject,
@@ -8,6 +17,7 @@ export {
   unFlatten,
   camelToSnakeCase,
 } from "./src/lodash.js";
+
 export {
   exec,
   spawn,
@@ -16,6 +26,7 @@ export {
   processDirectoryRecursive,
   processDirectoryRecursiveSync,
 } from "./src/node.js";
+
 export {
   getSecondsSinceEpoch,
   gc,
@@ -23,6 +34,4 @@ export {
   noop,
   filenameForModule,
   dirnameForModule,
-  isProduction,
-  isStaging,
 } from "./src/utils.js";

--- a/packages/stdlib/src/env.js
+++ b/packages/stdlib/src/env.js
@@ -1,0 +1,38 @@
+/**
+ * Cached process.env
+ */
+export let environment = {};
+
+/**
+ * Repopulate the cached environment copy.
+ * This should only be necessary when you or a sub package mutates the environment.
+ * The `mainFn` / `mainTestFn` / `mainBenchFn` / ... will call this function by default
+ * after loading your `.env` file.
+ *
+ * Accessing process.env.XXX is relatively in Node.js.
+ * Benchmark of a plain object property access and accessing process.env.NODE_ENV:
+ *
+ * property access       500000000  iterations     0  ns/op
+ * process.env access      5000000  iterations   246  ns/op
+ *
+ * See this thread: https://github.com/nodejs/node/issues/3104
+ */
+export function refreshEnvironmentCache() {
+  environment = JSON.parse(JSON.stringify(process.env));
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isProduction() {
+  return environment.NODE_ENV === "production";
+}
+
+/**
+ * @returns {boolean}
+ */
+export function isStaging() {
+  return (
+    environment.NODE_ENV !== "production" || environment.IS_STAGING === "true"
+  );
+}

--- a/packages/stdlib/src/env.test.js
+++ b/packages/stdlib/src/env.test.js
@@ -1,0 +1,59 @@
+import { mainTestFn, test } from "@lbu/cli";
+import { isProduction, isStaging, refreshEnvironmentCache } from "./env.js";
+
+mainTestFn(import.meta);
+
+test("stdlib/env", (t) => {
+  t.test("isProduction", (t) => {
+    const currentEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = "production";
+    refreshEnvironmentCache();
+    t.equal(isProduction(), true);
+
+    process.env.NODE_ENV = "development";
+    refreshEnvironmentCache();
+    t.equal(isProduction(), false);
+
+    process.env.NODE_ENV = undefined;
+    refreshEnvironmentCache();
+    t.equal(isProduction(), false);
+
+    process.env.NODE_ENV = currentEnv;
+    refreshEnvironmentCache();
+  });
+
+  t.test("isStaging", (t) => {
+    const currentEnv = process.env.NODE_ENV;
+    const currentIsStaging = process.env.IS_STAGING;
+
+    process.env.NODE_ENV = "production";
+    process.env.IS_STAGING = "true";
+    refreshEnvironmentCache();
+    t.equal(isStaging(), true);
+
+    process.env.NODE_ENV = "production";
+    process.env.IS_STAGING = undefined;
+    refreshEnvironmentCache();
+    t.equal(isStaging(), false);
+
+    process.env.NODE_ENV = "production";
+    process.env.IS_STAGING = "false";
+    refreshEnvironmentCache();
+    t.equal(isStaging(), false);
+
+    process.env.NODE_ENV = "development";
+    process.env.IS_STAGING = "true";
+    refreshEnvironmentCache();
+    t.equal(isStaging(), true);
+
+    process.env.NODE_ENV = "development";
+    process.env.IS_STAGING = "false";
+    refreshEnvironmentCache();
+    t.equal(isStaging(), true);
+
+    process.env.NODE_ENV = currentEnv;
+    process.env.IS_STAGING = currentIsStaging;
+    refreshEnvironmentCache();
+  });
+});

--- a/packages/stdlib/src/utils.test.js
+++ b/packages/stdlib/src/utils.test.js
@@ -1,11 +1,5 @@
 import { mainTestFn, test } from "@lbu/cli";
-import {
-  gc,
-  getSecondsSinceEpoch,
-  isMainFnAndReturnName,
-  isProduction,
-  isStaging,
-} from "./utils.js";
+import { gc, getSecondsSinceEpoch, isMainFnAndReturnName } from "./utils.js";
 
 mainTestFn(import.meta);
 
@@ -21,49 +15,6 @@ test("stdlib/utils", (t) => {
       t.fail("Should not throw");
       t.log.error(e);
     }
-  });
-
-  t.test("isProduction", (t) => {
-    const currentEnv = process.env.NODE_ENV;
-
-    process.env.NODE_ENV = "production";
-    t.equal(isProduction(), true);
-
-    process.env.NODE_ENV = "development";
-    t.equal(isProduction(), false);
-
-    process.env.NODE_ENV = undefined;
-    t.equal(isProduction(), false);
-
-    process.env.NODE_ENV = currentEnv;
-  });
-
-  t.test("isStaging", (t) => {
-    const currentEnv = process.env.NODE_ENV;
-    const currentIsStaging = process.env.IS_STAGING;
-
-    process.env.NODE_ENV = "production";
-    process.env.IS_STAGING = "true";
-    t.equal(isStaging(), true);
-
-    process.env.NODE_ENV = "production";
-    process.env.IS_STAGING = undefined;
-    t.equal(isStaging(), false);
-
-    process.env.NODE_ENV = "production";
-    process.env.IS_STAGING = "false";
-    t.equal(isStaging(), false);
-
-    process.env.NODE_ENV = "development";
-    process.env.IS_STAGING = "true";
-    t.equal(isStaging(), true);
-
-    process.env.NODE_ENV = "development";
-    process.env.IS_STAGING = "false";
-    t.equal(isStaging(), true);
-
-    process.env.NODE_ENV = currentEnv;
-    process.env.IS_STAGING = currentIsStaging;
   });
 
   t.test("isMainFnAndGetName", (t) => {

--- a/packages/store/src/migrations.js
+++ b/packages/store/src/migrations.js
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { existsSync } from "fs";
 import { readdir, readFile } from "fs/promises";
-import { dirnameForModule, pathJoin } from "@lbu/stdlib";
+import { dirnameForModule, environment, pathJoin } from "@lbu/stdlib";
 
 /**
  * @param {Postgres} sql
@@ -239,8 +239,8 @@ async function acquireLock(sql) {
  */
 async function readMigrationsDir(
   directory,
-  namespace = process.env.APP_NAME,
-  namespaces = [process.env.APP_NAME],
+  namespace = environment.APP_NAME,
+  namespaces = [environment.APP_NAME],
 ) {
   if (!existsSync(directory)) {
     return {

--- a/packages/store/src/migrations.test.js
+++ b/packages/store/src/migrations.test.js
@@ -1,5 +1,5 @@
 import { mainTestFn, test } from "@lbu/cli";
-import { dirnameForModule } from "@lbu/stdlib";
+import { dirnameForModule, environment } from "@lbu/stdlib";
 import {
   getMigrationsToBeApplied,
   newMigrateContext,
@@ -28,7 +28,7 @@ test("store/migrations", (t) => {
   t.test("run full migration", async (t) => {
     const mc = await newMigrateContext(sql, `./__fixtures__/store`);
 
-    t.deepEqual(mc.namespaces, ["@lbu/store", process.env.APP_NAME]);
+    t.deepEqual(mc.namespaces, ["@lbu/store", environment.APP_NAME]);
     t.equal(mc.files.length, 9);
 
     const { migrationQueue: list } = getMigrationsToBeApplied(mc);

--- a/packages/store/src/minio.js
+++ b/packages/store/src/minio.js
@@ -1,4 +1,4 @@
-import { isProduction, merge } from "@lbu/stdlib";
+import { environment, isProduction, merge } from "@lbu/stdlib";
 import minio from "minio";
 
 /**
@@ -7,10 +7,10 @@ import minio from "minio";
  */
 export function newMinioClient(opts) {
   const config = {
-    endPoint: process.env.MINIO_URI,
-    port: process.env.MINIO_PORT ? Number(process.env.MINIO_PORT) : undefined,
-    accessKey: process.env.MINIO_ACCESS_KEY,
-    secretKey: process.env.MINIO_SECRET_KEY,
+    endPoint: environment.MINIO_URI,
+    port: environment.MINIO_PORT ? Number(environment.MINIO_PORT) : undefined,
+    accessKey: environment.MINIO_ACCESS_KEY,
+    secretKey: environment.MINIO_SECRET_KEY,
     useSSL: isProduction(),
   };
   return new minio.Client(merge(config, opts));

--- a/packages/store/src/postgres.js
+++ b/packages/store/src/postgres.js
@@ -1,4 +1,4 @@
-import { isProduction, merge } from "@lbu/stdlib";
+import { environment, isProduction, merge } from "@lbu/stdlib";
 import postgres from "postgres";
 
 /**
@@ -7,30 +7,30 @@ import postgres from "postgres";
  * @returns {Postgres}
  */
 export async function newPostgresConnection(opts) {
-  if (!process.env.POSTGRES_URI || !process.env.APP_NAME) {
+  if (!environment.POSTGRES_URI || !environment.APP_NAME) {
     throw new Error(
       "Provide the 'POSTGRES_URI' and 'APP_NAME' environment variables.",
     );
   }
 
-  if (!process.env.POSTGRES_URI.endsWith("/")) {
-    process.env.POSTGRES_URI += "/";
+  if (!environment.POSTGRES_URI.endsWith("/")) {
+    environment.POSTGRES_URI += "/";
   }
 
   if (opts && opts.createIfNotExists) {
     const oldConnection = await createDatabaseIfNotExists(
       undefined,
-      process.env.APP_NAME,
+      environment.APP_NAME,
     );
     setImmediate(() => oldConnection.end({}));
   }
 
   return postgres(
-    process.env.POSTGRES_URI + process.env.APP_NAME,
+    environment.POSTGRES_URI + environment.APP_NAME,
     merge(
       {
         connection: {
-          application_name: process.env.APP_NAME,
+          application_name: environment.APP_NAME,
           ssl: isProduction(),
         },
         no_prepare: true,
@@ -47,7 +47,7 @@ export async function newPostgresConnection(opts) {
  */
 export async function createDatabaseIfNotExists(sql, databaseName, template) {
   if (!sql) {
-    sql = postgres(process.env.POSTGRES_URI);
+    sql = postgres(environment.POSTGRES_URI);
   }
   const [db] = await sql`
     SELECT datname

--- a/packages/store/src/queue.js
+++ b/packages/store/src/queue.js
@@ -1,4 +1,5 @@
-import { log } from "@lbu/insight";
+import { newLogger } from "@lbu/insight";
+import { environment } from "@lbu/stdlib";
 import { queries } from "./generated.js";
 
 const LBU_RECURRING_JOB = "lbu.job.recurring";
@@ -141,6 +142,7 @@ export class JobQueueWorker {
       );
       this.name = nameOrOptions;
     } else {
+      this.name = undefined;
       options = nameOrOptions;
     }
 
@@ -153,6 +155,7 @@ export class JobQueueWorker {
     this.isStarted = false;
 
     this.jobHandler = options?.handler;
+    this.logger = newLogger({ ctx: { type: this.name } });
   }
 
   start() {
@@ -300,8 +303,8 @@ export class JobQueueWorker {
         }
       })
       .catch((e) => {
-        log.error(e);
-      }); // user should have handled error already, so ignore it
+        this.logger.error(e);
+      });
   }
 }
 
@@ -315,7 +318,7 @@ export class JobQueueWorker {
 export async function addJobToQueue(sql, job) {
   const [result] = await queries.jobInsert(sql, {
     ...job,
-    name: job.name ?? process.env.APP_NAME,
+    name: job.name ?? environment.APP_NAME,
   });
   return result?.id;
 }

--- a/packages/store/src/testing.js
+++ b/packages/store/src/testing.js
@@ -1,5 +1,5 @@
-import { log } from "@lbu/insight";
-import { isNil, uuid } from "@lbu/stdlib";
+import { newLogger } from "@lbu/insight";
+import { environment, isNil, uuid } from "@lbu/stdlib";
 import {
   createDatabaseIfNotExists,
   newPostgresConnection,
@@ -54,15 +54,15 @@ export async function cleanupPostgresDatabaseTemplate() {
  * @param verboseSql
  */
 export async function createTestPostgresDatabase(verboseSql = false) {
-  const name = process.env.APP_NAME + uuid().substring(0, 7);
+  const name = environment.APP_NAME + uuid().substring(0, 7);
 
   // Setup a template to work from
   if (isNil(testDatabase)) {
-    testDatabase = process.env.APP_NAME + uuid().substring(0, 7);
+    testDatabase = environment.APP_NAME + uuid().substring(0, 7);
 
     const creationSql = await createDatabaseIfNotExists(
       undefined,
-      process.env.APP_NAME,
+      environment.APP_NAME,
     );
 
     // Clean all connections
@@ -73,7 +73,7 @@ export async function createTestPostgresDatabase(verboseSql = false) {
       FROM
         pg_stat_activity
       WHERE
-        pg_stat_activity.datname = ${process.env.APP_NAME}
+        pg_stat_activity.datname = ${environment.APP_NAME}
         AND pid <> pg_backend_pid()
     `;
 
@@ -82,7 +82,7 @@ export async function createTestPostgresDatabase(verboseSql = false) {
     await createDatabaseIfNotExists(
       creationSql,
       testDatabase,
-      process.env.APP_NAME,
+      environment.APP_NAME,
     );
 
     const sql = await newPostgresConnection({
@@ -122,7 +122,7 @@ export async function createTestPostgresDatabase(verboseSql = false) {
 
   const sql = await newPostgresConnection({
     database: name,
-    debug: verboseSql ? log.error : undefined,
+    debug: verboseSql ? newLogger({ ctx: { type: "sql" } }).error : undefined,
   });
 
   // Initialize new connection and kill old connection


### PR DESCRIPTION
Removes the 'log' export from 'insight'.

Accessing process.env.XXX is relatively slow in Node.js.
Benchmark of a plain object property access and accessing process.env.NODE_ENV:

```
property access       500000000  iterations     0  ns/op
process.env access      5000000  iterations   246  ns/op
```

See this thread https://github.com/nodejs/node/issues/3104 for some more context