### PR TITLE
store: force call `setStoreQueries`

### DIFF
--- a/packages/store/src/generated.js
+++ b/packages/store/src/generated.js
@@ -1,11 +1,9 @@
-import { queries as defaultQueries } from "./generated/index.js";
-
-export let queries = defaultQueries;
+export let queries = undefined;
 
 /**
  * Overwrite used generated queries.
  * This is needed when you want cascading soft deletes to any of the exposed types
- * @param {typeof defaultQueries} q
+ * @param {typeof import("./generated/index.js").queries} q
  */
 export function setStoreQueries(q) {
   queries = q;


### PR DESCRIPTION
This may prevent some soft delete bugs. We don't handle the errors thrown if queries is not set, so we should document this!