### PR TITLE
code-gen: throw when generated queryBuilder function is awaited

### DIFF
--- a/packages/code-gen/src/generator/sql/query-builder.js
+++ b/packages/code-gen/src/generator/sql/query-builder.js
@@ -19,6 +19,7 @@ export function generateQueryBuilder(context, imports, type, src) {
   imports.destructureImport("query", `@compas/store`);
   imports.destructureImport("isPlainObject", "@compas/stdlib");
   imports.destructureImport("isNil", "@compas/stdlib");
+  imports.destructureImport("AppError", "@compas/stdlib");
 
   src.push(queryBuilderForType(context, imports, type));
   src.push(transformerForType(context, imports, type));
@@ -240,7 +241,13 @@ function queryBuilderForType(context, imports, type) {
          }
 
          return {
-            execRaw: (sql) => qb.exec(sql), exec: (sql) => {
+            then: () => {
+               throw AppError.serverError({
+                                             message: "Awaited 'query${upperCaseFirst(
+                                               type.name,
+                                             )}' directly. Please use '.exec' or '.execRaw'."
+                                          });
+            }, execRaw: (sql) => qb.exec(sql), exec: (sql) => {
                return qb.exec(sql).then(result => {
                   transform${upperCaseFirst(type.name)}(result, builder);
                   return result;

--- a/packages/code-gen/test/sql.test.js
+++ b/packages/code-gen/test/sql.test.js
@@ -442,7 +442,7 @@ test("code-gen/e2e/sql", async (t) => {
     t.equal(category.id, id);
   });
 
-  t.test("deletedAt in the future", async (t) => {
+  t.test("deletedAt in the future should return result", async (t) => {
     const future = new Date();
     future.setUTCDate(future.getUTCDate() + 1);
     const [user] = await client.queries.userInsert(sql, {
@@ -455,6 +455,16 @@ test("code-gen/e2e/sql", async (t) => {
 
     t.ok(selectUser);
     t.deepEqual(selectUser.deletedAt, future);
+  });
+
+  t.test("await of queryBuilder should throw", async (t) => {
+    try {
+      await client.queryUser({});
+      t.fail("QueryBuilder should throw");
+    } catch (e) {
+      t.ok(AppError.instanceOf(e));
+      t.equal(e.status, 500);
+    }
   });
 
   t.test("destroy test db", async (t) => {

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -740,6 +740,12 @@ ORDER BY ${fileOrderBy()}
     qb.append(query`FETCH NEXT ${builder.limit} ROWS ONLY`);
   }
   return {
+    then: () => {
+      throw AppError.serverError({
+        message:
+          "Awaited 'queryFile' directly. Please use '.exec' or '.execRaw'.",
+      });
+    },
     execRaw: (sql) => qb.exec(sql),
     exec: (sql) => {
       return qb.exec(sql).then((result) => {

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -1006,6 +1006,12 @@ ORDER BY ${fileGroupOrderBy()}
     qb.append(query`FETCH NEXT ${builder.limit} ROWS ONLY`);
   }
   return {
+    then: () => {
+      throw AppError.serverError({
+        message:
+          "Awaited 'queryFileGroup' directly. Please use '.exec' or '.execRaw'.",
+      });
+    },
     execRaw: (sql) => qb.exec(sql),
     exec: (sql) => {
       return qb.exec(sql).then((result) => {

--- a/packages/store/src/generated/database/fileGroupView.js
+++ b/packages/store/src/generated/database/fileGroupView.js
@@ -872,6 +872,12 @@ ORDER BY ${fileGroupViewOrderBy()}
     qb.append(query`FETCH NEXT ${builder.limit} ROWS ONLY`);
   }
   return {
+    then: () => {
+      throw AppError.serverError({
+        message:
+          "Awaited 'queryFileGroupView' directly. Please use '.exec' or '.execRaw'.",
+      });
+    },
     execRaw: (sql) => qb.exec(sql),
     exec: (sql) => {
       return qb.exec(sql).then((result) => {

--- a/packages/store/src/generated/database/index.js
+++ b/packages/store/src/generated/database/index.js
@@ -2,28 +2,28 @@
 /* eslint-disable no-unused-vars */
 
 import {
+  fileSelect,
   fileCount,
   fileDelete,
-  fileDeletePermanent,
   fileInsert,
-  fileSelect,
   fileUpdate,
+  fileDeletePermanent,
 } from "./file.js";
 import {
+  fileGroupSelect,
   fileGroupCount,
   fileGroupDelete,
-  fileGroupDeletePermanent,
   fileGroupInsert,
-  fileGroupSelect,
   fileGroupUpdate,
+  fileGroupDeletePermanent,
 } from "./fileGroup.js";
-import { fileGroupViewCount, fileGroupViewSelect } from "./fileGroupView.js";
-import { jobCount, jobDelete, jobInsert, jobSelect, jobUpdate } from "./job.js";
+import { fileGroupViewSelect, fileGroupViewCount } from "./fileGroupView.js";
+import { jobSelect, jobCount, jobDelete, jobInsert, jobUpdate } from "./job.js";
 import {
+  sessionSelect,
   sessionCount,
   sessionDelete,
   sessionInsert,
-  sessionSelect,
   sessionUpdate,
 } from "./session.js";
 

--- a/packages/store/src/generated/database/job.js
+++ b/packages/store/src/generated/database/job.js
@@ -595,6 +595,12 @@ ORDER BY ${jobOrderBy()}
     qb.append(query`FETCH NEXT ${builder.limit} ROWS ONLY`);
   }
   return {
+    then: () => {
+      throw AppError.serverError({
+        message:
+          "Awaited 'queryJob' directly. Please use '.exec' or '.execRaw'.",
+      });
+    },
     execRaw: (sql) => qb.exec(sql),
     exec: (sql) => {
       return qb.exec(sql).then((result) => {

--- a/packages/store/src/generated/database/session.js
+++ b/packages/store/src/generated/database/session.js
@@ -505,6 +505,12 @@ ORDER BY ${sessionOrderBy()}
     qb.append(query`FETCH NEXT ${builder.limit} ROWS ONLY`);
   }
   return {
+    then: () => {
+      throw AppError.serverError({
+        message:
+          "Awaited 'querySession' directly. Please use '.exec' or '.execRaw'.",
+      });
+    },
     execRaw: (sql) => qb.exec(sql),
     exec: (sql) => {
       return qb.exec(sql).then((result) => {


### PR DESCRIPTION
This may prevent some errors, and improves on th readability of existing errors when doing `const [foo] = await queryFoo();`