### PR TITLE
stdlib: improve error formatting

### DIFF
--- a/packages/cli/src/benchmarking/printer.js
+++ b/packages/cli/src/benchmarking/printer.js
@@ -109,28 +109,20 @@ function printErrorResults(result, state) {
     const indent = "  ";
     const exception = AppError.format(bench.caughtException);
 
-    const stack = exception.stack.map((it) => `${indent}  ${it.trim()}`);
-
     if (AppError.instanceOf(bench.caughtException)) {
       result.push(`${indent}AppError: ${exception.key} - ${exception.status}`);
-
-      // Pretty print info object
-      const infoObject = inspect(exception.info, {
-        depth: null,
-        colors: true,
-      }).split("\n");
-
-      for (const it of infoObject) {
-        result.push(`${indent}  ${it}`);
-      }
     } else {
-      result.push(
-        `${indent}${bench.caughtException.name} - ${bench.caughtException.message}`,
-      );
+      result.push(`${indent}${exception.name} - ${exception.message}`);
     }
 
-    for (const item of stack) {
-      result.push(item);
+    // Pretty print info object
+    const errorPretty = inspect(exception, {
+      depth: null,
+      colors: true,
+    }).split("\n");
+
+    for (const it of errorPretty) {
+      result.push(`${indent}  ${it}`);
     }
   }
 }

