### PR TITLE
code-gen: fix name clash for self referencing tables in the query-bui…

### DIFF
--- a/packages/store/src/file-group.test.js
+++ b/packages/store/src/file-group.test.js
@@ -127,6 +127,24 @@ test("store/file-group", async (t) => {
     t.ok(!isNil(result[0].children[0].file.id));
   });
 
+  t.test("query builder self referencing tables work", async (t) => {
+    const result = await queryFileGroup({
+      children: {
+        parent: {
+          children: {},
+        },
+      },
+      where: {
+        id: groups.top2,
+      },
+    }).exec(sql);
+
+    t.equal(result.length, 1);
+    t.equal(result[0].children.length, 3);
+    t.equal(result[0].children[0].parent.id, groups.top2);
+    t.equal(result[0].children[0].parent.children.length, 3);
+  });
+
   t.test("delete file should also delete fileGroup reference", async (t) => {
     const files = await queries.fileGroupSelect(sql, {
       parent: groups.top2,
@@ -165,7 +183,7 @@ test("store/file-group", async (t) => {
         viaFile: {},
       },
     }).exec(sql);
-    // const result = await traverseFile().getGroup().getParent({}).exec(sql);
+
     t.equal(result.length, 2);
   });
 


### PR DESCRIPTION
…lder

We solve this by generating an equivalent internal query-builder, that uses a different shortName when joining. This way we can hop back and forth between these functions if a nested self referencing query is executed.

The generator code didn't become any prettier, need to think a bit about it and get cleanup in at some point

Closes #611