### PR TITLE
code-gen: only use an extensions in imports in ES Modules

### DIFF
--- a/packages/code-gen/src/generated/anonymous-validators.js
+++ b/packages/code-gen/src/generated/anonymous-validators.js
@@ -1652,13 +1652,18 @@ export function anonymousValidator51(
   }
   const result = Object.create(null);
   for (const key of Object.keys(value)) {
-    result[
-      anonymousValidator52(key, `${propertyPath}.$key[${key}]`, errors)
-    ] = anonymousValidator53(
-      value[key],
-      `${propertyPath}.$value[${key}]`,
+    const genericKey = anonymousValidator52(
+      key,
+      `${propertyPath}.$key[${key}]`,
       errors,
     );
+    if (genericKey !== undefined) {
+      result[genericKey] = anonymousValidator53(
+        value[key],
+        `${propertyPath}.$value[${key}]`,
+        errors,
+      );
+    }
   }
   return result;
 }
@@ -3669,13 +3674,18 @@ export function anonymousValidator101(
   }
   const result = Object.create(null);
   for (const key of Object.keys(value)) {
-    result[
-      anonymousValidator52(key, `${propertyPath}.$key[${key}]`, errors)
-    ] = anonymousValidator102(
-      value[key],
-      `${propertyPath}.$value[${key}]`,
+    const genericKey = anonymousValidator52(
+      key,
+      `${propertyPath}.$key[${key}]`,
       errors,
     );
+    if (genericKey !== undefined) {
+      result[genericKey] = anonymousValidator102(
+        value[key],
+        `${propertyPath}.$value[${key}]`,
+        errors,
+      );
+    }
   }
   return result;
 }
@@ -3702,13 +3712,18 @@ export function anonymousValidator100(
   }
   const result = Object.create(null);
   for (const key of Object.keys(value)) {
-    result[
-      anonymousValidator52(key, `${propertyPath}.$key[${key}]`, errors)
-    ] = anonymousValidator101(
-      value[key],
-      `${propertyPath}.$value[${key}]`,
+    const genericKey = anonymousValidator52(
+      key,
+      `${propertyPath}.$key[${key}]`,
       errors,
     );
+    if (genericKey !== undefined) {
+      result[genericKey] = anonymousValidator101(
+        value[key],
+        `${propertyPath}.$value[${key}]`,
+        errors,
+      );
+    }
   }
   return result;
 }

--- a/packages/code-gen/src/generator/index.js
+++ b/packages/code-gen/src/generator/index.js
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { pathJoin } from "@lbu/stdlib";
 import { copyAndSort } from "../generate.js";
 import { templateContext } from "../template.js";
@@ -53,6 +53,8 @@ export async function generate(logger, options, structure) {
     enabledGroups: options.enabledGroups,
   });
 
+  const isModule = shouldGenerateModules();
+
   /**
    * @type {CodeGenContext}
    */
@@ -61,7 +63,7 @@ export async function generate(logger, options, structure) {
     options,
     structure,
     extension: options.useTypescript ? ".ts" : ".js",
-    importExtension: ".js",
+    importExtension: isModule ? ".js" : "",
     outputFiles: [],
     rootExports: [],
     errors: [],
@@ -197,5 +199,22 @@ export function writeFiles(context) {
 
     mkdirSync(directory, { recursive: true });
     writeFileSync(fullPath, file.contents, "utf8");
+  }
+}
+
+/**
+ * Check if we should generate ES Modules based on the package.json
+ * @returns {boolean}
+ */
+export async function shouldGenerateModules() {
+  try {
+    const packageJsonSource = readFileSync(
+      pathJoin(process.cwd(), "package.json"),
+      "utf8",
+    );
+    const packageJson = JSON.parse(packageJsonSource);
+    return packageJson?.type === "module";
+  } catch {
+    return true;
   }
 }


### PR DESCRIPTION
TypeScript doesn't rewrite paths, so when the target is not ES modules, we should not specify import extensions. The easiest way is to use `type: "module"` from the package.json