### PR TITLE
code-gen: add dumpApiStructure and throwingValidators options

### DIFF
--- a/gen/code-gen.js
+++ b/gen/code-gen.js
@@ -36,6 +36,9 @@ export function applyCodeGenStructure(app) {
       ),
       useTypescript: T.bool(),
       dumpStructure: T.bool(),
+      dumpApiStructure: T.bool(),
+      dumpPostgres: T.bool(),
+      throwingValidators: T.bool(),
       fileHeader: T.string(),
       outputDirectory: T.string(),
     }),
@@ -66,6 +69,9 @@ export function applyCodeGenStructure(app) {
           },
           {
             key: "sqlEnableValidator",
+          },
+          {
+            key: "sqlThrowingValidators",
           },
         ),
       ],

--- a/packages/code-gen/index.d.ts
+++ b/packages/code-gen/index.d.ts
@@ -38,7 +38,9 @@ interface GenerateOpts {
    *   isNode: false,
    *   enabledGenerators: ["type", "validator", "apiClient", "reactQuery"],
    *   useTypescript: true,
+   *   throwingValidators: false,
    *   dumpStructure: false,
+   *   dumpApiStructure: false,
    *   dumpPostgres: false,
    */
   isBrowser?: boolean;
@@ -52,7 +54,9 @@ interface GenerateOpts {
    *   isNode: true,
    *   enabledGenerators: ["type", "validator", "sql", "router", "apiClient"],
    *   useTypescript: false,
-   *   dumpStructure: true,
+   *   throwingValidators: true,
+   *   dumpStructure: false,
+   *   dumpApiStructure: true,
    *   dumpPostgres: true,
    */
   isNodeServer?: boolean;
@@ -66,7 +70,9 @@ interface GenerateOpts {
    *   isNode: true,
    *   enabledGenerators: ["type", "validator"],
    *   useTypescript: false,
+   *   throwingValidators: false,
    *   dumpStructure: false,
+   *   dumpApiStructure: false,
    *   dumpPostgres: false,
    */
   isNode?: boolean;
@@ -83,9 +89,22 @@ interface GenerateOpts {
   useTypescript?: boolean;
 
   /**
-   * Dump a structure.js file with the used payload in it
+   * Generate throwing validators.
+   * This is expected by the router and sql generator.
+   */
+  throwingValidators?: boolean;
+
+  /**
+   * Dump a structure.js file with the used payload in it.
+   * This is useful when creating packages.
    */
   dumpStructure?: boolean;
+
+  /**
+   * An api only variant of dumpStructure.
+   * This should be used when you want others to generate api clients.
+   */
+  dumpApiStructure?: boolean;
 
   /**
    * Custom file header to for example disable linting or something

--- a/packages/code-gen/src/App.js
+++ b/packages/code-gen/src/App.js
@@ -25,7 +25,9 @@ const defaultGenerateOptionsBrowser = {
   isNode: false,
   enabledGenerators: ["type", "validator", "apiClient", "reactQuery"],
   useTypescript: true,
+  throwingValidators: false,
   dumpStructure: false,
+  dumpApiStructure: false,
   dumpPostgres: false,
 };
 
@@ -38,7 +40,9 @@ const defaultGenerateOptionsNodeServer = {
   isNode: true,
   enabledGenerators: ["type", "validator", "sql", "router", "apiClient"],
   useTypescript: false,
-  dumpStructure: true,
+  throwingValidators: true,
+  dumpStructure: false,
+  dumpApiStructure: true,
   dumpPostgres: true,
 };
 
@@ -51,7 +55,9 @@ const defaultGenerateOptionsNode = {
   isNode: true,
   enabledGenerators: ["type", "validator"],
   useTypescript: false,
+  throwingValidators: false,
   dumpStructure: false,
+  dumpApiStructure: false,
   dumpPostgres: false,
 };
 
@@ -246,7 +252,6 @@ export class App {
       Object.assign(opts, defaultGenerateOptionsBrowser);
     } else if (
       options.isNodeServer ||
-      options.enabledGenerators.indexOf("sql") !== -1 ||
       options.enabledGenerators.indexOf("router") !== -1
     ) {
       Object.assign(opts, defaultGenerateOptionsNodeServer);
@@ -258,7 +263,10 @@ export class App {
     }
 
     opts.useTypescript = options.useTypescript ?? !!opts.useTypescript;
+    opts.throwingValidators =
+      options.throwingValidators ?? !!opts.throwingValidators;
     opts.dumpStructure = options.dumpStructure ?? !!opts.dumpStructure;
+    opts.dumpApiStructure = options.dumpApiStructure ?? !!opts.dumpApiStructure;
     opts.dumpPostgres = options.dumpPostgres ?? !!opts.dumpPostgres;
     opts.enabledGenerators =
       options.enabledGenerators.length > 0
@@ -289,10 +297,12 @@ export class App {
       throw new Error("Need at least a single group in enabledGroups");
     }
 
+    // Make sure _compas/structure.json is enabled.
+    // This is only needed when we have a router and dumpApiStructure is true
     if (
       opts.enabledGenerators.indexOf("router") !== -1 &&
       opts.enabledGroups.indexOf("compas") === -1 &&
-      opts.dumpStructure
+      opts.dumpApiStructure
     ) {
       opts.enabledGroups.push("compas");
     }

--- a/packages/code-gen/src/generate.js
+++ b/packages/code-gen/src/generate.js
@@ -69,7 +69,7 @@ export function addToData(dataStructure, item) {
  * @param generatorInput
  * @param value
  */
-function includeReferenceTypes(rootData, generatorInput, value) {
+export function includeReferenceTypes(rootData, generatorInput, value) {
   if (isNil(value) || (!isPlainObject(value) && !Array.isArray(value))) {
     // Skip primitives & null / undefined
     return;

--- a/packages/code-gen/src/generated/anonymous-validators.js
+++ b/packages/code-gen/src/generated/anonymous-validators.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 
 const objectKeys1283136356 = new Set(["uniqueName", "group", "name"]);
-const objectKeys710084980 = new Set([
+const objectKeys1289628375 = new Set([
   "options",
   "structure",
   "extension",
@@ -11,7 +11,7 @@ const objectKeys710084980 = new Set([
   "rootExports",
   "errors",
 ]);
-const objectKeys1311847056 = new Set([
+const objectKeys2050316243 = new Set([
   "enabledGroups",
   "isBrowser",
   "isNode",
@@ -19,6 +19,9 @@ const objectKeys1311847056 = new Set([
   "enabledGenerators",
   "useTypescript",
   "dumpStructure",
+  "dumpApiStructure",
+  "dumpPostgres",
+  "throwingValidators",
   "fileHeader",
   "outputDirectory",
 ]);
@@ -33,6 +36,7 @@ const objectKeys1239750152 = new Set([
   "relationOwnKey",
 ]);
 const objectKeys1573063370 = new Set(["key"]);
+const objectKeys212814474 = new Set(["key"]);
 const objectKeys427792324 = new Set(["phase"]);
 const objectKeys2093265039 = new Set([
   "isJSON",
@@ -2706,9 +2710,9 @@ export function anonymousValidator1009589157(
  * @param {string} propertyPath
  * @param {*[]} errors
  * @param {string} parentType
- * @returns {{"enabledGroups": (string)[], "isBrowser": boolean, "isNode": boolean, "isNodeServer": boolean, "enabledGenerators": ("type"|"validator"|"router"|"sql"|"apiClient"|"reactQuery")[], "useTypescript": boolean, "dumpStructure": boolean, "fileHeader": string, "outputDirectory": string, }|undefined}
+ * @returns {{"enabledGroups": (string)[], "isBrowser": boolean, "isNode": boolean, "isNodeServer": boolean, "enabledGenerators": ("type"|"validator"|"router"|"sql"|"apiClient"|"reactQuery")[], "useTypescript": boolean, "dumpStructure": boolean, "dumpApiStructure": boolean, "dumpPostgres": boolean, "throwingValidators": boolean, "fileHeader": string, "outputDirectory": string, }|undefined}
  */
-export function anonymousValidator1311847056(
+export function anonymousValidator2050316243(
   value,
   propertyPath,
   errors = [],
@@ -2724,7 +2728,7 @@ export function anonymousValidator1311847056(
   }
   const result = Object.create(null);
   for (const key of Object.keys(value)) {
-    if (!objectKeys1311847056.has(key)) {
+    if (!objectKeys2050316243.has(key)) {
       errors.push(
         buildError(parentType, "strict", { propertyPath, extraKey: key }),
       );
@@ -2795,6 +2799,42 @@ export function anonymousValidator1311847056(
     );
   }
   result["dumpStructure"] = value["dumpStructure"] ?? undefined;
+  if (
+    isNil(value["dumpApiStructure"]) ||
+    typeof value["dumpApiStructure"] !== "boolean"
+  ) {
+    const parentType = "boolean";
+    errors.push(
+      buildError(parentType, "type", {
+        propertyPath: `${propertyPath}.dumpApiStructure`,
+      }),
+    );
+  }
+  result["dumpApiStructure"] = value["dumpApiStructure"] ?? undefined;
+  if (
+    isNil(value["dumpPostgres"]) ||
+    typeof value["dumpPostgres"] !== "boolean"
+  ) {
+    const parentType = "boolean";
+    errors.push(
+      buildError(parentType, "type", {
+        propertyPath: `${propertyPath}.dumpPostgres`,
+      }),
+    );
+  }
+  result["dumpPostgres"] = value["dumpPostgres"] ?? undefined;
+  if (
+    isNil(value["throwingValidators"]) ||
+    typeof value["throwingValidators"] !== "boolean"
+  ) {
+    const parentType = "boolean";
+    errors.push(
+      buildError(parentType, "type", {
+        propertyPath: `${propertyPath}.throwingValidators`,
+      }),
+    );
+  }
+  result["throwingValidators"] = value["throwingValidators"] ?? undefined;
   result["fileHeader"] = anonymousValidator1801034940(
     value["fileHeader"],
     `${propertyPath}.fileHeader`,
@@ -3168,9 +3208,52 @@ export function anonymousValidator1573063370(
  * @param {string} propertyPath
  * @param {*[]} errors
  * @param {string} parentType
- * @returns {{"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", }|undefined}
+ * @returns {{"key": "sqlThrowingValidators", }|undefined}
  */
-export function anonymousValidator527840024(
+export function anonymousValidator212814474(
+  value,
+  propertyPath,
+  errors = [],
+  parentType = "object",
+) {
+  if (isNil(value)) {
+    errors.push(buildError(parentType, "undefined", { propertyPath }));
+    return undefined;
+  }
+  if (typeof value !== "object") {
+    errors.push(buildError(parentType, "type", { propertyPath }));
+    return undefined;
+  }
+  const result = Object.create(null);
+  for (const key of Object.keys(value)) {
+    if (!objectKeys212814474.has(key)) {
+      errors.push(
+        buildError(parentType, "strict", { propertyPath, extraKey: key }),
+      );
+      return undefined;
+    }
+  }
+  if (value["key"] !== "sqlThrowingValidators") {
+    const parentType = "string";
+    const oneOf = ["sqlThrowingValidators"];
+    errors.push(
+      buildError(parentType, "oneOf", {
+        propertyPath: `${propertyPath}.key`,
+        oneOf,
+      }),
+    );
+  }
+  result["key"] = value["key"] ?? undefined;
+  return result;
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @param {*[]} errors
+ * @param {string} parentType
+ * @returns {{"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", }|{"key": "sqlThrowingValidators", }|undefined}
+ */
+export function anonymousValidator1621069940(
   value,
   propertyPath,
   errors = [],
@@ -3207,6 +3290,12 @@ export function anonymousValidator527840024(
   }
   subErrors.splice(errorCount + 1, subErrors.length - errorCount);
   errorCount = subErrors.length;
+  result = anonymousValidator212814474(value, propertyPath, subErrors);
+  if (subErrors.length === errorCount) {
+    return result;
+  }
+  subErrors.splice(errorCount + 1, subErrors.length - errorCount);
+  errorCount = subErrors.length;
   errors.push(
     buildError(parentType, "type", { propertyPath, errors: subErrors }),
   );
@@ -3217,9 +3306,9 @@ export function anonymousValidator527840024(
  * @param {string} propertyPath
  * @param {*[]} errors
  * @param {string} parentType
- * @returns {({"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", })[]|undefined}
+ * @returns {({"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", }|{"key": "sqlThrowingValidators", })[]|undefined}
  */
-export function anonymousValidator1686428333(
+export function anonymousValidator1002720483(
   value,
   propertyPath,
   errors = [],
@@ -3235,7 +3324,7 @@ export function anonymousValidator1686428333(
   }
   const result = Array.from({ length: value.length });
   for (let i = 0; i < value.length; ++i) {
-    result[i] = anonymousValidator527840024(
+    result[i] = anonymousValidator1621069940(
       value[i],
       `${propertyPath}[${i}]`,
       errors,
@@ -3248,9 +3337,9 @@ export function anonymousValidator1686428333(
  * @param {string} propertyPath
  * @param {*[]} errors
  * @param {string} parentType
- * @returns {{"options": CodeGenGenerateOpts, "structure": CodeGenStructure, "extension": ".js"|".ts", "importExtension": string, "outputFiles": (CodeGenFile)[], "rootExports": (string)[], "errors": ({"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", })[], }|undefined}
+ * @returns {{"options": CodeGenGenerateOpts, "structure": CodeGenStructure, "extension": ".js"|".ts", "importExtension": string, "outputFiles": (CodeGenFile)[], "rootExports": (string)[], "errors": ({"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", }|{"key": "sqlThrowingValidators", })[], }|undefined}
  */
-export function anonymousValidator710084980(
+export function anonymousValidator1289628375(
   value,
   propertyPath,
   errors = [],
@@ -3266,14 +3355,14 @@ export function anonymousValidator710084980(
   }
   const result = Object.create(null);
   for (const key of Object.keys(value)) {
-    if (!objectKeys710084980.has(key)) {
+    if (!objectKeys1289628375.has(key)) {
       errors.push(
         buildError(parentType, "strict", { propertyPath, extraKey: key }),
       );
       return undefined;
     }
   }
-  result["options"] = anonymousValidator1311847056(
+  result["options"] = anonymousValidator2050316243(
     value["options"],
     `${propertyPath}.options`,
     errors,
@@ -3309,7 +3398,7 @@ export function anonymousValidator710084980(
     `${propertyPath}.rootExports`,
     errors,
   );
-  result["errors"] = anonymousValidator1686428333(
+  result["errors"] = anonymousValidator1002720483(
     value["errors"],
     `${propertyPath}.errors`,
     errors,

--- a/packages/code-gen/src/generated/types.js
+++ b/packages/code-gen/src/generated/types.js
@@ -65,11 +65,11 @@ export const __generated__ = true;
  */
 /**
  * @name CodeGenContext
- * @typedef {{"options": CodeGenGenerateOpts, "structure": CodeGenStructure, "extension": ".js"|".ts", "importExtension": string, "outputFiles": (CodeGenFile)[], "rootExports": (string)[], "errors": ({"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", })[], }}
+ * @typedef {{"options": CodeGenGenerateOpts, "structure": CodeGenStructure, "extension": ".js"|".ts", "importExtension": string, "outputFiles": (CodeGenFile)[], "rootExports": (string)[], "errors": ({"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlEnableValidator", }|{"key": "sqlThrowingValidators", })[], }}
  */
 /**
  * @name CodeGenGenerateOpts
- * @typedef {{"enabledGroups": (string)[], "isBrowser": boolean, "isNode": boolean, "isNodeServer": boolean, "enabledGenerators": ("type"|"validator"|"router"|"sql"|"apiClient"|"reactQuery")[], "useTypescript": boolean, "dumpStructure": boolean, "fileHeader": string, "outputDirectory": string, }}
+ * @typedef {{"enabledGroups": (string)[], "isBrowser": boolean, "isNode": boolean, "isNodeServer": boolean, "enabledGenerators": ("type"|"validator"|"router"|"sql"|"apiClient"|"reactQuery")[], "useTypescript": boolean, "dumpStructure": boolean, "dumpApiStructure": boolean, "dumpPostgres": boolean, "throwingValidators": boolean, "fileHeader": string, "outputDirectory": string, }}
  */
 /**
  * @name CodeGenStructure

--- a/packages/code-gen/src/generated/validators.js
+++ b/packages/code-gen/src/generated/validators.js
@@ -7,20 +7,20 @@ import {
   anonymousValidator1199721884,
   anonymousValidator1207910150,
   anonymousValidator1210796142,
-  anonymousValidator1311847056,
+  anonymousValidator1289628375,
   anonymousValidator1371848646,
   anonymousValidator1448768479,
   anonymousValidator158572615,
   anonymousValidator1985175360,
   anonymousValidator2003332250,
   anonymousValidator2029007679,
+  anonymousValidator2050316243,
   anonymousValidator2080078377,
   anonymousValidator2093265039,
   anonymousValidator267932131,
   anonymousValidator368260888,
   anonymousValidator427792324,
   anonymousValidator647792494,
-  anonymousValidator710084980,
   anonymousValidator722636964,
   anonymousValidator98797027,
 } from "./anonymous-validators.js";
@@ -95,7 +95,7 @@ export function validateCodeGenBooleanType(value, propertyPath = "$") {
  */
 export function validateCodeGenContext(value, propertyPath = "$") {
   const errors = [];
-  const data = anonymousValidator710084980(value, propertyPath, errors);
+  const data = anonymousValidator1289628375(value, propertyPath, errors);
   if (errors.length > 0) {
     return { data: undefined, errors };
   }
@@ -159,7 +159,7 @@ export function validateCodeGenFileType(value, propertyPath = "$") {
  */
 export function validateCodeGenGenerateOpts(value, propertyPath = "$") {
   const errors = [];
-  const data = anonymousValidator1311847056(value, propertyPath, errors);
+  const data = anonymousValidator2050316243(value, propertyPath, errors);
   if (errors.length > 0) {
     return { data: undefined, errors };
   }

--- a/packages/code-gen/src/generator/errors.js
+++ b/packages/code-gen/src/generator/errors.js
@@ -18,6 +18,9 @@ export function exitOnErrorsOrReturn(context) {
     if (error.key === "sqlEnableValidator") {
       str += `Validator generator not enabled. The sql generator requires this.
   Please add 'validator' to the 'App.generate({ enabledGenerators: ["sql"] })' array.`;
+    } else if (error.key === "sqlThrowingValidators") {
+      str += `Option 'throwingValidators' not enabled. The sql generator requires this.
+  Please add 'throwingValidators' to the 'App.generate({ throwingValidators: true })' call.`;
     } else if (error.key === "sqlMissingPrimaryKey") {
       str += `Type '${error.typeName}' is missing a primary key.
   Either remove 'withPrimaryKey' from the options passed to 'enableQueries()' or add 'T.uuid().primary()' / 'T.number().primary()' to your type.

--- a/packages/code-gen/src/generator/router/index.js
+++ b/packages/code-gen/src/generator/router/index.js
@@ -7,6 +7,11 @@ import { buildTrie } from "./trie.js";
  * @param {CodeGenContext} context
  */
 export function generateRouterFiles(context) {
+  if (!context.options.throwingValidators) {
+    throw new Error(`Option 'throwingValidators' not enabled. The router generator requires this.
+  Please add 'throwingValidators' to the 'App.generate({ throwingValidators: true })' call.`);
+  }
+
   const routeTrie = buildTrie(context.structure);
   const routeTags = buildRouteTags(context.structure);
 
@@ -43,7 +48,7 @@ export function getInternalRoutes(options) {
 
   const result = [];
 
-  if (options.dumpStructure) {
+  if (options.dumpApiStructure) {
     result.push(
       G.get("structure.json", "structure")
         .response(T.any())

--- a/packages/code-gen/src/generator/router/templates/routerFile.tmpl
+++ b/packages/code-gen/src/generator/router/templates/routerFile.tmpl
@@ -26,8 +26,8 @@ import {
 {{ } }}
 } from "./validators{{= importExtension }}";
 
-{{ if (options.dumpStructure) { }}
-import { structureString } from "./structure{{= importExtension }}";
+{{ if (options.dumpApiStructure) { }}
+import { compasApiStructureString } from "./structure{{= importExtension }}";
 {{ } }}
 ((newline))
 
@@ -257,10 +257,10 @@ export function router(ctx, next) {
 }
 ((newline))
 
-{{ if (options.dumpStructure) { }}
+{{ if (options.dumpApiStructure) { }}
 compasHandlers.structure = (ctx, next) => {
   ctx.set("Content-Type", "application/json");
-  ctx.body = structureString;
+  ctx.body = compasApiStructureString;
 
   return next();
 }

--- a/packages/code-gen/src/generator/sql/utils.js
+++ b/packages/code-gen/src/generator/sql/utils.js
@@ -153,6 +153,12 @@ export function doSqlChecks(context) {
     });
   }
 
+  if (context.options.throwingValidators === false) {
+    context.errors.push({
+      key: "sqlThrowingValidators",
+    });
+  }
+
   for (const type of getQueryEnabledObjects(context)) {
     // Throw errors for missing primary keys
     staticCheckPrimaryKey(context, type);

--- a/packages/code-gen/src/generator/structure.js
+++ b/packages/code-gen/src/generator/structure.js
@@ -1,41 +1,80 @@
+import { addToData, includeReferenceTypes } from "../generate.js";
 import { js } from "./tag/index.js";
 
 /**
- * If `options.dumpStructure` is on, create a structure.js file with the structure payload
+ * If `options.dumpStructure` and/or `options.dumpApiStructure` is true, create a
+ * structure.js file with the structure payload
  *
  * @param {CodeGenContext} context
  */
 export function generateStructureFile(context) {
-  if (!context.options.dumpStructure) {
+  if (!context.options.dumpStructure && !context.options.dumpApiStructure) {
     return;
   }
-
   let structureSource = "";
 
-  for (const group of Object.keys(context.structure)) {
-    // Make it safe to inject in contents
-    const string = JSON.stringify(context.structure[group])
+  if (context.options.dumpStructure) {
+    for (const group of Object.keys(context.structure)) {
+      // Make it safe to inject in contents
+      const string = JSON.stringify(context.structure[group])
+        .replace(/\\/g, "\\\\")
+        .replace(/[^\\]'/g, "\\'");
+
+      structureSource += js`
+            export const ${group}StructureString = '${string}';
+            export const ${group}Structure = JSON.parse(${group}StructureString);
+         `;
+    }
+
+    const groups = Object.keys(context.structure)
+      .map((it) => `{ ${it}: ${it}Structure }`)
+      .join(", ");
+
+    structureSource += js`
+         export const structure = Object.assign({}, ${groups});
+         export const structureString = JSON.stringify(structure);
+      `;
+  }
+
+  if (context.options.dumpApiStructure) {
+    const apiStructure = {};
+    // Create a new structure object with all routes
+    for (const groupValues of Object.values(context.structure)) {
+      for (const type of Object.values(groupValues)) {
+        if (type.type !== "route") {
+          continue;
+        }
+        addToData(apiStructure, type);
+      }
+    }
+
+    // Include recursive references that are used in route types
+    const error = includeReferenceTypes(
+      context.structure,
+      apiStructure,
+      apiStructure,
+    );
+    if (error) {
+      throw error;
+    }
+
+    const string = JSON.stringify(apiStructure)
       .replace(/\\/g, "\\\\")
       .replace(/[^\\]'/g, "\\'");
 
+    // We only need a string here at all times, which saves us on some doing a
+    // stringify when sending the structure response.
     structureSource += js`
-      export const ${group}StructureString = '${string}';
-      export const ${group}Structure = JSON.parse(${group}StructureString);
-    `;
+         export const compasApiStructureString = '${string}';
+      `;
   }
 
-  const groups = Object.keys(context.structure)
-    .map((it) => `{ ${it}: ${it}Structure }`)
-    .join(", ");
-
-  context.outputFiles.push({
-    contents: js`
-                               ${structureSource}
-                               export const structure = Object.assign({}, ${groups});
-                               export const structureString = JSON.stringify(structure);
-                             `,
-    relativePath: `./structure${context.extension}`,
-  });
+  if (structureSource.length > 0) {
+    context.outputFiles.push({
+      contents: js`${structureSource}`,
+      relativePath: `./structure${context.extension}`,
+    });
+  }
 }
 
 /**

--- a/packages/code-gen/src/generator/validator.js
+++ b/packages/code-gen/src/generator/validator.js
@@ -37,7 +37,7 @@ export function generateValidatorFile(context) {
    */
   const subContext = {
     context,
-    collectErrors: !context.options.isNodeServer,
+    collectErrors: !context.options.throwingValidators,
     anonymousFunctionMapping: new Map(),
     anonymousFunctions: [],
     objectSets: new Map(),

--- a/scripts/internal_generate.js
+++ b/scripts/internal_generate.js
@@ -29,9 +29,11 @@ async function main() {
   await app.generate({
     outputDirectory: `packages/store/src/generated`,
     enabledGroups: ["store"],
-    isNode: true,
     enabledGenerators: ["type", "sql", "validator"],
+    throwingValidators: true,
+    isNode: true,
     dumpStructure: true,
+    dumpApiStructure: false,
     dumpPostgres: true,
   });
 }


### PR DESCRIPTION
We only want to exposes the necessary things outside of the api. This is only the router and related types. This can now be enabled via `dumpApiStructure`.
This also results in `dumpStructure` never being enabled by default, and is thus manually needed when creating packages.

This also adds a `throwingValidators` option. This is expected by the router and sql generator. However it is only enabled by default with `isNodeServer`.

Closes #525