### PR TITLE
fix(code-gen): fix missing relation type in sub query builder

### DIFF
--- a/packages/code-gen/src/generator/sql/query-builder.js
+++ b/packages/code-gen/src/generator/sql/query-builder.js
@@ -382,14 +382,20 @@ if (!isNil(builder.${key}.limit)) {
             ${getLimitOffset()}
 
             ${Object.entries(otherSide.queryBuilder.relations).map(
-              ([key, { joinKey: otherJoinKey, subType: otherSubType }]) => {
+              ([
+                key,
+                {
+                  joinKey: otherJoinKey,
+                  relation: { subType: otherSubType },
+                },
+              ]) => {
                 const coalescedValue =
                   otherSubType === "oneToMany"
                     ? `coalesce("${otherJoinKey}"."result", '{}')`
                     : `"${otherJoinKey}"."result"`;
                 return `
             if (builder.${relationKey}.${key}) {
-              joinedKeys.push("'" + (builder.${relationKey}.${key}?.as ?? "${key}") + "'", '${coalescedValue}');
+              joinedKeys.push("'" + (builder.${relationKey}.${key}?.as ?? "${key}") + "'", \`${coalescedValue}\`);
             }
           `;
               },

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -665,19 +665,19 @@ ${offsetLimitQb}
     if (builder.group.file) {
       joinedKeys.push(
         `'${builder.group.file?.as ?? "file"}'`,
-        '"fg_f_0"."result"',
+        `"fg_f_0"."result"`,
       );
     }
     if (builder.group.parent) {
       joinedKeys.push(
         `'${builder.group.parent?.as ?? "parent"}'`,
-        '"fg_fg_0"."result"',
+        `"fg_fg_0"."result"`,
       );
     }
     if (builder.group.children) {
       joinedKeys.push(
         `'${builder.group.children?.as ?? "children"}'`,
-        '"fg_fg_1"."result"',
+        `coalesce("fg_fg_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -702,19 +702,19 @@ ${offsetLimitQb}
     if (builder.groupView.file) {
       joinedKeys.push(
         `'${builder.groupView.file?.as ?? "file"}'`,
-        '"fgv_f_0"."result"',
+        `"fgv_f_0"."result"`,
       );
     }
     if (builder.groupView.parent) {
       joinedKeys.push(
         `'${builder.groupView.parent?.as ?? "parent"}'`,
-        '"fgv_fgv_0"."result"',
+        `"fgv_fgv_0"."result"`,
       );
     }
     if (builder.groupView.children) {
       joinedKeys.push(
         `'${builder.groupView.children?.as ?? "children"}'`,
-        '"fgv_fgv_1"."result"',
+        `coalesce("fgv_fgv_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -748,13 +748,13 @@ ${offsetLimitQb}
     if (builder.file.group) {
       joinedKeys.push(
         `'${builder.file.group?.as ?? "group"}'`,
-        '"f_fg_0"."result"',
+        `"f_fg_0"."result"`,
       );
     }
     if (builder.file.groupView) {
       joinedKeys.push(
         `'${builder.file.groupView?.as ?? "groupView"}'`,
-        '"f_fgv_0"."result"',
+        `"f_fgv_0"."result"`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -777,19 +777,19 @@ ${offsetLimitQb}
     if (builder.parent.file) {
       joinedKeys.push(
         `'${builder.parent.file?.as ?? "file"}'`,
-        '"fg_f_0"."result"',
+        `"fg_f_0"."result"`,
       );
     }
     if (builder.parent.parent) {
       joinedKeys.push(
         `'${builder.parent.parent?.as ?? "parent"}'`,
-        '"fg_fg_0"."result"',
+        `"fg_fg_0"."result"`,
       );
     }
     if (builder.parent.children) {
       joinedKeys.push(
         `'${builder.parent.children?.as ?? "children"}'`,
-        '"fg_fg_1"."result"',
+        `coalesce("fg_fg_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -814,19 +814,19 @@ ${offsetLimitQb}
     if (builder.children.file) {
       joinedKeys.push(
         `'${builder.children.file?.as ?? "file"}'`,
-        '"fg_f_0"."result"',
+        `"fg_f_0"."result"`,
       );
     }
     if (builder.children.parent) {
       joinedKeys.push(
         `'${builder.children.parent?.as ?? "parent"}'`,
-        '"fg_fg_0"."result"',
+        `"fg_fg_0"."result"`,
       );
     }
     if (builder.children.children) {
       joinedKeys.push(
         `'${builder.children.children?.as ?? "children"}'`,
-        '"fg_fg_1"."result"',
+        `coalesce("fg_fg_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -967,13 +967,13 @@ ${offsetLimitQb}
     if (builder.file.group) {
       joinedKeys.push(
         `'${builder.file.group?.as ?? "group"}'`,
-        '"f_fg_0"."result"',
+        `"f_fg_0"."result"`,
       );
     }
     if (builder.file.groupView) {
       joinedKeys.push(
         `'${builder.file.groupView?.as ?? "groupView"}'`,
-        '"f_fgv_0"."result"',
+        `"f_fgv_0"."result"`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -996,19 +996,19 @@ ${offsetLimitQb}
     if (builder.parent.file) {
       joinedKeys.push(
         `'${builder.parent.file?.as ?? "file"}'`,
-        '"fg_f_0"."result"',
+        `"fg_f_0"."result"`,
       );
     }
     if (builder.parent.parent) {
       joinedKeys.push(
         `'${builder.parent.parent?.as ?? "parent"}'`,
-        '"fg_fg_0"."result"',
+        `"fg_fg_0"."result"`,
       );
     }
     if (builder.parent.children) {
       joinedKeys.push(
         `'${builder.parent.children?.as ?? "children"}'`,
-        '"fg_fg_1"."result"',
+        `coalesce("fg_fg_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -1033,19 +1033,19 @@ ${offsetLimitQb}
     if (builder.children.file) {
       joinedKeys.push(
         `'${builder.children.file?.as ?? "file"}'`,
-        '"fg_f_0"."result"',
+        `"fg_f_0"."result"`,
       );
     }
     if (builder.children.parent) {
       joinedKeys.push(
         `'${builder.children.parent?.as ?? "parent"}'`,
-        '"fg_fg_0"."result"',
+        `"fg_fg_0"."result"`,
       );
     }
     if (builder.children.children) {
       joinedKeys.push(
         `'${builder.children.children?.as ?? "children"}'`,
-        '"fg_fg_1"."result"',
+        `coalesce("fg_fg_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (

--- a/packages/store/src/generated/database/fileGroupView.js
+++ b/packages/store/src/generated/database/fileGroupView.js
@@ -602,13 +602,13 @@ ${offsetLimitQb}
     if (builder.file.group) {
       joinedKeys.push(
         `'${builder.file.group?.as ?? "group"}'`,
-        '"f_fg_0"."result"',
+        `"f_fg_0"."result"`,
       );
     }
     if (builder.file.groupView) {
       joinedKeys.push(
         `'${builder.file.groupView?.as ?? "groupView"}'`,
-        '"f_fgv_0"."result"',
+        `"f_fgv_0"."result"`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -631,19 +631,19 @@ ${offsetLimitQb}
     if (builder.parent.file) {
       joinedKeys.push(
         `'${builder.parent.file?.as ?? "file"}'`,
-        '"fgv_f_0"."result"',
+        `"fgv_f_0"."result"`,
       );
     }
     if (builder.parent.parent) {
       joinedKeys.push(
         `'${builder.parent.parent?.as ?? "parent"}'`,
-        '"fgv_fgv_0"."result"',
+        `"fgv_fgv_0"."result"`,
       );
     }
     if (builder.parent.children) {
       joinedKeys.push(
         `'${builder.parent.children?.as ?? "children"}'`,
-        '"fgv_fgv_1"."result"',
+        `coalesce("fgv_fgv_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -671,19 +671,19 @@ ${offsetLimitQb}
     if (builder.children.file) {
       joinedKeys.push(
         `'${builder.children.file?.as ?? "file"}'`,
-        '"fgv_f_0"."result"',
+        `"fgv_f_0"."result"`,
       );
     }
     if (builder.children.parent) {
       joinedKeys.push(
         `'${builder.children.parent?.as ?? "parent"}'`,
-        '"fgv_fgv_0"."result"',
+        `"fgv_fgv_0"."result"`,
       );
     }
     if (builder.children.children) {
       joinedKeys.push(
         `'${builder.children.children?.as ?? "children"}'`,
-        '"fgv_fgv_1"."result"',
+        `coalesce("fgv_fgv_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -827,13 +827,13 @@ ${offsetLimitQb}
     if (builder.file.group) {
       joinedKeys.push(
         `'${builder.file.group?.as ?? "group"}'`,
-        '"f_fg_0"."result"',
+        `"f_fg_0"."result"`,
       );
     }
     if (builder.file.groupView) {
       joinedKeys.push(
         `'${builder.file.groupView?.as ?? "groupView"}'`,
-        '"f_fgv_0"."result"',
+        `"f_fgv_0"."result"`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -856,19 +856,19 @@ ${offsetLimitQb}
     if (builder.parent.file) {
       joinedKeys.push(
         `'${builder.parent.file?.as ?? "file"}'`,
-        '"fgv_f_0"."result"',
+        `"fgv_f_0"."result"`,
       );
     }
     if (builder.parent.parent) {
       joinedKeys.push(
         `'${builder.parent.parent?.as ?? "parent"}'`,
-        '"fgv_fgv_0"."result"',
+        `"fgv_fgv_0"."result"`,
       );
     }
     if (builder.parent.children) {
       joinedKeys.push(
         `'${builder.parent.children?.as ?? "children"}'`,
-        '"fgv_fgv_1"."result"',
+        `coalesce("fgv_fgv_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
@@ -896,19 +896,19 @@ ${offsetLimitQb}
     if (builder.children.file) {
       joinedKeys.push(
         `'${builder.children.file?.as ?? "file"}'`,
-        '"fgv_f_0"."result"',
+        `"fgv_f_0"."result"`,
       );
     }
     if (builder.children.parent) {
       joinedKeys.push(
         `'${builder.children.parent?.as ?? "parent"}'`,
-        '"fgv_fgv_0"."result"',
+        `"fgv_fgv_0"."result"`,
       );
     }
     if (builder.children.children) {
       joinedKeys.push(
         `'${builder.children.children?.as ?? "children"}'`,
-        '"fgv_fgv_1"."result"',
+        `coalesce("fgv_fgv_1"."result", '{}')`,
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (


### PR DESCRIPTION
The relation type (oneToMany, ManyToOne) was missing for the secondary query builder. This resulted in some `null` values instead of empty array's (`[]`), because of some missing `coalesce` calls.

This is resolved and regenerated for the store package