### PR TITLE
fix(code-gen): date validator should support special string cases

### DIFF
--- a/gen/testing.js
+++ b/gen/testing.js
@@ -58,7 +58,12 @@ export function applyTestingValidatorsStructure(app) {
   );
 
   // Date
-  app.add(T.date("date"));
+  app.add(
+    T.date("date"),
+    T.date("dateOptional").optional(),
+    T.date("dateAllowNull").allowNull(),
+    T.date("dateDefault").defaultToNow(),
+  );
 
   // Generic
   app.add(T.generic("generic").keys(T.number().convert()).values(T.bool()));

--- a/packages/code-gen/src/generator/validator.js
+++ b/packages/code-gen/src/generator/validator.js
@@ -391,7 +391,7 @@ function anonymousValidatorForType(context, imports, type) {
     case "boolean":
       return anonymousValidatorBoolean(context, imports, type);
     case "date":
-      return anonymousValidatorDate(context, imports);
+      return anonymousValidatorDate(context, imports, type);
     case "file":
       return anonymousValidatorFile(context);
     case "generic":
@@ -603,12 +603,15 @@ function anonymousValidatorBoolean(context, imports, type) {
 /**
  * @param {ValidatorContext} context
  * @param {ImportCreator} imports
+ * @param {CodeGenDateType} type
  */
-function anonymousValidatorDate(context, imports) {
+function anonymousValidatorDate(context, imports, type) {
   const stringType = {
     ...TypeBuilder.getBaseData(),
     type: "string",
+    isOptional: type.isOptional,
     validator: {
+      allowNull: type.validator.allowNull,
       min: 24,
       max: 29,
       pattern:
@@ -628,6 +631,13 @@ function anonymousValidatorDate(context, imports) {
            "value =",
            `"date"`,
          )}
+         
+         ${
+           type.isOptional && type.defaultValue
+             ? `if (!value) { return ${type.defaultValue}; }`
+             : ""
+         }
+         ${type.isOptional ? `if (!value) { return value; }` : ""}
       }
       try {
          const date = new Date(value);

--- a/packages/code-gen/test/validators.test.js
+++ b/packages/code-gen/test/validators.test.js
@@ -291,6 +291,56 @@ test("code-gen/validators", async (t) => {
     );
   });
 
+  t.test("dateOptional", (t) => {
+    const date = new Date();
+
+    assertAll(
+      t,
+      [
+        {
+          input: date,
+          expected: date,
+        },
+        {
+          input: "",
+          expected: undefined,
+        },
+        {
+          input: undefined,
+          expected: undefined,
+        },
+      ],
+      validators.validateValidatorDateOptional,
+    );
+  });
+
+  t.test("dateAllowNull", (t) => {
+    const date = new Date();
+
+    assertAll(
+      t,
+      [
+        {
+          input: date,
+          expected: date,
+        },
+        {
+          input: "",
+          expected: null,
+        },
+        {
+          input: undefined,
+          expected: undefined,
+        },
+        {
+          input: null,
+          expected: null,
+        },
+      ],
+      validators.validateValidatorDateAllowNull,
+    );
+  });
+
   t.test("generic", (t) => {
     assertAll(
       t,

--- a/packages/store/src/generated/anonymous-validators.js
+++ b/packages/store/src/generated/anonymous-validators.js
@@ -518,23 +518,24 @@ export function anonymousValidator56355924(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {string|undefined}
+d * @returns {undefined|string|undefined}
  */
-export function anonymousValidator1135331723(
+export function anonymousValidator852571656(
   value,
   propertyPath,
   errors = [],
   parentType = "string",
 ) {
   if (isNil(value)) {
-    throw AppError.validationError(`validator.${parentType}.undefined`, {
-      propertyPath,
-    });
+    return value;
   }
   if (typeof value !== "string") {
     throw AppError.validationError(`validator.${parentType}.type`, {
       propertyPath,
     });
+  }
+  if (value.length === 0) {
+    return undefined;
   }
   if (value.length < 24) {
     const min = 24;
@@ -578,7 +579,13 @@ export function anonymousValidator1389014320(
     return new Date();
   }
   if (typeof value === "string") {
-    value = anonymousValidator1135331723(value, propertyPath, errors, "date");
+    value = anonymousValidator852571656(value, propertyPath, errors, "date");
+    if (!value) {
+      return new Date();
+    }
+    if (!value) {
+      return value;
+    }
   }
   try {
     const date = new Date(value);
@@ -611,7 +618,10 @@ export function anonymousValidator1988053796(
     return value;
   }
   if (typeof value === "string") {
-    value = anonymousValidator1135331723(value, propertyPath, errors, "date");
+    value = anonymousValidator852571656(value, propertyPath, errors, "date");
+    if (!value) {
+      return value;
+    }
   }
   try {
     const date = new Date(value);
@@ -1257,6 +1267,54 @@ export function anonymousValidator430889951(
     errors,
   );
   return result;
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @param {{ key: string, info: any }[]} errors
+ * @param {string} parentType
+ * @returns {string|undefined}
+ */
+export function anonymousValidator1135331723(
+  value,
+  propertyPath,
+  errors = [],
+  parentType = "string",
+) {
+  if (isNil(value)) {
+    throw AppError.validationError(`validator.${parentType}.undefined`, {
+      propertyPath,
+    });
+  }
+  if (typeof value !== "string") {
+    throw AppError.validationError(`validator.${parentType}.type`, {
+      propertyPath,
+    });
+  }
+  if (value.length < 24) {
+    const min = 24;
+    throw AppError.validationError(`validator.${parentType}.min`, {
+      propertyPath,
+      min,
+    });
+  }
+  if (value.length > 29) {
+    const max = 29;
+    throw AppError.validationError(`validator.${parentType}.max`, {
+      propertyPath,
+      max,
+    });
+  }
+  if (
+    !/^(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))$/gi.test(
+      value,
+    )
+  ) {
+    throw AppError.validationError(`validator.${parentType}.pattern`, {
+      propertyPath,
+    });
+  }
+  return value;
 }
 /**
  * @param {*} value


### PR DESCRIPTION
The Date validator now passes `isOptional` and `allowNull` values down to the string validator. So dates can be set to `null` or `undefined` if an empty string is passed in.

Closes #551