### PR TITLE
cli: add parallel test running and order randomizer

### DIFF
--- a/packages/cli/scripts/test.js
+++ b/packages/cli/scripts/test.js
@@ -1,26 +1,180 @@
+import { cpus } from "os";
+import { isMainThread, Worker } from "worker_threads";
 import {
+  dirnameForModule,
   filenameForModule,
   mainFn,
-  processDirectoryRecursive,
+  pathJoin,
+  processDirectoryRecursiveSync,
 } from "@compas/stdlib";
 import { mainTestFn } from "../index.js";
+import { printTestResultsFromWorkers } from "../src/testing/printer.js";
+import {
+  setAreTestRunning,
+  setTestLogger,
+  testLogger,
+} from "../src/testing/state.js";
 
 const __filename = filenameForModule(import.meta);
-
-const contentHandler = async (file) => {
-  // Skip this index file
-  if (file === __filename) {
-    return;
-  }
-  if (!file.endsWith(".test.js")) {
-    return;
-  }
-  await import(file);
-};
+const workerFile = new URL(
+  `file://${pathJoin(dirnameForModule(import.meta), "../src/testing/test.js")}`,
+);
 
 mainFn(import.meta, main);
 
-async function main() {
-  await processDirectoryRecursive(process.cwd(), contentHandler);
-  mainTestFn(import.meta);
+async function main(logger) {
+  if (!isMainThread) {
+    logger.error("Test runner can only run as main thread");
+    process.exit(1);
+  }
+
+  if (process.argv.indexOf("--serial") !== -1) {
+    // Allow same process execution for coverage collecting
+    const files = listTestFiles();
+    for (const file of files) {
+      await import(file);
+    }
+    mainTestFn(import.meta);
+    return;
+  }
+
+  let randomizeRounds = Number(
+    (
+      process.argv.find((it) => it.startsWith("--randomize-rounds")) ?? "=1"
+    ).split("=")[1],
+  );
+
+  if (isNaN(randomizeRounds) || !isFinite(randomizeRounds)) {
+    randomizeRounds = 1;
+  }
+
+  // Make sure to set tests running, so `mainTestFn` is 'disabled'.
+  setAreTestRunning(true);
+  setTestLogger(logger);
+
+  // Almost does the same things as `mainTestFn`, however since tests are run by workers
+  // in stead of directly. We dispatch them, and then print the results.
+  const files = listTestFiles();
+  const results = [];
+
+  for (let i = 0; i < randomizeRounds; ++i) {
+    if (i !== 0) {
+      // Shuffle files in place
+      // From: https://stackoverflow.com/a/6274381
+      for (let i = files.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [files[i], files[j]] = [files[j], files[i]];
+      }
+    }
+
+    const workers = await initializeWorkers();
+    const testResult = await runTests(workers, files);
+
+    // Early exit on test failure
+    const hasFailure = testResult.find((it) => it.isFailed);
+    if (hasFailure) {
+      const exitCode = printTestResultsFromWorkers(testResult);
+      process.exit(exitCode);
+    }
+
+    // Only keep success results
+    results.push(
+      ...testResult.map((it) => ({
+        isFailed: it.isFailed,
+        assertions: it.assertions,
+      })),
+    );
+
+    // Kill workers
+    await Promise.all(workers.map((it) => it.terminate()));
+  }
+
+  const exitCode = printTestResultsFromWorkers(results);
+  process.exit(exitCode);
+}
+
+/**
+ * Run tests on a worker pull-basis.
+ * Once all files are done or in process, we request results.
+ *
+ * @param {Worker[]} workers
+ * @param {string[]} files
+ */
+async function runTests(workers, files) {
+  let idx = 0;
+  const results = [];
+
+  for (const worker of workers) {
+    worker.on("message", (message) => {
+      if (message.type === "request_file") {
+        if (idx === files.length) {
+          // Already through our file list, request results
+          worker.postMessage({ type: "request_result" });
+        } else {
+          const file = files[idx];
+          idx++;
+
+          worker.postMessage({ type: "provide_file", file });
+        }
+      } else if (message.type === "provide_result") {
+        results.push(message);
+      } else {
+        testLogger.error({
+          type: "test_unknown_worker_message",
+          message,
+        });
+      }
+    });
+  }
+
+  // Wait till all workers have exited. They should do this once they have provided the
+  // results.
+  const pArr = [];
+  for (const worker of workers) {
+    pArr.push(
+      new Promise((r) => {
+        worker.once("exit", r);
+      }),
+    );
+  }
+
+  await Promise.all(pArr);
+  return results;
+}
+
+/**
+ * List all test files, skipping this file and the worker source file.
+ *
+ * @returns {string[]}
+ */
+function listTestFiles() {
+  const files = [];
+  processDirectoryRecursiveSync(process.cwd(), (file) => {
+    if (file === __filename || file === workerFile.pathname) {
+      return;
+    }
+
+    if (!file.endsWith(".test.js")) {
+      return;
+    }
+
+    files.push(file);
+  });
+
+  return files;
+}
+
+/**
+ * Create workers and wait till they are initialized.
+ * @returns {Promise<Worker[]>}
+ */
+async function initializeWorkers() {
+  const workers = [];
+
+  for (let i = 0; i < cpus().length - 1; ++i) {
+    const w = new Worker(workerFile, {});
+    workers.push(w);
+  }
+
+  return workers;
 }

--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -3,12 +3,13 @@
 import { mainFn } from "@compas/stdlib";
 import { execute } from "./execute.js";
 import { parseArgs } from "./parse.js";
-import { collectScripts } from "./utils.js";
+import { collectNodeArgs, collectScripts } from "./utils.js";
 
 mainFn(import.meta, async (logger) => {
   const args = process.argv.slice(2);
   const scripts = collectScripts();
-  const command = parseArgs(args, Object.keys(scripts));
+  const acceptedArgs = await collectNodeArgs();
+  const command = parseArgs(acceptedArgs, Object.keys(scripts), args);
 
   const result = await execute(logger, command, scripts);
   if (result && result.exitCode !== undefined) {

--- a/packages/cli/src/commands/bench.js
+++ b/packages/cli/src/commands/bench.js
@@ -17,7 +17,7 @@ export function benchCommand(logger, command) {
     command.verbose,
     command.watch,
     "node",
-    [...command.nodeArguments, benchFile],
+    [...command.nodeArguments, benchFile, ...command.execArguments],
     {},
   );
 }

--- a/packages/cli/src/commands/coverage.js
+++ b/packages/cli/src/commands/coverage.js
@@ -18,7 +18,13 @@ export function coverageCommand(logger, command) {
     command.verbose,
     command.watch,
     c8Path,
-    [...command.toolArguments, "node", ...command.nodeArguments, testFile],
+    [
+      ...command.execArguments,
+      "node",
+      ...command.nodeArguments,
+      testFile,
+      "--serial",
+    ],
     {},
   );
 }

--- a/packages/cli/src/commands/test.js
+++ b/packages/cli/src/commands/test.js
@@ -17,7 +17,7 @@ export function testCommand(logger, command) {
     command.verbose,
     command.watch,
     "node",
-    [...command.nodeArguments, testFile],
+    [...command.nodeArguments, testFile, ...command.execArguments],
     {},
   );
 }

--- a/packages/cli/src/testing/config.js
+++ b/packages/cli/src/testing/config.js
@@ -1,6 +1,6 @@
 import { existsSync } from "fs";
-import { noop, pathJoin } from "@compas/stdlib";
-import { setTestTimeout } from "./state.js";
+import { pathJoin } from "@compas/stdlib";
+import { setGlobalSetup, setGlobalTeardown, setTestTimeout } from "./state.js";
 
 const configPath = pathJoin(process.cwd(), "test/config.js");
 
@@ -10,10 +10,7 @@ const configPath = pathJoin(process.cwd(), "test/config.js");
  * - timeout, used as timeout per test case
  * - setup, function called once before tests run
  * - teardown, function called once after all tests run
- * @returns {Promise<{
- *    setup: function(): (void|Promise<void>)
- *    teardown: function(): (void|Promise<void>)
- * }>}
+ * @returns {Promise<void>}
  */
 export async function loadTestConfig() {
   if (!existsSync(configPath)) {
@@ -31,8 +28,6 @@ export async function loadTestConfig() {
     setTestTimeout(config.timeout);
   }
 
-  return {
-    setup: config?.setup ?? noop,
-    teardown: config?.teardown ?? noop,
-  };
+  setGlobalSetup(config?.setup);
+  setGlobalTeardown(config?.teardown);
 }

--- a/packages/cli/src/testing/state.js
+++ b/packages/cli/src/testing/state.js
@@ -1,3 +1,5 @@
+import { noop } from "@compas/stdlib";
+
 /**
  * @type {Logger}
  */
@@ -12,6 +14,16 @@ export let areTestsRunning = false;
  * @type {number}
  */
 export let timeout = 2500;
+
+/**
+ * @type {function(): void|Promise<void>}
+ */
+export let globalSetup = noop;
+
+/**
+ * @type {function(): void|Promise<void>}
+ */
+export let globalTeardown = noop;
 
 /**
  * @type {TestState}
@@ -44,4 +56,22 @@ export function setTestLogger(logger) {
  */
 export function setTestTimeout(value) {
   timeout = value;
+}
+
+/**
+ * Only accepts the value if it is a function
+ */
+export function setGlobalSetup(value) {
+  if (typeof value === "function") {
+    globalSetup = value;
+  }
+}
+
+/**
+ * Only accepts the value if it is a function
+ */
+export function setGlobalTeardown(value) {
+  if (typeof value === "function") {
+    globalTeardown = value;
+  }
 }

--- a/packages/cli/src/testing/test.js
+++ b/packages/cli/src/testing/test.js
@@ -1,0 +1,88 @@
+import { isMainThread, parentPort, threadId } from "worker_threads";
+import { mainFn } from "@compas/stdlib";
+import { loadTestConfig } from "./config.js";
+import {
+  markTestFailuresRecursively,
+  printFailedResults,
+  sumAssertions,
+} from "./printer.js";
+import { runTestsRecursively } from "./runner.js";
+import {
+  globalSetup,
+  globalTeardown,
+  setAreTestRunning,
+  setTestLogger,
+  state,
+} from "./state.js";
+
+mainFn(import.meta, main);
+
+async function main(logger) {
+  if (isMainThread) {
+    logger.error("Can't run worker as main thread.");
+    process.exit(1);
+  }
+
+  // Make sure `mainTestFn` is disabled
+  setAreTestRunning(true);
+  setTestLogger(logger);
+
+  await loadTestConfig();
+  await globalSetup();
+
+  parentPort.on("message", dispatchMessage);
+  // Start requesting files as soon as possible
+  parentPort.postMessage({ type: "request_file" });
+}
+
+/**
+ * Small message handler.
+ * It works by this worker requesting a new file as soon as possible. If the controller
+ * does not have any files left, it will request a result. Once the worker provided the
+ * results, it can safely exit.
+ *
+ * @param {*} message
+ */
+function dispatchMessage(message) {
+  if (message.type === "request_result") {
+    markTestFailuresRecursively(state);
+
+    // Provide a summary of the results
+    parentPort.postMessage({
+      type: "provide_result",
+      threadId,
+      isFailed: state.hasFailure,
+      assertions: sumAssertions(state),
+      failedResult: getFailedResult(),
+    });
+
+    globalTeardown().then(() => {
+      process.exit(0);
+    });
+  } else if (message.type === "provide_file") {
+    const idx = state.children.length;
+    import(message.file).then(async () => {
+      if (state.children[idx]) {
+        // Handle multiple added suites for a single import
+        for (let i = idx; i < state.children.length; ++i) {
+          await runTestsRecursively(state.children[i]);
+        }
+      }
+      parentPort.postMessage({ type: "request_file" });
+    });
+  }
+}
+
+/**
+ * Format failed result for all tests run by this worker. This is only used if one of the
+ * workers reports a failure.
+ *
+ * @returns {string[]}
+ */
+function getFailedResult() {
+  const result = [];
+  for (const child of state.children) {
+    printFailedResults(child, result, 0);
+  }
+  return result;
+}

--- a/packages/cli/src/testing/utils.js
+++ b/packages/cli/src/testing/utils.js
@@ -4,6 +4,8 @@ import { printTestResults } from "./printer.js";
 import { runTestsRecursively } from "./runner.js";
 import {
   areTestsRunning,
+  globalSetup,
+  globalTeardown,
   setAreTestRunning,
   setTestLogger,
   state,
@@ -28,17 +30,11 @@ export function mainTestFn(meta) {
       setTimeout(r, 2);
     });
 
-    const config = await loadTestConfig();
-
-    if (typeof config?.setup === "function") {
-      await config.setup();
-    }
-
+    await loadTestConfig();
+    await globalSetup();
     await runTestsRecursively(state);
+    await globalTeardown();
 
-    if (typeof config?.teardown === "function") {
-      await config.teardown();
-    }
     const exitCode = printTestResults();
 
     process.exit(exitCode);

--- a/packages/stdlib/src/utils.test.js
+++ b/packages/stdlib/src/utils.test.js
@@ -26,12 +26,5 @@ test("stdlib/utils", (t) => {
     t.equal(nonMainFnResult.isMainFn, false);
     // Still returns the name of the file that is the process entrypoint
     t.equal(nonMainFnResult.name, "test");
-
-    const isMainFnResult = isMainFnAndReturnName({
-      url: `${baseUrl}/packages/cli/scripts/test.js`,
-    });
-
-    t.equal(isMainFnResult.isMainFn, true);
-    t.equal(isMainFnResult.name, "test");
   });
 });

