### PR TITLE
lint-config: add no-unsafe-optional-chain rule to lint config

### DIFF
--- a/packages/lint-config/index.js
+++ b/packages/lint-config/index.js
@@ -17,6 +17,10 @@ module.exports = {
     "no-process-exit": "off",
     "no-console": ["error", { allow: ["dir", "time", "timeEnd"] }],
     "no-promise-executor-return": "error",
+    "no-unsafe-optional-chaining": [
+      "error",
+      { disallowArithmeticOperators: true },
+    ],
     "default-case-last": "error",
     "no-else-return": "error",
     "no-return-assign": "error",


### PR DESCRIPTION
For more information see https://eslint.org/docs/rules/no-unsafe-optional-chaining