### PR TITLE
store: add stringifyQueryPart function

### DIFF
--- a/packages/store/index.d.ts
+++ b/packages/store/index.d.ts
@@ -522,6 +522,25 @@ export function query(strings: string[], ...values: any[]): QueryPart;
 export function isQueryPart(value: any): value is QueryPart;
 
 /**
+ * Stringify a queryPart.
+ * When interpolateParameters is true, we do a best effort in replacing the parameterized
+ * query with the real params. If the result doesn't look right, please turn it off.
+ */
+export function stringifyQueryPart(
+  queryPart: QueryPart,
+): { sql: string; params: any[] };
+
+/**
+ * Stringify a queryPart.
+ * When interpolateParameters is true, we do a best effort in replacing the parameterized
+ * query with the real params. If the result doesn't look right, please turn it off.
+ */
+export function stringifyQueryPart(
+  queryPart: QueryPart,
+  { interpolateParameters }: { interpolateParameters: true },
+): string;
+
+/**
  * Creates a transaction, executes the query, and rollback the transaction afterwards.
  * This is safe to use with insert, update and delete queries.
  *

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -51,5 +51,10 @@ export { newSessionStore } from "./src/sessions.js";
 export const migrations = `${dirnameForModule(import.meta)}/migrations`;
 export { structure as storeStructure } from "./src/generated/index.js";
 
-export { query, isQueryPart, explainAnalyzeQuery } from "./src/query.js";
+export {
+  query,
+  isQueryPart,
+  stringifyQueryPart,
+  explainAnalyzeQuery,
+} from "./src/query.js";
 export { setStoreQueries } from "./src/generated.js";

--- a/packages/store/src/query.test.js
+++ b/packages/store/src/query.test.js
@@ -1,6 +1,6 @@
 import { mainTestFn, test } from "@compas/cli";
 import { AppError, isPlainObject } from "@compas/stdlib";
-import { explainAnalyzeQuery, query } from "./query.js";
+import { explainAnalyzeQuery, query, stringifyQueryPart } from "./query.js";
 import {
   cleanupTestPostgresDatabase,
   createTestPostgresDatabase,
@@ -8,116 +8,114 @@ import {
 
 mainTestFn(import.meta);
 
-const getResult = (q) => {
-  let sql, args;
-
-  q.exec({
-    unsafe(query, values) {
-      sql = query.trim();
-      args = values;
-    },
-  });
-
-  return {
-    sql,
-    args,
-  };
-};
-
 test("store/query", (t) => {
   t.test("base string", (t) => {
-    const { sql, args } = getResult(query`SELECT 1 + 1`);
+    const { sql, params } = stringifyQueryPart(query`SELECT 1 + 1`);
 
     t.equal(sql, `SELECT 1 + 1`);
-    t.equal(args.length, 0);
+    t.equal(params.length, 0);
   });
 
   t.test("base interpolation", (t) => {
-    const { sql, args } = getResult(query`SELECT 1 + 1 WHERE 2 > ${1}`);
+    const { sql, params } = stringifyQueryPart(
+      query`SELECT 1 + 1 WHERE 2 > ${1}`,
+    );
     t.equal(sql, `SELECT 1 + 1 WHERE 2 > $1`);
-    t.equal(args.length, 1);
-    t.equal(args[0], 1);
+    t.equal(params.length, 1);
+    t.equal(params[0], 1);
   });
 
   t.test("undefined interpolation", (t) => {
-    const { sql, args } = getResult(query`SELECT ${undefined}1 + 1`);
+    const { sql, params } = stringifyQueryPart(query`SELECT ${undefined}1 + 1`);
 
     t.equal(sql, `SELECT 1 + 1`);
-    t.equal(args.length, 0);
+    t.equal(params.length, 0);
   });
 
   t.test("base append", (t) => {
-    const { sql, args } = getResult(
+    const { sql, params } = stringifyQueryPart(
       query`SELECT 1 + 1`.append(query`WHERE 1 = 1`),
     );
 
     t.equal(sql, `SELECT 1 + 1 WHERE 1 = 1`);
-    t.equal(args.length, 0);
+    t.equal(params.length, 0);
   });
 
   t.test("append with single interpolation", (t) => {
-    const { sql, args } = getResult(
+    const { sql, params } = stringifyQueryPart(
       query`SELECT 1 + ${1}`.append(query`WHERE 1 = ${1}`),
     );
 
     t.equal(sql, `SELECT 1 + $1 WHERE 1 = $2`);
-    t.deepEqual(args, [1, 1]);
+    t.deepEqual(params, [1, 1]);
   });
 
   t.test("append with many interpolations", (t) => {
-    const { sql, args } = getResult(
+    const { sql, params } = stringifyQueryPart(
       query`SELECT ${1} + ${1} as "foo" WHERE`.append(
         query`${2} = ${3} AND "foo" = ${2}`,
       ),
     );
 
     t.equal(sql, `SELECT $1 + $2 as "foo" WHERE $3 = $4 AND "foo" = $5`);
-    t.deepEqual(args, [1, 1, 2, 3, 2]);
+    t.deepEqual(params, [1, 1, 2, 3, 2]);
   });
 
   t.test("append with undefined values", (t) => {
-    const { sql, args } = getResult(
+    const { sql, params } = stringifyQueryPart(
       query`SELECT ${1} + ${1} as "foo" WHERE`
         .append(query`${2} = ${3} AND "foo" ${undefined} = ${2}`)
         .append(query`${undefined}`),
     );
 
     t.equal(sql, `SELECT $1 + $2 as "foo" WHERE $3 = $4 AND "foo"  = $5`);
-    t.deepEqual(args, [1, 1, 2, 3, 2]);
+    t.deepEqual(params, [1, 1, 2, 3, 2]);
   });
 
   t.test("base interpolate recursive", (t) => {
-    const { sql, args } = getResult(query`SELECT ${query`"foo"`}`);
+    const { sql, params } = stringifyQueryPart(query`SELECT ${query`"foo"`}`);
 
     t.equal(sql, `SELECT  "foo"`);
-    t.deepEqual(args, []);
+    t.deepEqual(params, []);
   });
 
   t.test("base interpolate recursive - multiple", (t) => {
-    const { sql, args } = getResult(
+    const { sql, params } = stringifyQueryPart(
       query`SELECT ${query`"foo", ${query`"bar"`}`}`,
     );
 
     t.equal(sql, `SELECT  "foo",  "bar"`);
-    t.deepEqual(args, []);
+    t.deepEqual(params, []);
   });
 
   t.test("interpolate recursive", (t) => {
-    const { sql, args } = getResult(
+    const { sql, params } = stringifyQueryPart(
       query`SELECT ${query`${1} as "foo", ${query`${2} as "bar"`}`}`,
     );
 
     t.equal(sql, `SELECT  $1 as "foo",  $2 as "bar"`);
-    t.deepEqual(args, [1, 2]);
+    t.deepEqual(params, [1, 2]);
   });
 
   t.test("mix interpolate and append", (t) => {
-    const { sql, args } = getResult(
+    const { sql, params } = stringifyQueryPart(
       query`FROM "foo" ${query`WHERE 1 = ${1}`}`.append(query`ORDER BY "bar"`),
     );
 
     t.equal(sql, `FROM "foo"  WHERE 1 = $1 ORDER BY "bar"`);
-    t.deepEqual(args, [1]);
+    t.deepEqual(params, [1]);
+  });
+
+  t.test("stringify interpolate", (t) => {
+    const result = stringifyQueryPart(
+      query`FROM "foo" ${query`WHERE 1 = ${1}`}`.append(
+        query`ORDER BY ${"bar"}`,
+      ),
+      { interpolateParameters: true },
+    );
+
+    // May be a bit flaky, since it is whitespace sensitive
+    t.equal(result, `FROM "foo"  WHERE 1 = 1 ORDER BY 'bar'`);
   });
 });
 


### PR DESCRIPTION
Helps with debugging queries or when you quickly want to see what query is generated. Supports a bit of interpolating variables, but may not work in a lot of cases. Haven't decided yet if I want to harden the implementation or remove it. But we'll roll with it for now

Closes #644