### PR TITLE
stdlib: add support for util.inspect.custom to AppError

### DIFF
--- a/packages/code-gen/src/template.js
+++ b/packages/code-gen/src/template.js
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { inspect } from "util";
 import {
+  AppError,
   camelToSnakeCase,
   isNil,
   processDirectoryRecursiveSync,
@@ -129,9 +130,15 @@ export function executeTemplate(name, data) {
   try {
     return templateContext.context[name](getExecutionContext(), data).trim();
   } catch (e) {
-    const err = new Error(`Error while executing ${name} template`);
-    err.originalErr = e;
-    throw err;
+    throw new AppError(
+      "codeGen.executeTemplate.error",
+      500,
+      {
+        message: "Error while executing template",
+        template: name,
+      },
+      e,
+    );
   }
 }
 

--- a/packages/stdlib/src/error.js
+++ b/packages/stdlib/src/error.js
@@ -1,3 +1,4 @@
+import { inspect } from "util";
 import { isNil } from "./lodash.js";
 
 export class AppError extends Error {
@@ -119,5 +120,14 @@ export class AppError extends Error {
       message: e.message,
       stack: skipStack ? [] : stack,
     };
+  }
+
+  /**
+   * Use AppError#format when AppError is passed to console.log / console.error.
+   * This works because it uses `util.inspect` under the hood.
+   * Util#inspect checks if the Symbol `util.inspect.custom` is available.
+   */
+  [inspect.custom]() {
+    return AppError.format(this);
   }
 }


### PR DESCRIPTION
This is used when AppErrors are passed to Node.js' util#inspect directly, or indirectly via console.log.
It does not work with console.dir tho.

Closes #453