### PR TITLE
feat(code-gen): expose query key functions for generated hooks

### DIFF
--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFile.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFile.tmpl
@@ -1,6 +1,7 @@
 import { AxiosError, CancelTokenSource } from "axios";
 import { createContext, PropsWithChildren, useContext } from "react";
 import {
+  QueryKey,
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions as ReactUseQueryOptions,

--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -50,9 +50,7 @@ options: UseQueryOptions<{{= responseType }}, AppErrorResponse> = {},
     {{ } }}
   ));
 
-  return useQuery([
-     "{{= item.uniqueName }}",
-
+  return useQuery({{= funcName }}.queryKey(
     {{ if (item.params) { }}
     params,
     {{ } }}
@@ -62,7 +60,7 @@ options: UseQueryOptions<{{= responseType }}, AppErrorResponse> = {},
     {{ if (item.body) { }}
     body,
     {{ } }}
-    ],
+    ),
     () => {
       const promise: CancellablePromise<{{= responseType }}> = {{= item.group }}.{{= item.name }}(
         {{= item.params ? "params, " : ""}}
@@ -79,6 +77,35 @@ options: UseQueryOptions<{{= responseType }}, AppErrorResponse> = {},
     },
     options,
   );
+}
+
+((newline))
+/**
+ * Query key used by {{= funcName }}
+ */
+{{= funcName }}.queryKey = function(
+{{ if (item.params) { }}
+params: T.{{= getTypeNameForType(item.params.reference, typeSuffix.apiInput, { useDefaults: false }) }},
+{{ } }}
+{{ if (item.query) { }}
+query: T.{{= getTypeNameForType(item.query.reference, typeSuffix.apiInput, { useDefaults: false }) }},
+{{ } }}
+{{ if (item.body) { }}
+body: T.{{= getTypeNameForType(item.body.reference, typeSuffix.apiInput, { useDefaults: false }) }},
+{{ } }}
+): QueryKey {
+  return [
+      "{{= item.uniqueName }}",
+     {{ if (item.params) { }}
+     params,
+     {{ } }}
+     {{ if (item.query) { }}
+     query,
+     {{ } }}
+     {{ if (item.body) { }}
+     body,
+     {{ } }}
+ ];
 }
 
 {{ } else { }}


### PR DESCRIPTION
This allows reactQuery consumers to for example invalidate a query without having to know the internal query keys.

This allows us to do some improvements to the generated keys, without doing breaking changes to the user.

References #697 