### PR TITLE
stdlib: use crypto randomUUID if available

### DIFF
--- a/packages/stdlib/src/datatypes.js
+++ b/packages/stdlib/src/datatypes.js
@@ -1,10 +1,12 @@
+import crypto from "crypto";
 import { v4 } from "./vendor/uuid.js";
 
 /**
  * @function
  * @returns {string}
  */
-export const uuid = v4;
+export const uuid =
+  typeof crypto.randomUUID === "function" ? crypto.randomUUID : v4;
 
 /**
  * @param {*} value


### PR DESCRIPTION
The crypto.randomUUID function is added in Node.js v15.6.0. It is about 30 percent faster than the vendored version.