--- a/packages/cli/src/testing/printer.js
+++ b/packages/cli/src/testing/printer.js
@@ -71,40 +71,22 @@ function printFailedResults(state, result, indentCount) {
     if (state.caughtException) {
       const exception = AppError.format(state.caughtException);
 
-      const stack = exception.stack.map((it) => `${indent}  ${it.trim()}`);
-
       if (AppError.instanceOf(state.caughtException)) {
         result.push(
           `${indent}AppError: ${exception.key} - ${exception.status}`,
         );
-
-        // Pretty print info object
-        const infoObject = inspect(exception.info, {
-          depth: null,
-          colors: true,
-        }).split("\n");
-
-        for (const it of infoObject) {
-          result.push(`${indent}  ${it}`);
-        }
       } else {
         result.push(`${indent}${exception.name} - ${exception.message}`);
       }
 
-      for (const item of stack) {
-        result.push(item);
-      }
+      // Pretty print info object
+      const errorPretty = inspect(exception, {
+        depth: null,
+        colors: true,
+      }).split("\n");
 
-      if (exception.originalError) {
-        // Pretty print original error object
-        const originalError = inspect(exception.originalError, {
-          depth: null,
-          colors: true,
-        }).split("\n");
-
-        for (const it of originalError) {
-          result.push(`${indent}    ${it}`);
-        }
+      for (const it of errorPretty) {
+        result.push(`${indent}  ${it}`);
       }
     } else {
       for (const assertion of failedAssertions) {

--- a/packages/server/src/app.test.js
+++ b/packages/server/src/app.test.js
@@ -1,5 +1,5 @@
 import { mainTestFn, test } from "@lbu/cli";
-import { AppError, uuid } from "@lbu/stdlib";
+import { AppError, isPlainObject, uuid } from "@lbu/stdlib";
 import Axios from "axios";
 import { closeTestApp, createTestAppAndClient, getApp } from "../index.js";
 
@@ -69,6 +69,21 @@ test("server/app", async (t) => {
       t.equal(response.data.key, response.data.message);
       t.equal(response.data.key, "error.server.internal");
       t.ok(Array.isArray(response.data.info._error.stack));
+    }
+  });
+
+  t.test("AppError format of Axios errors", async (t) => {
+    try {
+      await client.get("/wrap-500");
+      t.fail("wrap-500, so axios should have thrown");
+    } catch (e) {
+      const formatted = AppError.format(e);
+      t.equal(formatted.name, "Error");
+      t.ok(isPlainObject(formatted.axios.responseHeaders));
+      t.ok(isPlainObject(formatted.axios.responseBody));
+      t.equal(formatted.axios.responseStatus, 500);
+      t.equal(formatted.axios.requestPath, "/wrap-500");
+      t.equal(formatted.axios.requestMethod, "GET");
     }
   });
 

--- a/packages/server/src/middleware/error.js
+++ b/packages/server/src/middleware/error.js
@@ -43,10 +43,8 @@ export function errorHandler({ onAppError, onError, leakError }) {
       ctx.body = onAppError(ctx, err.key, err.info);
 
       const formatted = AppError.format(error);
-      log({
-        type: "api_error",
-        ...formatted,
-      });
+      formatted.type = "api_error";
+      log(formatted);
 
       if (!isNil(err.originalError) && leakError) {
         ctx.body.info = ctx.body.info || {};

--- a/packages/stdlib/index.d.ts
+++ b/packages/stdlib/index.d.ts
@@ -98,15 +98,7 @@ export class AppError<T extends any> extends Error {
   static format<T extends any>(
     e: AppError<T> | Error,
     skipStack?: boolean,
-  ):
-    | {
-        key: string;
-        status: number;
-        info: T;
-        originalError: any;
-        stack: string[];
-      }
-    | { name: string; message: string; stack: string[] };
+  ): any;
 }
 
 /**

--- a/packages/stdlib/src/error.test.js
+++ b/packages/stdlib/src/error.test.js
@@ -1,0 +1,121 @@
+import { mainTestFn, test } from "../../cli/index.js";
+import { AppError } from "./error.js";
+
+mainTestFn(import.meta);
+
+test("stdlib/error", (t) => {
+  // We do basic AppError testing here, specific use cases, related to external error
+  // formatting, are handled throughout other test files.
+
+  t.test("throws on incorrect arguments: key", (t) => {
+    const e = new AppError(500, 500);
+
+    t.equal(AppError.instanceOf(e), true);
+    t.equal(e.key, "error.server.internal");
+    t.equal(e.info.appErrorConstructParams.key, 500);
+    t.equal(e.originalError.key, 500);
+  });
+
+  t.test("throws on incorrect arguments: status", (t) => {
+    const e = new AppError("test.error", "500");
+
+    t.equal(AppError.instanceOf(e), true);
+    t.equal(e.key, "error.server.internal");
+    t.equal(e.info.appErrorConstructParams.key, "test.error");
+    t.equal(e.info.appErrorConstructParams.status, "500");
+    t.equal(e.originalError.key, "test.error");
+    t.equal(e.originalError.status, "500");
+  });
+
+  t.test("AppError#format with stack", (t) => {
+    try {
+      throw AppError.validationError("test.error", {});
+    } catch (e) {
+      t.ok(AppError.instanceOf(e));
+
+      const formatted = AppError.format(e);
+      t.equal(formatted.key, "test.error");
+      t.ok(Array.isArray(formatted.stack));
+      t.deepEqual(formatted.info, {});
+    }
+  });
+
+  t.test("AppError#format without stack", (t) => {
+    try {
+      throw AppError.validationError("test.error", {});
+    } catch (e) {
+      t.ok(AppError.instanceOf(e));
+
+      const formatted = AppError.format(e, true);
+      t.equal(formatted.key, "test.error");
+      t.ok(Array.isArray(formatted.stack));
+      t.deepEqual(formatted.info, {});
+    }
+  });
+
+  t.test("AppError#format with original AppError", (t) => {
+    try {
+      throw AppError.validationError("test.error", {}, AppError.serverError());
+    } catch (e) {
+      t.ok(AppError.instanceOf(e));
+
+      const formatted = AppError.format(e);
+      t.equal(formatted.key, "test.error");
+      t.ok(Array.isArray(formatted.stack));
+      t.deepEqual(formatted.info, {});
+
+      t.equal(formatted.originalError.key, "error.server.internal");
+      t.equal(formatted.originalError.status, 500);
+      t.ok(Array.isArray(formatted.originalError.stack));
+    }
+  });
+
+  t.test("AppError#format with original Error", (t) => {
+    try {
+      throw AppError.validationError(
+        "test.error",
+        {},
+        new Error("test message"),
+      );
+    } catch (e) {
+      t.ok(AppError.instanceOf(e));
+
+      const formatted = AppError.format(e);
+      t.equal(formatted.key, "test.error");
+      t.ok(Array.isArray(formatted.stack));
+      t.deepEqual(formatted.info, {});
+
+      t.equal(formatted.originalError.message, "test message");
+      t.equal(formatted.originalError.name, "Error");
+      t.ok(Array.isArray(formatted.originalError.stack));
+    }
+  });
+
+  t.test("AppError#format originalError with toJSON", (t) => {
+    try {
+      throw AppError.validationError(
+        "test.error",
+        {},
+        {
+          toJSON() {
+            return {
+              name: "JSONError",
+              message: "JSON message",
+            };
+          },
+        },
+      );
+    } catch (e) {
+      t.ok(AppError.instanceOf(e));
+
+      const formatted = AppError.format(e);
+      t.equal(formatted.key, "test.error");
+      t.ok(Array.isArray(formatted.stack));
+      t.deepEqual(formatted.info, {});
+
+      t.equal(formatted.originalError.message, "JSON message");
+      t.equal(formatted.originalError.name, "JSONError");
+      t.ok(Array.isArray(formatted.originalError.stack));
+    }
+  });
+});

--- a/packages/store/src/query.test.js
+++ b/packages/store/src/query.test.js
@@ -1,5 +1,5 @@
 import { mainTestFn, test } from "@lbu/cli";
-import { isPlainObject } from "@lbu/stdlib";
+import { AppError, isPlainObject } from "@lbu/stdlib";
 import { explainAnalyzeQuery, query } from "./query.js";
 import {
   cleanupTestPostgresDatabase,
@@ -151,6 +151,19 @@ test("store/analyze-query", (t) => {
     );
     const result = await sql`SELECT * FROM "temp"`;
     t.equal(result.length, 0);
+  });
+
+  t.test("AppError format Postgres errors", async (t) => {
+    try {
+      await sql`SELECT 1 + 1 FROM "foo"`;
+      t.fail("should throw");
+    } catch (e) {
+      const formatted = AppError.format(e);
+
+      t.equal(formatted.name, "PostgresError");
+      t.equal(formatted.postgres.severity, "ERROR");
+      t.equal(formatted.postgres.routine, "parserOpenTable");
+    }
   });
 
   t.test("teardown", async () => {


### PR DESCRIPTION
We now handle some third party library errors like Axios errors and Postgres errors much better. Also consistent behaviour when printing uncaught exceptions in the test runner and bench runner.

Closes #494 and closes #495