### PR TITLE
store: prioritize priority over scheduled at in JobWorker

### DIFF
--- a/packages/store/src/queue.js
+++ b/packages/store/src/queue.js
@@ -18,7 +18,7 @@ const queueQueries = {
          WHERE
              NOT "isComplete"
          AND "scheduledAt" < now()
-         ORDER BY "scheduledAt", "priority" FOR UPDATE SKIP LOCKED
+         ORDER BY "priority", "scheduledAt" FOR UPDATE SKIP LOCKED
          LIMIT 1
        )
      RETURNING id
@@ -38,7 +38,7 @@ const queueQueries = {
              NOT "isComplete"
          AND "scheduledAt" < now()
          AND "name" = ${name}
-         ORDER BY "scheduledAt", "priority" FOR UPDATE SKIP LOCKED
+         ORDER BY "priority", "scheduledAt" FOR UPDATE SKIP LOCKED
          LIMIT 1
        )
      RETURNING "id"


### PR DESCRIPTION
This ensures that high prio jobs will be picked up first even if low prio jobs are scheduled first.

In the old scenario, earlier scheduled jobs will always have priority over higher priority jobs.

Closes #597