### PR TITLE
code-gen: support multiple 'viaXxx' in the query builder

### DIFF
--- a/packages/code-gen/src/generator/sql/structure.js
+++ b/packages/code-gen/src/generator/sql/structure.js
@@ -3,7 +3,7 @@ import { upperCaseFirst } from "../../utils.js";
 import { getQueryEnabledObjects, getSortedKeysForType } from "./utils.js";
 import { getSearchableFields } from "./where-type.js";
 
-const typeTable = {
+export const typeTable = {
   any: "jsonb",
   anyOf: "jsonb",
   array: "jsonb",
@@ -13,16 +13,19 @@ const typeTable = {
   /**
    *
    * @param {CodeGenNumberType} type
+   * @param {boolean} skipPrimary
    * @returns {string}
-   */ number: (type) =>
-    !type.sql?.primary
+   */ number: (type, skipPrimary) =>
+    !type.sql?.primary || skipPrimary
       ? type.validator.floatingPoint
         ? "float"
         : "int"
       : "BIGSERIAL PRIMARY KEY",
   object: "jsonb",
-  string: (type) => (type.sql?.primary ? "varchar PRIMARY KEY" : "varchar"),
-  uuid: (type) => (type.sql?.primary ? "uuid PRIMARY KEY" : "uuid"),
+  string: (type, skipPrimary) =>
+    type.sql?.primary && !skipPrimary ? "varchar PRIMARY KEY" : "varchar",
+  uuid: (type, skipPrimary) =>
+    type.sql?.primary && !skipPrimary ? "uuid PRIMARY KEY" : "uuid",
 };
 
 /**
@@ -77,7 +80,7 @@ function getFields(object) {
 
     let sqlType = typeTable[type.type];
     if (typeof sqlType === "function") {
-      sqlType = sqlType(type);
+      sqlType = sqlType(type, false);
     }
 
     let defaultValue = "";

--- a/packages/code-gen/test/sql.test.js
+++ b/packages/code-gen/test/sql.test.js
@@ -335,6 +335,23 @@ test("code-gen/e2e/sql", async (t) => {
     t.equal(dbUser.id, user.id);
   });
 
+  t.test("traverse with 'via' and idIn", async (t) => {
+    const [dbUser] = await client
+      .queryUser({
+        where: {
+          idIn: [post.writer],
+        },
+        viaPosts: {
+          where: {
+            id: post.id,
+          },
+        },
+      })
+      .exec(sql);
+
+    t.equal(dbUser.id, user.id);
+  });
+
   t.test("traverse via queryCategory", async (t) => {
     const builder = {
       viaPosts: {

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -637,6 +637,24 @@ export function internalQueryFileGroup2(builder = {}, wherePartial) {
   const joinQb = query``;
   if (builder.viaFile) {
     builder.where = builder.where ?? {};
+    // Prepare fileIn
+    if (isQueryPart(builder.where.fileIn)) {
+      builder.where.fileIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.fileIn) &&
+      builder.where.fileIn.length > 0
+    ) {
+      builder.where.fileIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.fileIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.fileIn,
+      );
+    } else {
+      builder.where.fileIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaFile.offset)
       ? query`OFFSET ${builder.viaFile.offset}`
       : query``;
@@ -645,14 +663,32 @@ export function internalQueryFileGroup2(builder = {}, wherePartial) {
         query`FETCH NEXT ${builder.viaFile.limit} ROWS ONLY`,
       );
     }
-    builder.where.fileIn = query`
+    builder.where.fileIn.append(query`
 SELECT DISTINCT f."id"
 ${internalQueryFile(builder.viaFile)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaParent) {
     builder.where = builder.where ?? {};
+    // Prepare parentIn
+    if (isQueryPart(builder.where.parentIn)) {
+      builder.where.parentIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.parentIn) &&
+      builder.where.parentIn.length > 0
+    ) {
+      builder.where.parentIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.parentIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.parentIn,
+      );
+    } else {
+      builder.where.parentIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaParent.offset)
       ? query`OFFSET ${builder.viaParent.offset}`
       : query``;
@@ -661,14 +697,32 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaParent.limit} ROWS ONLY`,
       );
     }
-    builder.where.parentIn = query`
+    builder.where.parentIn.append(query`
 SELECT DISTINCT fg."id"
 ${internalQueryFileGroup(builder.viaParent)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaChildren) {
     builder.where = builder.where ?? {};
+    // Prepare idIn
+    if (isQueryPart(builder.where.idIn)) {
+      builder.where.idIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.idIn) &&
+      builder.where.idIn.length > 0
+    ) {
+      builder.where.idIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.idIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.idIn,
+      );
+    } else {
+      builder.where.idIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaChildren.offset)
       ? query`OFFSET ${builder.viaChildren.offset}`
       : query``;
@@ -677,11 +731,11 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaChildren.limit} ROWS ONLY`,
       );
     }
-    builder.where.idIn = query`
+    builder.where.idIn.append(query`
 SELECT DISTINCT fg."parent"
 ${internalQueryFileGroup(builder.viaChildren)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.file) {
     const joinedKeys = [];
@@ -802,6 +856,24 @@ export function internalQueryFileGroup(builder = {}, wherePartial) {
   const joinQb = query``;
   if (builder.viaFile) {
     builder.where = builder.where ?? {};
+    // Prepare fileIn
+    if (isQueryPart(builder.where.fileIn)) {
+      builder.where.fileIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.fileIn) &&
+      builder.where.fileIn.length > 0
+    ) {
+      builder.where.fileIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.fileIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.fileIn,
+      );
+    } else {
+      builder.where.fileIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaFile.offset)
       ? query`OFFSET ${builder.viaFile.offset}`
       : query``;
@@ -810,14 +882,32 @@ export function internalQueryFileGroup(builder = {}, wherePartial) {
         query`FETCH NEXT ${builder.viaFile.limit} ROWS ONLY`,
       );
     }
-    builder.where.fileIn = query`
+    builder.where.fileIn.append(query`
 SELECT DISTINCT f."id"
 ${internalQueryFile(builder.viaFile)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaParent) {
     builder.where = builder.where ?? {};
+    // Prepare parentIn
+    if (isQueryPart(builder.where.parentIn)) {
+      builder.where.parentIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.parentIn) &&
+      builder.where.parentIn.length > 0
+    ) {
+      builder.where.parentIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.parentIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.parentIn,
+      );
+    } else {
+      builder.where.parentIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaParent.offset)
       ? query`OFFSET ${builder.viaParent.offset}`
       : query``;
@@ -826,14 +916,32 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaParent.limit} ROWS ONLY`,
       );
     }
-    builder.where.parentIn = query`
+    builder.where.parentIn.append(query`
 SELECT DISTINCT fg2."id"
 ${internalQueryFileGroup2(builder.viaParent)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaChildren) {
     builder.where = builder.where ?? {};
+    // Prepare idIn
+    if (isQueryPart(builder.where.idIn)) {
+      builder.where.idIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.idIn) &&
+      builder.where.idIn.length > 0
+    ) {
+      builder.where.idIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.idIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.idIn,
+      );
+    } else {
+      builder.where.idIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaChildren.offset)
       ? query`OFFSET ${builder.viaChildren.offset}`
       : query``;
@@ -842,11 +950,11 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaChildren.limit} ROWS ONLY`,
       );
     }
-    builder.where.idIn = query`
+    builder.where.idIn.append(query`
 SELECT DISTINCT fg2."parent"
 ${internalQueryFileGroup2(builder.viaChildren)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.file) {
     const joinedKeys = [];

--- a/packages/store/src/generated/database/fileGroupView.js
+++ b/packages/store/src/generated/database/fileGroupView.js
@@ -491,6 +491,24 @@ export function internalQueryFileGroupView2(builder = {}, wherePartial) {
   const joinQb = query``;
   if (builder.viaFile) {
     builder.where = builder.where ?? {};
+    // Prepare fileIn
+    if (isQueryPart(builder.where.fileIn)) {
+      builder.where.fileIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.fileIn) &&
+      builder.where.fileIn.length > 0
+    ) {
+      builder.where.fileIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.fileIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.fileIn,
+      );
+    } else {
+      builder.where.fileIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaFile.offset)
       ? query`OFFSET ${builder.viaFile.offset}`
       : query``;
@@ -499,14 +517,32 @@ export function internalQueryFileGroupView2(builder = {}, wherePartial) {
         query`FETCH NEXT ${builder.viaFile.limit} ROWS ONLY`,
       );
     }
-    builder.where.fileIn = query`
+    builder.where.fileIn.append(query`
 SELECT DISTINCT f."id"
 ${internalQueryFile(builder.viaFile)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaParent) {
     builder.where = builder.where ?? {};
+    // Prepare parentIn
+    if (isQueryPart(builder.where.parentIn)) {
+      builder.where.parentIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.parentIn) &&
+      builder.where.parentIn.length > 0
+    ) {
+      builder.where.parentIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.parentIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.parentIn,
+      );
+    } else {
+      builder.where.parentIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaParent.offset)
       ? query`OFFSET ${builder.viaParent.offset}`
       : query``;
@@ -515,14 +551,32 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaParent.limit} ROWS ONLY`,
       );
     }
-    builder.where.parentIn = query`
+    builder.where.parentIn.append(query`
 SELECT DISTINCT fgv."id"
 ${internalQueryFileGroupView(builder.viaParent)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaChildren) {
     builder.where = builder.where ?? {};
+    // Prepare idIn
+    if (isQueryPart(builder.where.idIn)) {
+      builder.where.idIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.idIn) &&
+      builder.where.idIn.length > 0
+    ) {
+      builder.where.idIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.idIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.idIn,
+      );
+    } else {
+      builder.where.idIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaChildren.offset)
       ? query`OFFSET ${builder.viaChildren.offset}`
       : query``;
@@ -531,11 +585,11 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaChildren.limit} ROWS ONLY`,
       );
     }
-    builder.where.idIn = query`
+    builder.where.idIn.append(query`
 SELECT DISTINCT fgv."parent"
 ${internalQueryFileGroupView(builder.viaChildren)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.file) {
     const joinedKeys = [];
@@ -662,6 +716,24 @@ export function internalQueryFileGroupView(builder = {}, wherePartial) {
   const joinQb = query``;
   if (builder.viaFile) {
     builder.where = builder.where ?? {};
+    // Prepare fileIn
+    if (isQueryPart(builder.where.fileIn)) {
+      builder.where.fileIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.fileIn) &&
+      builder.where.fileIn.length > 0
+    ) {
+      builder.where.fileIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.fileIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.fileIn,
+      );
+    } else {
+      builder.where.fileIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaFile.offset)
       ? query`OFFSET ${builder.viaFile.offset}`
       : query``;
@@ -670,14 +742,32 @@ export function internalQueryFileGroupView(builder = {}, wherePartial) {
         query`FETCH NEXT ${builder.viaFile.limit} ROWS ONLY`,
       );
     }
-    builder.where.fileIn = query`
+    builder.where.fileIn.append(query`
 SELECT DISTINCT f."id"
 ${internalQueryFile(builder.viaFile)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaParent) {
     builder.where = builder.where ?? {};
+    // Prepare parentIn
+    if (isQueryPart(builder.where.parentIn)) {
+      builder.where.parentIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.parentIn) &&
+      builder.where.parentIn.length > 0
+    ) {
+      builder.where.parentIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.parentIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.parentIn,
+      );
+    } else {
+      builder.where.parentIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaParent.offset)
       ? query`OFFSET ${builder.viaParent.offset}`
       : query``;
@@ -686,14 +776,32 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaParent.limit} ROWS ONLY`,
       );
     }
-    builder.where.parentIn = query`
+    builder.where.parentIn.append(query`
 SELECT DISTINCT fgv2."id"
 ${internalQueryFileGroupView2(builder.viaParent)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.viaChildren) {
     builder.where = builder.where ?? {};
+    // Prepare idIn
+    if (isQueryPart(builder.where.idIn)) {
+      builder.where.idIn.append(query` INTERSECT `);
+    } else if (
+      Array.isArray(builder.where.idIn) &&
+      builder.where.idIn.length > 0
+    ) {
+      builder.where.idIn = query(
+        [
+          "(SELECT value::uuid FROM(values (",
+          ...builder.where.idIn.map(() => "").join("), ("),
+          ")) as ids(value)) INTERSECT ",
+        ],
+        ...builder.where.idIn,
+      );
+    } else {
+      builder.where.idIn = query``;
+    }
     const offsetLimitQb = !isNil(builder.viaChildren.offset)
       ? query`OFFSET ${builder.viaChildren.offset}`
       : query``;
@@ -702,11 +810,11 @@ ${offsetLimitQb}
         query`FETCH NEXT ${builder.viaChildren.limit} ROWS ONLY`,
       );
     }
-    builder.where.idIn = query`
+    builder.where.idIn.append(query`
 SELECT DISTINCT fgv2."parent"
 ${internalQueryFileGroupView2(builder.viaChildren)}
 ${offsetLimitQb}
-`;
+`);
   }
   if (builder.file) {
     const joinedKeys = [];


### PR DESCRIPTION
This works by intersecting the result of multiple traverses. This guarantees the same 'AND' behaviour as usual. It also works when the 'xxIn' property is already set, by converting it inline to a 'select from values' expression.

Closes #660