### PR TITLE
code-gen: fix names for optional, pick, omit and searchable type

### DIFF
--- a/packages/code-gen/src/builders/OmitType.js
+++ b/packages/code-gen/src/builders/OmitType.js
@@ -17,7 +17,7 @@ export class OmitType extends TypeBuilder {
     const buildResult = buildOrInfer(this.builder);
 
     if (isNil(this.data.name) && !isNil(buildResult.name)) {
-      this.name(`${buildResult.name}Omit`);
+      this.data.name = `${buildResult.name}Omit`;
     }
 
     const thisResult = super.build();

--- a/packages/code-gen/src/builders/OptionalType.js
+++ b/packages/code-gen/src/builders/OptionalType.js
@@ -14,7 +14,7 @@ export class OptionalType extends TypeBuilder {
     const buildResult = buildOrInfer(this.builder);
 
     if (isNil(this.data.name) && !isNil(buildResult.name)) {
-      this.name(`${buildResult.name}Optional`);
+      this.data.name = `${buildResult.name}Optional`;
     }
 
     const thisResult = super.build();

--- a/packages/code-gen/src/builders/PickType.js
+++ b/packages/code-gen/src/builders/PickType.js
@@ -17,7 +17,7 @@ export class PickType extends TypeBuilder {
     const buildResult = buildOrInfer(this.builder);
 
     if (isNil(this.data.name) && !isNil(buildResult.name)) {
-      this.name(`${buildResult.name}Pick`);
+      this.data.name = `${buildResult.name}Pick`;
     }
 
     const thisResult = super.build();

--- a/packages/code-gen/src/builders/SearchableType.js
+++ b/packages/code-gen/src/builders/SearchableType.js
@@ -14,7 +14,7 @@ export class SearchableType extends TypeBuilder {
     const buildResult = buildOrInfer(this.builder);
 
     if (isNil(this.data.name) && !isNil(buildResult.name)) {
-      this.name(`${buildResult.name}Searchable`);
+      this.data.name = `${buildResult.name}Searchable`;
     }
 
     const thisResult = super.build();


### PR DESCRIPTION
A pretty long unnoticed bug for Compas standards, oh well.

Closes #637