### PR TITLE
insight,stdlib: stricter NODE_ENV checks

### DIFF
--- a/packages/insight/src/logger/logger.js
+++ b/packages/insight/src/logger/logger.js
@@ -13,7 +13,7 @@ export function newLogger(options) {
 
   const app = environment.APP_NAME;
   const isProduction =
-    options?.pretty === false || environment.NODE_ENV === "production";
+    options?.pretty === false || environment.NODE_ENV !== "development";
   const stream = options?.stream ?? process.stdout;
 
   const logFn = isProduction

--- a/packages/stdlib/src/env.js
+++ b/packages/stdlib/src/env.js
@@ -25,7 +25,7 @@ export function refreshEnvironmentCache() {
  * @returns {boolean}
  */
 export function isProduction() {
-  return environment.NODE_ENV === "production";
+  return environment.NODE_ENV !== "development";
 }
 
 /**
@@ -33,6 +33,6 @@ export function isProduction() {
  */
 export function isStaging() {
   return (
-    environment.NODE_ENV !== "production" || environment.IS_STAGING === "true"
+    environment.NODE_ENV === "development" || environment.IS_STAGING === "true"
   );
 }

--- a/packages/stdlib/src/env.test.js
+++ b/packages/stdlib/src/env.test.js
@@ -17,7 +17,7 @@ test("stdlib/env", (t) => {
 
     process.env.NODE_ENV = undefined;
     refreshEnvironmentCache();
-    t.equal(isProduction(), false);
+    t.equal(isProduction(), true);
 
     process.env.NODE_ENV = currentEnv;
     refreshEnvironmentCache();


### PR DESCRIPTION
We now by default run in 'production'-mode, except when `NODE_ENV=development` is passed in explicitly. This should make the default more secure.