### PR TITLE
feat(store): handler timeout for job queue

### DIFF
--- a/packages/store/index.d.ts
+++ b/packages/store/index.d.ts
@@ -386,6 +386,12 @@ export interface JobQueueWorkerOptions {
    * Defaults to 5 retries
    */
   maxRetryCount?: number;
+
+  /**
+   * Maximum time the handler could take to fulfill a job in milliseconds
+   * Defaults to 30 seconds.
+   */
+  handlerTimeout?: number;
 }
 
 /**


### PR DESCRIPTION
Add the option to add a handlerTimeout on Queue worker creation. This defaults to 30 seconds. A faster timeout increases throughput and may force for smaller targeted jobs instead of doing all kinds of things in a single job. Combined with the retry count, this should prevent the worker from ever getting stuck on jobs that can't be completed.

Closes #651