--- a/test/config.js
+++ b/test/config.js
@@ -10,7 +10,7 @@ export async function setup() {
   const sql = await createTestPostgresDatabase();
   await setPostgresDatabaseTemplate(sql);
 
-  await sql.end({ timeout: 0.01 });
+  await sql.end({ timeout: 0 });
 }
 
 export async function teardown() {

--- a/test/repo/migrations.test.js
+++ b/test/repo/migrations.test.js
@@ -1,9 +1,9 @@
 import { mainTestFn, test } from "@compas/cli";
 import {
+  cleanupTestPostgresDatabase,
   createTestPostgresDatabase,
   getMigrationsToBeApplied,
   newMigrateContext,
-  cleanupTestPostgresDatabase,
 } from "@compas/store";
 
 mainTestFn(import.meta);
@@ -16,8 +16,8 @@ test("repo/migrations", (t) => {
     t.ok(!!sql);
 
     const result = await sql`
-      SELECT 1 + 2 AS sum
-    `;
+        SELECT 1 + 2 AS sum
+      `;
     t.equal(result[0].sum, 3);
   });
 


### PR DESCRIPTION
The test runner now uses worker_threads to dispatch test files. Every worker runs the global setup before executing tests and runs the global teardown when no test files are available.

The unit of distribution used are files, so tests in a single file will always run in serial.

When `--serial` is passed, the standard test runner is used, and the same happens when you execute a test file directly and call `mainTestFn`.

To find flaky tests you can use `--randomize-rounds=n`, where n is any integer. This will randomize the files passed to workers. Note that the workers are restarted after every full test run, and thus the global setup and teardown are execute multiple times.

To enable these arguments, the cli parser also got upgraded. We try to match Node.js arguments against their long flags as specified in `node --help`.

Closes #509