### PR TITLE
feat(lint-config): add support for JSDoc linting

### DIFF
--- a/packages/cli/scripts/test.js
+++ b/packages/cli/scripts/test.js
@@ -195,6 +195,7 @@ function listTestFiles() {
 
 /**
  * Create workers and wait till they are initialized.
+ *
  * @returns {Promise<Worker[]>}
  */
 async function initializeWorkers() {

--- a/packages/cli/src/benchmarking/runner.js
+++ b/packages/cli/src/benchmarking/runner.js
@@ -39,7 +39,7 @@ export async function runBenchmarks(state) {
  *
  * @param {string} name
  * @param {BenchCallback} callback
- * @returns {undefined}
+ * @returns {void}
  */
 export function bench(name, callback) {
   state.push({ name, callback });

--- a/packages/cli/src/benchmarking/state.js
+++ b/packages/cli/src/benchmarking/state.js
@@ -15,6 +15,7 @@ export const state = [];
 
 /**
  * Mutate the global areBenchRunning
+ *
  * @param {boolean} running
  */
 export function setAreBenchRunning(running) {
@@ -23,6 +24,7 @@ export function setAreBenchRunning(running) {
 
 /**
  * Set the bench logger
+ *
  * @param {Logger} logger
  */
 export function setBenchLogger(logger) {

--- a/packages/cli/src/benchmarking/utils.js
+++ b/packages/cli/src/benchmarking/utils.js
@@ -17,7 +17,7 @@ import {
  * @since 0.1.0
  *
  * @param {ImportMeta} meta
- * @returns {undefined}
+ * @returns {void}
  */
 export function mainBenchFn(meta) {
   if (areBenchRunning) {

--- a/packages/cli/src/commands/help.js
+++ b/packages/cli/src/commands/help.js
@@ -5,7 +5,7 @@ import { dirnameForModule, pathJoin } from "@compas/stdlib";
  * @param {Logger} logger
  * @param {UtilCommand} command
  * @param {ScriptCollection} scriptCollection
- * @returns {undefined}
+ * @returns {void}
  */
 export function helpCommand(logger, command, scriptCollection) {
   const { name, version } = JSON.parse(

--- a/packages/cli/src/commands/visualise.js
+++ b/packages/cli/src/commands/visualise.js
@@ -199,6 +199,7 @@ async function getCodeGenExports() {
 
 /**
  * Check if the passed in structure file exists
+ *
  * @param {string} structureFile
  * @returns {Promise<boolean>}
  */
@@ -217,6 +218,7 @@ async function structureFileExists(structureFile) {
 
 /**
  * Check if the exported structure conforms to the Compas structure
+ *
  * @param structureFile
  * @param codeGen
  * @returns {Promise<boolean>}

--- a/packages/cli/src/parse.js
+++ b/packages/cli/src/parse.js
@@ -2,6 +2,7 @@ import { existsSync } from "fs";
 
 /**
  * List of commands that don't need to parse node args, script args and tooling args
+ *
  * @type {string[]}
  */
 const utilCommands = ["init", "help", "docker", "proxy", "visualise"];
@@ -9,6 +10,7 @@ const utilCommands = ["init", "help", "docker", "proxy", "visualise"];
 /**
  * Object of commands that accept special input like node arguments, script name or
  * tooling args
+ *
  * @type {object<string, { useScriptOrFile: boolean, }>}
  */
 const execCommands = {
@@ -31,6 +33,7 @@ const execCommands = {
 
 /**
  * Used for checking if an argument is a valid script path
+ *
  * @type {RegExp}
  */
 const pathRegex = /^([^/]*\/)+(.*)$/;

--- a/packages/cli/src/testing/config.js
+++ b/packages/cli/src/testing/config.js
@@ -11,6 +11,7 @@ const configPath = pathJoin(process.cwd(), "test/config.js");
  * - timeout, used as timeout per test case
  * - setup, function called once before tests run
  * - teardown, function called once after all tests run
+ *
  * @returns {Promise<void>}
  */
 export async function loadTestConfig() {

--- a/packages/cli/src/testing/printer.js
+++ b/packages/cli/src/testing/printer.js
@@ -4,6 +4,7 @@ import { state, testLogger } from "./state.js";
 
 /**
  * Prints test results and returns the exit code
+ *
  * @returns {number}
  */
 export function printTestResults() {
@@ -78,6 +79,7 @@ export function printTestResultsFromWorkers(testResults) {
 
 /**
  * Prints a quick test summary for the provided state
+ *
  * @param {TestState} state
  * @param {string[]} result
  * @param {number} indentCount
@@ -90,6 +92,7 @@ function printTreeSummary(state, result, indentCount) {
 
 /**
  * Prints information over test failures
+ *
  * @param {TestState} state
  * @param {string[]} result
  * @param {number} indentCount
@@ -171,6 +174,7 @@ export function printFailedResults(state, result, indentCount) {
 /**
  * Recursively marks hasFailure if test has a caughtException or if an assertion did not
  * pass
+ *
  * @param {TestState} state
  */
 export function markTestFailuresRecursively(state) {

--- a/packages/cli/src/testing/runner.js
+++ b/packages/cli/src/testing/runner.js
@@ -79,7 +79,7 @@ export async function runTestsRecursively(testState) {
  * @param {string} name The test name
  * @param {TestCallback} callback The function that is executed by the test runner. This
  *    can do async setup, register child tests and run assertions
- * @returns {undefined}
+ * @returns {void}
  */
 export const test = subTest.bind(undefined, state);
 

--- a/packages/cli/src/testing/state.js
+++ b/packages/cli/src/testing/state.js
@@ -36,6 +36,7 @@ export const state = {
 
 /**
  * Mutate the global areTestsRunning
+ *
  * @param {boolean} running
  */
 export function setAreTestRunning(running) {
@@ -44,6 +45,7 @@ export function setAreTestRunning(running) {
 
 /**
  * Set the test logger
+ *
  * @param {Logger} logger
  */
 export function setTestLogger(logger) {
@@ -52,6 +54,7 @@ export function setTestLogger(logger) {
 
 /**
  * Set test timeout value in milliseconds
+ *
  * @param value
  */
 export function setTestTimeout(value) {

--- a/packages/cli/src/testing/utils.js
+++ b/packages/cli/src/testing/utils.js
@@ -20,7 +20,7 @@ import {
  * @since 0.1.0
  *
  * @param {ImportMeta} meta
- * @returns {undefined}
+ * @returns {void}
  */
 export function mainTestFn(meta) {
   if (areTestsRunning) {

--- a/packages/cli/src/utils.js
+++ b/packages/cli/src/utils.js
@@ -46,6 +46,7 @@ export function collectScripts() {
 
 /**
  * Not so fool proof way of returning the accepted cli arguments of Node.js and v8
+ *
  * @returns {Promise<string[]>}
  */
 export async function collectNodeArgs() {
@@ -105,6 +106,7 @@ export function watchOptionsWithDefaults(options) {
 
 /**
  * Compiles an chokidar ignore array for the specified options
+ *
  * @param {CliWatchOptions} options
  * @returns {function(string): boolean}
  */
@@ -258,6 +260,7 @@ export async function executeCommand(
 
   /**
    * Restart with debounce
+   *
    * @param {boolean} [skipDebounce]
    */
   function debounceRestart(skipDebounce) {
@@ -281,6 +284,7 @@ export async function executeCommand(
 
 /**
  * Prepare stdin to be used for manual restarting
+ *
  * @param {Function} restart
  */
 function prepareStdin(restart) {

--- a/packages/code-gen/src/App.js
+++ b/packages/code-gen/src/App.js
@@ -71,7 +71,8 @@ export class App {
 
   /**
    * Create a new App.
-   * @param {AppOpts=} options
+   *
+   * @param {AppOpts} [options={}]
    */
   constructor({ verbose } = {}) {
     /**

--- a/packages/code-gen/src/builders/AnyType.js
+++ b/packages/code-gen/src/builders/AnyType.js
@@ -27,7 +27,7 @@ export class AnyType extends TypeBuilder {
    * Add raw type string instead of any.
    *
    * @param {string} value
-   * @param {{ javaScript?: string, typeScript?: string }=} importValue
+   * @param {{ javaScript?: string, typeScript?: string }} [importValue={}]
    * @returns {AnyType}
    */
   raw(value, importValue = {}) {
@@ -42,7 +42,7 @@ export class AnyType extends TypeBuilder {
    * This is validator is called with a value and should return a boolean.
    *
    * @param {string} value
-   * @param {{ javaScript?: string, typeScript?: string }=} importValue
+   * @param {{ javaScript?: string, typeScript?: string }} [importValue={}]
    * @returns {AnyType}
    */
   validator(value, importValue = {}) {

--- a/packages/code-gen/src/builders/utils.js
+++ b/packages/code-gen/src/builders/utils.js
@@ -28,6 +28,7 @@ export function isNamedTypeBuilderLike(value) {
  * - string oneOf
  * - array
  * - object
+ *
  * @param {TypeBuilderLike|undefined} value
  * @returns {*}
  */

--- a/packages/code-gen/src/generated/anonymous-validators.js
+++ b/packages/code-gen/src/generated/anonymous-validators.js
@@ -386,7 +386,7 @@ export function anonymousValidator942201043(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"javaScript"?: string, "typeScript"?: string, }|undefined}
+ * @returns {{"javaScript"?: undefined|string, "typeScript"?: undefined|string, }|undefined}
  */
 export function anonymousValidator1282254259(
   value,
@@ -422,7 +422,7 @@ export function anonymousValidator1282254259(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "any", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, "rawValue"?: string, "rawValueImport": {"javaScript"?: string, "typeScript"?: string, }, "rawValidator"?: string, "rawValidatorImport": {"javaScript"?: string, "typeScript"?: string, }, }|undefined}
+ * @returns {{"type": "any", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, "rawValue"?: undefined|string, "rawValueImport": {"javaScript"?: undefined|string, "typeScript"?: undefined|string, }, "rawValidator"?: undefined|string, "rawValidatorImport": {"javaScript"?: undefined|string, "typeScript"?: undefined|string, }, }|undefined}
  */
 export function anonymousValidator1519740867(
   value,
@@ -553,7 +553,7 @@ export function anonymousValidator2045286580(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"convert": boolean, "min"?: number, "max"?: number, }|undefined}
+ * @returns {{"convert": boolean, "min"?: undefined|number, "max"?: undefined|number, }|undefined}
  */
 export function anonymousValidator2043902290(
   value,
@@ -598,7 +598,7 @@ export function anonymousValidator2043902290(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "array", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "min"?: number, "max"?: number, }, "values": CodeGenType, }|undefined}
+ * @returns {{"type": "array", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "min"?: undefined|number, "max"?: undefined|number, }, "values": CodeGenType, }|undefined}
  */
 export function anonymousValidator1312175728(
   value,
@@ -722,7 +722,7 @@ export function anonymousValidator1064911095(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "boolean", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "allowNull": boolean, }, "oneOf"?: boolean, }|undefined}
+ * @returns {{"type": "boolean", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "allowNull": boolean, }, "oneOf"?: undefined|boolean, }|undefined}
  */
 export function anonymousValidator17476225(
   value,
@@ -809,7 +809,7 @@ export function anonymousValidator17476225(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "date", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }|undefined}
+ * @returns {{"type": "date", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }|undefined}
  */
 export function anonymousValidator2019605291(
   value,
@@ -888,7 +888,7 @@ export function anonymousValidator2019605291(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "file", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, }|undefined}
+ * @returns {{"type": "file", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, }|undefined}
  */
 export function anonymousValidator508679687(
   value,
@@ -967,7 +967,7 @@ export function anonymousValidator508679687(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "generic", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "keys": CodeGenType, "values": CodeGenType, }|undefined}
+ * @returns {{"type": "generic", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "keys": CodeGenType, "values": CodeGenType, }|undefined}
  */
 export function anonymousValidator1377926226(
   value,
@@ -1056,7 +1056,7 @@ export function anonymousValidator1377926226(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"convert": boolean, "floatingPoint": boolean, "min"?: number, "max"?: number, "allowNull": boolean, }|undefined}
+ * @returns {{"convert": boolean, "floatingPoint": boolean, "min"?: undefined|number, "max"?: undefined|number, "allowNull": boolean, }|undefined}
  */
 export function anonymousValidator1221128624(
   value,
@@ -1144,7 +1144,7 @@ export function anonymousValidator1367113100(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "number", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "floatingPoint": boolean, "min"?: number, "max"?: number, "allowNull": boolean, }, "oneOf"?: (number)[], }|undefined}
+ * @returns {{"type": "number", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "floatingPoint": boolean, "min"?: undefined|number, "max"?: undefined|number, "allowNull": boolean, }, "oneOf"?: undefined|(number)[], }|undefined}
  */
 export function anonymousValidator1441913722(
   value,
@@ -1415,7 +1415,7 @@ export function anonymousValidator1591987555(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"uniqueName"?: string, "group"?: string, "name"?: string, }|undefined}
+ * @returns {{"uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, }|undefined}
  */
 export function anonymousValidator815277285(
   value,
@@ -1469,7 +1469,7 @@ export function anonymousValidator815277285(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {CodeGenType|{"uniqueName"?: string, "group"?: string, "name"?: string, }|undefined}
+ * @returns {CodeGenType|{"uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, }|undefined}
  */
 export function anonymousValidator2139331922(
   value,
@@ -1510,7 +1510,7 @@ export function anonymousValidator2139331922(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "reference", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "reference": CodeGenType|{"uniqueName"?: string, "group"?: string, "name"?: string, }, }|undefined}
+ * @returns {{"type": "reference", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "reference": CodeGenType|{"uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, }, }|undefined}
  */
 export function anonymousValidator127554530(
   value,
@@ -1594,7 +1594,7 @@ export function anonymousValidator127554530(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "relation", "subType": "manyToOne"|"oneToMany"|"oneToOne"|"oneToOneReverse", "reference": CodeGenReferenceType, "ownKey": string, "referencedKey"?: string, "isOptional": boolean, }|undefined}
+ * @returns {{"type": "relation", "subType": "manyToOne"|"oneToMany"|"oneToOne"|"oneToOneReverse", "reference": CodeGenReferenceType, "ownKey": string, "referencedKey"?: undefined|string, "isOptional": boolean, }|undefined}
  */
 export function anonymousValidator243901689(
   value,
@@ -1848,7 +1848,7 @@ export function anonymousValidator1209434737(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"key": string, "defaultValue"?: string, "isJsonb": boolean, }|undefined}
+ * @returns {{"key": string, "defaultValue"?: undefined|string, "isJsonb": boolean, }|undefined}
  */
 export function anonymousValidator767145861(
   value,
@@ -1893,7 +1893,7 @@ export function anonymousValidator767145861(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {({"key": string, "defaultValue"?: string, "isJsonb": boolean, })[]|undefined}
+ * @returns {({"key": string, "defaultValue"?: undefined|string, "isJsonb": boolean, })[]|undefined}
  */
 export function anonymousValidator53797699(
   value,
@@ -1930,7 +1930,7 @@ export function anonymousValidator53797699(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {undefined|{"insertType": string, "updateType": string, "fields": ({"key": string, "defaultValue"?: string, "isJsonb": boolean, })[], }|undefined}
+ * @returns {undefined|{"insertType": string, "updateType": string, "fields": ({"key": string, "defaultValue"?: undefined|string, "isJsonb": boolean, })[], }|undefined}
  */
 export function anonymousValidator2068553851(
   value,
@@ -1971,7 +1971,7 @@ export function anonymousValidator2068553851(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "object", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"strict": boolean, }, "shortName"?: string, "keys": Object<string, CodeGenType>, "enableQueries": boolean, "queryOptions"?: {"withSoftDeletes": boolean, "withDates": boolean, "withPrimaryKey": boolean, "isView": boolean, }, "relations": (CodeGenRelationType)[], "where"?: {"type": string, "fields": ({"key": string, "name": string, "variant": "equal"|"notEqual"|"in"|"notIn"|"greaterThan"|"lowerThan"|"isNull"|"isNotNull"|"includeNotNull"|"like"|"iLike"|"notLike", })[], }, "partial"?: {"insertType": string, "updateType": string, "fields": ({"key": string, "defaultValue"?: string, "isJsonb": boolean, })[], }, }|undefined}
+ * @returns {{"type": "object", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"strict": boolean, }, "shortName"?: undefined|string, "keys": Object<string, CodeGenType>, "enableQueries": boolean, "queryOptions"?: undefined|{"withSoftDeletes": boolean, "withDates": boolean, "withPrimaryKey": boolean, "isView": boolean, }, "relations": (CodeGenRelationType)[], "where"?: undefined|{"type": string, "fields": ({"key": string, "name": string, "variant": "equal"|"notEqual"|"in"|"notIn"|"greaterThan"|"lowerThan"|"isNull"|"isNotNull"|"includeNotNull"|"like"|"iLike"|"notLike", })[], }, "partial"?: undefined|{"insertType": string, "updateType": string, "fields": ({"key": string, "defaultValue"?: undefined|string, "isJsonb": boolean, })[], }, }|undefined}
  */
 export function anonymousValidator17105276(
   value,
@@ -2117,7 +2117,7 @@ export function anonymousValidator946557101(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"convert": boolean, "trim": boolean, "lowerCase": boolean, "upperCase": boolean, "min": number, "max"?: number, "pattern"?: string, "allowNull": boolean, }|undefined}
+ * @returns {{"convert": boolean, "trim": boolean, "lowerCase": boolean, "upperCase": boolean, "min": number, "max"?: undefined|number, "pattern"?: undefined|string, "allowNull": boolean, }|undefined}
  */
 export function anonymousValidator1549436230(
   value,
@@ -2220,7 +2220,7 @@ export function anonymousValidator890105892(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "string", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "trim": boolean, "lowerCase": boolean, "upperCase": boolean, "min": number, "max"?: number, "pattern"?: string, "allowNull": boolean, }, "oneOf"?: (string)[], }|undefined}
+ * @returns {{"type": "string", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "trim": boolean, "lowerCase": boolean, "upperCase": boolean, "min": number, "max"?: undefined|number, "pattern"?: undefined|string, "allowNull": boolean, }, "oneOf"?: undefined|(string)[], }|undefined}
  */
 export function anonymousValidator1672152398(
   value,
@@ -2304,7 +2304,7 @@ export function anonymousValidator1672152398(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "uuid", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }|undefined}
+ * @returns {{"type": "uuid", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }|undefined}
  */
 export function anonymousValidator1836970168(
   value,
@@ -2438,7 +2438,7 @@ export function anonymousValidator708039854(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "route", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "method": "GET"|"POST"|"PUT"|"DELETE"|"HEAD"|"PATCH", "idempotent": boolean, "path": string, "tags": (string)[], "query"?: CodeGenType, "params"?: CodeGenType, "body"?: CodeGenType, "files"?: CodeGenType, "response"?: CodeGenType, }|undefined}
+ * @returns {{"type": "route", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "method": "GET"|"POST"|"PUT"|"DELETE"|"HEAD"|"PATCH", "idempotent": boolean, "path": string, "tags": (string)[], "query"?: undefined|CodeGenType, "params"?: undefined|CodeGenType, "body"?: undefined|CodeGenType, "files"?: undefined|CodeGenType, "response"?: undefined|CodeGenType, }|undefined}
  */
 export function anonymousValidator1390215584(
   value,
@@ -2723,7 +2723,7 @@ export function anonymousValidator1978730633(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"type": "anyOf", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "values": (CodeGenType)[], }|undefined}
+ * @returns {{"type": "anyOf", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "values": (CodeGenType)[], }|undefined}
  */
 export function anonymousValidator20588538(
   value,
@@ -3831,7 +3831,7 @@ export function anonymousValidator1664519436(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"isJSON"?: boolean, "nestedIsJSON"?: boolean, "useDefaults"?: boolean, "useTypescript"?: boolean, "isNode"?: boolean, "isBrowser"?: boolean, "suffix"?: string, "fileTypeIO"?: "input"|"outputRouter"|"outputClient", }|undefined}
+ * @returns {{"isJSON"?: undefined|boolean, "nestedIsJSON"?: undefined|boolean, "useDefaults"?: undefined|boolean, "useTypescript"?: undefined|boolean, "isNode"?: undefined|boolean, "isBrowser"?: undefined|boolean, "suffix"?: undefined|string, "fileTypeIO"?: undefined|"input"|"outputRouter"|"outputClient", }|undefined}
  */
 export function anonymousValidator1287070944(
   value,

--- a/packages/code-gen/src/generated/types.js
+++ b/packages/code-gen/src/generated/types.js
@@ -13,49 +13,49 @@ export const __generated__ = true;
  * @typedef {import("@compas/code-gen").RouteCreator} RouteCreator
  */
 /**
- * @typedef {{"type": "anyOf", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "values": (CodeGenType)[], }} CodeGenAnyOfType
+ * @typedef {{"type": "anyOf", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "values": (CodeGenType)[], }} CodeGenAnyOfType
  */
 /**
  * @typedef {CodeGenAnyType|CodeGenAnyOfType|CodeGenArrayType|CodeGenBooleanType|CodeGenDateType|CodeGenFileType|CodeGenGenericType|CodeGenNumberType|CodeGenObjectType|CodeGenReferenceType|CodeGenRelationType|CodeGenStringType|CodeGenUuidType|CodeGenRouteType} CodeGenType
  */
 /**
- * @typedef {{"type": "any", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, "rawValue"?: string, "rawValueImport": {"javaScript"?: string, "typeScript"?: string, }, "rawValidator"?: string, "rawValidatorImport": {"javaScript"?: string, "typeScript"?: string, }, }} CodeGenAnyType
+ * @typedef {{"type": "any", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, "rawValue"?: undefined|string, "rawValueImport": {"javaScript"?: undefined|string, "typeScript"?: undefined|string, }, "rawValidator"?: undefined|string, "rawValidatorImport": {"javaScript"?: undefined|string, "typeScript"?: undefined|string, }, }} CodeGenAnyType
  */
 /**
- * @typedef {{"type": "array", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "min"?: number, "max"?: number, }, "values": CodeGenType, }} CodeGenArrayType
+ * @typedef {{"type": "array", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "min"?: undefined|number, "max"?: undefined|number, }, "values": CodeGenType, }} CodeGenArrayType
  */
 /**
- * @typedef {{"type": "boolean", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "allowNull": boolean, }, "oneOf"?: boolean, }} CodeGenBooleanType
+ * @typedef {{"type": "boolean", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "allowNull": boolean, }, "oneOf"?: undefined|boolean, }} CodeGenBooleanType
  */
 /**
- * @typedef {{"type": "date", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }} CodeGenDateType
+ * @typedef {{"type": "date", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }} CodeGenDateType
  */
 /**
- * @typedef {{"type": "file", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, }} CodeGenFileType
+ * @typedef {{"type": "file", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, }} CodeGenFileType
  */
 /**
- * @typedef {{"type": "generic", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "keys": CodeGenType, "values": CodeGenType, }} CodeGenGenericType
+ * @typedef {{"type": "generic", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "keys": CodeGenType, "values": CodeGenType, }} CodeGenGenericType
  */
 /**
- * @typedef {{"type": "number", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "floatingPoint": boolean, "min"?: number, "max"?: number, "allowNull": boolean, }, "oneOf"?: (number)[], }} CodeGenNumberType
+ * @typedef {{"type": "number", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "floatingPoint": boolean, "min"?: undefined|number, "max"?: undefined|number, "allowNull": boolean, }, "oneOf"?: undefined|(number)[], }} CodeGenNumberType
  */
 /**
- * @typedef {{"type": "object", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"strict": boolean, }, "shortName"?: string, "keys": Object<string, CodeGenType>, "enableQueries": boolean, "queryOptions"?: {"withSoftDeletes": boolean, "withDates": boolean, "withPrimaryKey": boolean, "isView": boolean, }, "relations": (CodeGenRelationType)[], "where"?: {"type": string, "fields": ({"key": string, "name": string, "variant": "equal"|"notEqual"|"in"|"notIn"|"greaterThan"|"lowerThan"|"isNull"|"isNotNull"|"includeNotNull"|"like"|"iLike"|"notLike", })[], }, "partial"?: {"insertType": string, "updateType": string, "fields": ({"key": string, "defaultValue"?: string, "isJsonb": boolean, })[], }, }} CodeGenObjectType
+ * @typedef {{"type": "object", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"strict": boolean, }, "shortName"?: undefined|string, "keys": Object<string, CodeGenType>, "enableQueries": boolean, "queryOptions"?: undefined|{"withSoftDeletes": boolean, "withDates": boolean, "withPrimaryKey": boolean, "isView": boolean, }, "relations": (CodeGenRelationType)[], "where"?: undefined|{"type": string, "fields": ({"key": string, "name": string, "variant": "equal"|"notEqual"|"in"|"notIn"|"greaterThan"|"lowerThan"|"isNull"|"isNotNull"|"includeNotNull"|"like"|"iLike"|"notLike", })[], }, "partial"?: undefined|{"insertType": string, "updateType": string, "fields": ({"key": string, "defaultValue"?: undefined|string, "isJsonb": boolean, })[], }, }} CodeGenObjectType
  */
 /**
- * @typedef {{"type": "relation", "subType": "manyToOne"|"oneToMany"|"oneToOne"|"oneToOneReverse", "reference": CodeGenReferenceType, "ownKey": string, "referencedKey"?: string, "isOptional": boolean, }} CodeGenRelationType
+ * @typedef {{"type": "relation", "subType": "manyToOne"|"oneToMany"|"oneToOne"|"oneToOneReverse", "reference": CodeGenReferenceType, "ownKey": string, "referencedKey"?: undefined|string, "isOptional": boolean, }} CodeGenRelationType
  */
 /**
- * @typedef {{"type": "reference", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "reference": CodeGenType|{"uniqueName"?: string, "group"?: string, "name"?: string, }, }} CodeGenReferenceType
+ * @typedef {{"type": "reference", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "reference": CodeGenType|{"uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, }, }} CodeGenReferenceType
  */
 /**
- * @typedef {{"type": "string", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "trim": boolean, "lowerCase": boolean, "upperCase": boolean, "min": number, "max"?: number, "pattern"?: string, "allowNull": boolean, }, "oneOf"?: (string)[], }} CodeGenStringType
+ * @typedef {{"type": "string", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"convert": boolean, "trim": boolean, "lowerCase": boolean, "upperCase": boolean, "min": number, "max"?: undefined|number, "pattern"?: undefined|string, "allowNull": boolean, }, "oneOf"?: undefined|(string)[], }} CodeGenStringType
  */
 /**
- * @typedef {{"type": "uuid", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }} CodeGenUuidType
+ * @typedef {{"type": "uuid", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {"allowNull": boolean, }, }} CodeGenUuidType
  */
 /**
- * @typedef {{"type": "route", "docString": string, "isOptional": boolean, "defaultValue"?: string|boolean|number, "uniqueName"?: string, "group"?: string, "name"?: string, "sql"?: {"primary": boolean, "searchable": boolean, }, "validator": {}, "method": "GET"|"POST"|"PUT"|"DELETE"|"HEAD"|"PATCH", "idempotent": boolean, "path": string, "tags": (string)[], "query"?: CodeGenType, "params"?: CodeGenType, "body"?: CodeGenType, "files"?: CodeGenType, "response"?: CodeGenType, }} CodeGenRouteType
+ * @typedef {{"type": "route", "docString": string, "isOptional": boolean, "defaultValue"?: undefined|string|boolean|number, "uniqueName"?: undefined|string, "group"?: undefined|string, "name"?: undefined|string, "sql"?: undefined|{"primary": boolean, "searchable": boolean, }, "validator": {}, "method": "GET"|"POST"|"PUT"|"DELETE"|"HEAD"|"PATCH", "idempotent": boolean, "path": string, "tags": (string)[], "query"?: undefined|CodeGenType, "params"?: undefined|CodeGenType, "body"?: undefined|CodeGenType, "files"?: undefined|CodeGenType, "response"?: undefined|CodeGenType, }} CodeGenRouteType
  */
 /**
  * @typedef {{"options": CodeGenGenerateOpts, "structure": CodeGenStructure, "extension": ".js"|".ts", "importExtension": string, "outputFiles": (CodeGenFile)[], "rootExports": (string)[], "errors": ({"key": "sqlMissingPrimaryKey", "typeName": string, }|{"key": "sqlForgotEnableQueries", "typeName": string, "referencedByType": string, }|{"key": "sqlMissingOneToMany", "referencedByGroup": string, "referencedByType": string, "typeName": string, "relationOwnKey": string, }|{"key": "sqlUnusedOneToMany", "type": string, "referencedType": string, "ownKey": string, }|{"key": "sqlEnableValidator", }|{"key": "sqlThrowingValidators", }|{"key": "sqlDuplicateShortName", "shortName": string, "firstName": string, "secondName": string, }|{"key": "coreReservedGroupName", "groupName": string, })[], }} CodeGenContext
@@ -73,5 +73,5 @@ export const __generated__ = true;
  * @typedef {{"phase": "init"|"collect"|"finish", }} CodeGenTemplateState
  */
 /**
- * @typedef {{"isJSON"?: boolean, "nestedIsJSON"?: boolean, "useDefaults"?: boolean, "useTypescript"?: boolean, "isNode"?: boolean, "isBrowser"?: boolean, "suffix"?: string, "fileTypeIO"?: "input"|"outputRouter"|"outputClient", }} CodeGenTypeSettings
+ * @typedef {{"isJSON"?: undefined|boolean, "nestedIsJSON"?: undefined|boolean, "useDefaults"?: undefined|boolean, "useTypescript"?: undefined|boolean, "isNode"?: undefined|boolean, "isBrowser"?: undefined|boolean, "suffix"?: undefined|string, "fileTypeIO"?: undefined|"input"|"outputRouter"|"outputClient", }} CodeGenTypeSettings
  */

--- a/packages/code-gen/src/generator/index.js
+++ b/packages/code-gen/src/generator/index.js
@@ -163,6 +163,7 @@ export async function generate(logger, options, structure) {
 
 /**
  * Join all root exports in to a single index.js file
+ *
  * @param {CodeGenContext} context
  */
 export function generateRootExportsFile(context) {
@@ -182,6 +183,7 @@ export function generateRootExportsFile(context) {
 
 /**
  * Use the fileHeader from options, and prefix all file contents with it
+ *
  * @param {CodeGenContext} context
  */
 export function annotateFilesWithHeader(context) {
@@ -198,6 +200,7 @@ export function annotateFilesWithHeader(context) {
 
 /**
  * Write out all files
+ *
  * @param {CodeGenContext} context
  */
 export function writeFiles(context) {
@@ -215,6 +218,7 @@ export function writeFiles(context) {
 
 /**
  * Check if we should generate ES Modules based on the package.json
+ *
  * @param {Logger} logger
  * @returns {boolean}
  */

--- a/packages/code-gen/src/generator/sql/models.js
+++ b/packages/code-gen/src/generator/sql/models.js
@@ -7,6 +7,7 @@ import { getQueryEnabledObjects } from "./utils.js";
 
 /**
  * Generate model files with query basic, partials and builder
+ *
  * @param {CodeGenContext} context
  */
 export function generateModelFiles(context) {

--- a/packages/code-gen/src/generator/sql/partial-type.js
+++ b/packages/code-gen/src/generator/sql/partial-type.js
@@ -99,6 +99,7 @@ export function createPartialTypes(context) {
 
 /**
  * Adds builder to reuse inserts
+ *
  * @param {CodeGenContext} context
  * @param {CodeGenObjectType} type
  */
@@ -150,6 +151,7 @@ export function getInsertPartial(context, type) {
 
 /**
  * Adds builder to reuse updates
+ *
  * @param {CodeGenContext} context
  * @param {CodeGenObjectType} type
  */

--- a/packages/code-gen/src/generator/sql/query-basics.js
+++ b/packages/code-gen/src/generator/sql/query-basics.js
@@ -193,7 +193,7 @@ function insertQuery(context, imports, type) {
     /**
      * @param {Postgres} sql
      * @param {${type.partial.insertType}|(${type.partial.insertType}[])} insert
-     * @param {{ withPrimaryKey: boolean }=} options
+     * @param {{ withPrimaryKey: boolean }} [options={}]
      * @returns {Promise<${type.uniqueName}[]>}
      */
     export async function ${type.name}Insert(sql, insert, options = {}) {

--- a/packages/code-gen/src/generator/sql/query-builder.js
+++ b/packages/code-gen/src/generator/sql/query-builder.js
@@ -28,6 +28,7 @@ export function generateQueryBuilder(context, imports, type, src) {
 
 /**
  * Generate the necessary query builder types
+ *
  * @param {CodeGenContext} context
  */
 export function createQueryBuilderTypes(context) {
@@ -551,7 +552,7 @@ function transformerForType(context, imports, type) {
        *
        *
        * @param {*[]} values
-       * @param {${type.uniqueName}QueryBuilder=} builder
+       * @param {${type.uniqueName}QueryBuilder} [builder={}]
        */
       export function transform${upperCaseFirst(
         type.name,

--- a/packages/code-gen/src/generator/sql/query-partials.js
+++ b/packages/code-gen/src/generator/sql/query-partials.js
@@ -82,6 +82,7 @@ export function getFieldSet(context, type) {
 
 /**
  * A list of fields for the provided type, with dynamic tableName
+ *
  * @property {CodeGenContext} context
  * @property {CodeGenObjectType} type
  * @returns {string}

--- a/packages/code-gen/src/generator/sql/structure.js
+++ b/packages/code-gen/src/generator/sql/structure.js
@@ -30,6 +30,7 @@ export const typeTable = {
 
 /**
  * Generates the sql structure, this can be used to create migration files from
+ *
  * @param {CodeGenContext} context
  */
 export function generateSqlStructure(context) {

--- a/packages/code-gen/src/generator/sql/utils.js
+++ b/packages/code-gen/src/generator/sql/utils.js
@@ -3,6 +3,7 @@ import { isNil } from "@compas/stdlib";
 /**
  * This short name is used in the default basic queries an can be overwritten / used in
  * other queries
+ *
  * @param {CodeGenContext} context
  */
 export function addShortNamesToQueryEnabledObjects(context) {
@@ -93,6 +94,7 @@ export function getPrimaryKeyWithType(type) {
  * - Non nullable fields
  * - Nullable fields
  * - createdAt, updatedAt, deletedAt
+ *
  * @param {CodeGenObjectType} type
  * @returns {string[]}
  */
@@ -159,6 +161,7 @@ export function getSortedKeysForType(type) {
 
 /**
  * Statically check if objects are correctly setup do have queries enabled.
+ *
  * @param {CodeGenContext} context
  */
 export function doSqlChecks(context) {

--- a/packages/code-gen/src/generator/sql/where-type.js
+++ b/packages/code-gen/src/generator/sql/where-type.js
@@ -296,7 +296,7 @@ export function getWherePartial(context, type) {
      * Build 'WHERE ' part for ${type.name}
      * @param {${type.where.type}} [where={}]
      * @param {string} [tableName="${type.shortName}."]
-     * @param {{ skipValidator?: boolean }=} options
+     * @param {{ skipValidator?: boolean|undefined }} [options={}]
      * @returns {QueryPart}
      */
     export function ${type.name}Where(where = {}, tableName = "${type.shortName}.", options = {}) {
@@ -321,6 +321,7 @@ export function getWherePartial(context, type) {
 
 /**
  * Returns an object with only the searchable fields
+ *
  * @param {CodeGenObjectType} type
  * @returns {Object<string, CodeGenType>}
  */

--- a/packages/code-gen/src/generator/types.js
+++ b/packages/code-gen/src/generator/types.js
@@ -17,6 +17,7 @@ export function getTypeSuffixForUseCase(options) {
 
 /**
  * Setup stores for memoized types, so we can reuse types if necessary
+ *
  * @param {CodeGenContext} context
  */
 export function setupMemoizedTypes(context) {
@@ -47,6 +48,7 @@ export function setupMemoizedTypes(context) {
 
 /**
  * Use the memoized types and the provided settings to create a new type
+ *
  * @param {CodeGenContext} context
  * @param {CodeGenType} type
  * @param {string} suffix
@@ -290,7 +292,7 @@ export function generateTypeDefinition(
     case "object":
       result += "{";
       for (const key of Object.keys(type.keys)) {
-        let right = generateTypeDefinition(
+        const right = generateTypeDefinition(
           context,
           type.keys[key],
           recurseSettings,
@@ -299,7 +301,6 @@ export function generateTypeDefinition(
         let separator = ":";
         if (right.startsWith("undefined|")) {
           separator = "?:";
-          right = right.substring(10);
         }
 
         result += `"${key}"${separator} ${right}, `;

--- a/packages/code-gen/src/generator/utils.js
+++ b/packages/code-gen/src/generator/utils.js
@@ -12,6 +12,7 @@ import { isNil } from "@compas/stdlib";
 
 /**
  * Clean template output by removing redundant new lines
+ *
  * @param {string} str
  * @returns {string}
  */

--- a/packages/code-gen/src/generator/validator.js
+++ b/packages/code-gen/src/generator/validator.js
@@ -254,7 +254,7 @@ function addUtilitiesToAnonymousFunctions(context) {
  * @param {string} propertyPath
  * @param {string} errors
  * @param {string} prefix
- * @param {string=} parentType
+ * @param {string} [parentType]
  * @returns {string}
  */
 function generateAnonymousValidatorCall(

--- a/packages/code-gen/src/stringify.js
+++ b/packages/code-gen/src/stringify.js
@@ -5,7 +5,7 @@
  * queryOptions, sql and relations
  *
  * @param {CodeGenType} type
- * @param {boolean=} includeSqlRelated
+ * @param {boolean} [includeSqlRelated=false]
  * @returns {string}
  */
 export function stringifyType(type, includeSqlRelated = false) {

--- a/packages/code-gen/test/validators.test.js
+++ b/packages/code-gen/test/validators.test.js
@@ -12,7 +12,7 @@ mainTestFn(import.meta);
  *   expected?: *,
  *   input?: *
  * }[]} cases
- * @param {function} fn
+ * @param {Function} fn
  */
 const assertAll = (t, cases, fn) => {
   for (const item of cases) {

--- a/packages/insight/src/events.js
+++ b/packages/insight/src/events.js
@@ -43,7 +43,7 @@ export function newEventFromEvent(event) {
  *
  * @param {Event} event
  * @param {string} name
- * @returns {undefined}
+ * @returns {void}
  */
 export function eventStart(event, name) {
   event.name = name;
@@ -62,7 +62,7 @@ export function eventStart(event, name) {
  *
  * @param {Event} event
  * @param {string} name
- * @returns {undefined}
+ * @returns {void}
  */
 export function eventRename(event, name) {
   event.name = name;
@@ -75,7 +75,7 @@ export function eventRename(event, name) {
  * @since 0.1.0
  *
  * @param {Event} event
- * @returns {undefined}
+ * @returns {void}
  */
 export function eventStop(event) {
   event.callStack.push({

--- a/packages/insight/src/logger/logger.js
+++ b/packages/insight/src/logger/logger.js
@@ -44,8 +44,8 @@ export function newLogger(options) {
 /**
  * Wrap provided writer function to be used in the Logger
  *
- * @param {function} fn
- * @returns {function}
+ * @param {Function} fn
+ * @returns {Function}
  */
 function wrapWriter(fn) {
   return (stream, level, context, message) => {

--- a/packages/insight/src/logger/writer.js
+++ b/packages/insight/src/logger/writer.js
@@ -6,7 +6,7 @@ import { inspect } from "util";
  * @param {Date} timestamp
  * @param {string} context
  * @param {*} message
- * @returns {undefined}
+ * @returns {void}
  */
 export function writeNDJSON(stream, level, timestamp, context, message) {
   stream.write(
@@ -22,7 +22,7 @@ export function writeNDJSON(stream, level, timestamp, context, message) {
  * @param {Date} timestamp
  * @param {string} context
  * @param {*} message
- * @returns {undefined}
+ * @returns {void}
  */
 export function writePretty(stream, level, timestamp, context, message) {
   let prefix = `${formatDate(timestamp)} ${formatLevelAndType(

--- a/packages/insight/src/memory.js
+++ b/packages/insight/src/memory.js
@@ -33,7 +33,7 @@ export function bytesToHumanReadable(bytes) {
  * @since 0.1.0
  *
  * @param {Logger} logger
- * @returns {undefined}
+ * @returns {void}
  */
 export function printProcessMemoryUsage(logger) {
   const {

--- a/packages/lint-config/index.js
+++ b/packages/lint-config/index.js
@@ -3,7 +3,7 @@
 /**
  * @type {object} Eslint settings
  */
-module.exports = {
+const settings = {
   root: true,
   extends: [
     "eslint:recommended",
@@ -53,3 +53,53 @@ module.exports = {
     es2020: true,
   },
 };
+/**
+ * @type {object} Eslint settings
+ */
+const jsdocSettings = {
+  plugins: ["jsdoc"],
+  rules: {
+    // ESLint plugin jsdoc
+    "jsdoc/check-alignment": "error",
+    "jsdoc/check-examples": ["off", { padding: 2 }],
+    "jsdoc/check-param-names": "error",
+    "jsdoc/check-property-names": "error",
+    "jsdoc/check-syntax": "error",
+    "jsdoc/check-tag-names": ["error", { definedTags: [] }],
+    "jsdoc/check-types": ["error"],
+    "jsdoc/check-values": "error",
+    "jsdoc/empty-tags": "error",
+    "jsdoc/newline-after-description": ["error", "always"],
+    "jsdoc/require-param-name": "error",
+    "jsdoc/require-property": "error",
+    "jsdoc/require-property-type": "error",
+    "jsdoc/require-property-name": "error",
+    "jsdoc/require-returns-check": [
+      "off",
+      { reportMissingReturnForUndefinedTypes: true },
+    ],
+    "jsdoc/require-returns-description": "off",
+    "jsdoc/require-returns-type": "off",
+    "jsdoc/valid-types": "off",
+  },
+  settings: {
+    jsdoc: {
+      mode: "typescript",
+    },
+  },
+};
+
+/**
+ * @type {object} Eslint settings
+ */
+module.exports =
+  process.env.CI === "true"
+    ? {
+        ...settings,
+        ...jsdocSettings,
+        rules: {
+          ...settings.rules,
+          ...jsdocSettings.rules,
+        },
+      }
+    : settings;

--- a/packages/lint-config/package.json
+++ b/packages/lint-config/package.json
@@ -16,6 +16,7 @@
     "eslint": "7.20.0",
     "eslint-config-prettier": "7.2.0",
     "eslint-plugin-import": "2.22.1",
+    "eslint-plugin-jsdoc": "32.1.0",
     "prettier": "2.2.1"
   },
   "maintainers": [

--- a/packages/server/src/middleware/log.js
+++ b/packages/server/src/middleware/log.js
@@ -4,6 +4,7 @@ import { isNil, uuid } from "@compas/stdlib";
 
 /**
  * Log basic request and response information
+ *
  * @param {GetAppOptions.logOptions} options
  */
 export function logMiddleware(options) {

--- a/packages/server/src/middleware/session.js
+++ b/packages/server/src/middleware/session.js
@@ -63,9 +63,7 @@ function getKeys() {
  * This allows us to set extra cookies that are JS readable but don't contain any
  * sensitive information.
  *
- * @param {SessionStore} store
- * @param {string} key
- * @param {*} cookieOpts
+ * @param {{ store: SessionStore, key: string, } & SessionOptions} opts
  */
 function wrapStoreCalls({ store, key, ...cookieOpts }) {
   cookieOpts.httpOnly = false;

--- a/packages/stdlib/src/env.js
+++ b/packages/stdlib/src/env.js
@@ -25,7 +25,7 @@ export let environment = {};
  * @since 0.1.0
  * @summary Repopulate the cached environment copy.
  *
- * @returns {undefined}
+ * @returns {void}
  */
 export function refreshEnvironmentCache() {
   environment = JSON.parse(JSON.stringify(process.env));

--- a/packages/stdlib/src/utils.js
+++ b/packages/stdlib/src/utils.js
@@ -25,7 +25,7 @@ export function getSecondsSinceEpoch() {
  *
  * @since 0.1.0
  *
- * @returns {undefined}
+ * @returns {void}
  */
 export function noop() {
   return undefined;
@@ -43,7 +43,7 @@ let internalGc = global.gc;
  *
  * @since 0.1.0
  *
- * @returns {undefined}
+ * @returns {void}
  */
 export function gc() {
   if (isNil(internalGc)) {
@@ -64,7 +64,7 @@ export function gc() {
  *
  * @param {ImportMeta} meta
  * @param {MainFnCallback} cb
- * @returns {undefined}
+ * @returns {void}
  */
 export function mainFn(meta, cb) {
   const { isMainFn, name } = isMainFnAndReturnName(meta);
@@ -144,6 +144,7 @@ export function dirnameForModule(meta) {
 /**
  * Checks if the provided meta.url is the process entrypoint and also returns the name of
  * the entrypoint file
+ *
  * @param {ImportMeta} meta
  * @returns {{ isMainFn: boolean, name?: string}}
  */

--- a/packages/store/src/files.js
+++ b/packages/store/src/files.js
@@ -83,8 +83,7 @@ export async function createOrUpdateFile(
  * @param {minio.Client} minio
  * @param {string} bucketName
  * @param {string} id
- * @param {number} [start]
- * @param {number} [end]
+ * @param {{ start?: number|undefined, end?: number|undefined }} [seek={}]
  * @returns {Promise<ReadableStream>}
  */
 export async function getFileStream(

--- a/packages/store/src/generated.js
+++ b/packages/store/src/generated.js
@@ -10,7 +10,7 @@ export let queries = undefined;
  * @since 0.1.0
  *
  * @param {typeof import("./generated/index.js").queries} q
- * @returns {undefined}
+ * @returns {void}
  */
 export function setStoreQueries(q) {
   queries = q;

--- a/packages/store/src/generated/anonymous-validators.js
+++ b/packages/store/src/generated/anonymous-validators.js
@@ -518,7 +518,7 @@ export function anonymousValidator56355924(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
-d * @returns {undefined|string|undefined}
+ * @returns {undefined|string|undefined}
  */
 export function anonymousValidator852571656(
   value,
@@ -642,7 +642,7 @@ export function anonymousValidator1988053796(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"bucketName": string, "contentLength": number, "contentType": string, "name": string, "meta": StoreFileMeta, "id": string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: Date, }|undefined}
+ * @returns {{"bucketName": string, "contentLength": number, "contentType": string, "name": string, "meta": StoreFileMeta, "id": string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: undefined|Date, }|undefined}
  */
 export function anonymousValidator599447075(
   value,
@@ -832,7 +832,7 @@ export function anonymousValidator1802076175(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"name"?: string, "order": number, "meta": StoreFileGroupMeta, "id": string, "file"?: string, "parent"?: string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: Date, }|undefined}
+ * @returns {{"name"?: undefined|string, "order": number, "meta": StoreFileGroupMeta, "id": string, "file"?: undefined|string, "parent"?: undefined|string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: undefined|Date, }|undefined}
  */
 export function anonymousValidator2060025506(
   value,
@@ -911,7 +911,7 @@ export function anonymousValidator2060025506(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"name"?: string, "order": number, "meta": StoreFileGroupMeta, "isDirectory": boolean, "id": string, "file"?: string, "parent"?: string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: Date, }|undefined}
+ * @returns {{"name"?: undefined|string, "order": number, "meta": StoreFileGroupMeta, "isDirectory": boolean, "id": string, "file"?: undefined|string, "parent"?: undefined|string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: undefined|Date, }|undefined}
  */
 export function anonymousValidator420606873(
   value,
@@ -1209,7 +1209,7 @@ export function anonymousValidator2045286580(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"years"?: number, "months"?: number, "days"?: number, "hours"?: number, "minutes"?: number, "seconds"?: number, }|undefined}
+ * @returns {{"years"?: undefined|number, "months"?: undefined|number, "days"?: undefined|number, "hours"?: undefined|number, "minutes"?: undefined|number, "seconds"?: undefined|number, }|undefined}
  */
 export function anonymousValidator430889951(
   value,
@@ -1653,7 +1653,7 @@ export function anonymousValidator978954249(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"$raw"?: QueryPart, "$or"?: (StoreFileWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "bucketName"?: string, "bucketNameNotEqual"?: string, "bucketNameIn"?: (string)[]|QueryPart, "bucketNameNotIn"?: (string)[]|QueryPart, "bucketNameLike"?: string, "bucketNameILike"?: string, "bucketNameNotLike"?: string, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, "deletedAt"?: Date, "deletedAtNotEqual"?: Date, "deletedAtIn"?: (Date)[]|QueryPart, "deletedAtNotIn"?: (Date)[]|QueryPart, "deletedAtGreaterThan"?: Date, "deletedAtLowerThan"?: Date, "deletedAtIncludeNotNull"?: boolean, }|undefined}
+ * @returns {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreFileWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "bucketName"?: undefined|string, "bucketNameNotEqual"?: undefined|string, "bucketNameIn"?: undefined|(string)[]|QueryPart, "bucketNameNotIn"?: undefined|(string)[]|QueryPart, "bucketNameLike"?: undefined|string, "bucketNameILike"?: undefined|string, "bucketNameNotLike"?: undefined|string, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, "deletedAt"?: undefined|Date, "deletedAtNotEqual"?: undefined|Date, "deletedAtIn"?: undefined|(Date)[]|QueryPart, "deletedAtNotIn"?: undefined|(Date)[]|QueryPart, "deletedAtGreaterThan"?: undefined|Date, "deletedAtLowerThan"?: undefined|Date, "deletedAtIncludeNotNull"?: undefined|boolean, }|undefined}
  */
 export function anonymousValidator2074494218(
   value,
@@ -1936,7 +1936,7 @@ export function anonymousValidator58972158(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"$raw"?: QueryPart, "$or"?: (StoreFileGroupWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "file"?: string, "fileNotEqual"?: string, "fileIn"?: (string)[]|QueryPart, "fileNotIn"?: (string)[]|QueryPart, "fileLike"?: string, "fileNotLike"?: string, "fileIsNull"?: boolean, "fileIsNotNull"?: boolean, "parent"?: string, "parentNotEqual"?: string, "parentIn"?: (string)[]|QueryPart, "parentNotIn"?: (string)[]|QueryPart, "parentLike"?: string, "parentNotLike"?: string, "parentIsNull"?: boolean, "parentIsNotNull"?: boolean, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, "deletedAt"?: Date, "deletedAtNotEqual"?: Date, "deletedAtIn"?: (Date)[]|QueryPart, "deletedAtNotIn"?: (Date)[]|QueryPart, "deletedAtGreaterThan"?: Date, "deletedAtLowerThan"?: Date, "deletedAtIncludeNotNull"?: boolean, }|undefined}
+ * @returns {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreFileGroupWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "file"?: undefined|string, "fileNotEqual"?: undefined|string, "fileIn"?: undefined|(string)[]|QueryPart, "fileNotIn"?: undefined|(string)[]|QueryPart, "fileLike"?: undefined|string, "fileNotLike"?: undefined|string, "fileIsNull"?: undefined|boolean, "fileIsNotNull"?: undefined|boolean, "parent"?: undefined|string, "parentNotEqual"?: undefined|string, "parentIn"?: undefined|(string)[]|QueryPart, "parentNotIn"?: undefined|(string)[]|QueryPart, "parentLike"?: undefined|string, "parentNotLike"?: undefined|string, "parentIsNull"?: undefined|boolean, "parentIsNotNull"?: undefined|boolean, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, "deletedAt"?: undefined|Date, "deletedAtNotEqual"?: undefined|Date, "deletedAtIn"?: undefined|(Date)[]|QueryPart, "deletedAtNotIn"?: undefined|(Date)[]|QueryPart, "deletedAtGreaterThan"?: undefined|Date, "deletedAtLowerThan"?: undefined|Date, "deletedAtIncludeNotNull"?: undefined|boolean, }|undefined}
  */
 export function anonymousValidator153017499(
   value,
@@ -2281,7 +2281,7 @@ export function anonymousValidator1842665181(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"$raw"?: QueryPart, "$or"?: (StoreFileGroupViewWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "isDirectory"?: boolean, "file"?: string, "fileNotEqual"?: string, "fileIn"?: (string)[]|QueryPart, "fileNotIn"?: (string)[]|QueryPart, "fileLike"?: string, "fileNotLike"?: string, "fileIsNull"?: boolean, "fileIsNotNull"?: boolean, "parent"?: string, "parentNotEqual"?: string, "parentIn"?: (string)[]|QueryPart, "parentNotIn"?: (string)[]|QueryPart, "parentLike"?: string, "parentNotLike"?: string, "parentIsNull"?: boolean, "parentIsNotNull"?: boolean, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, "deletedAt"?: Date, "deletedAtNotEqual"?: Date, "deletedAtIn"?: (Date)[]|QueryPart, "deletedAtNotIn"?: (Date)[]|QueryPart, "deletedAtGreaterThan"?: Date, "deletedAtLowerThan"?: Date, "deletedAtIncludeNotNull"?: boolean, }|undefined}
+ * @returns {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreFileGroupViewWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "isDirectory"?: undefined|boolean, "file"?: undefined|string, "fileNotEqual"?: undefined|string, "fileIn"?: undefined|(string)[]|QueryPart, "fileNotIn"?: undefined|(string)[]|QueryPart, "fileLike"?: undefined|string, "fileNotLike"?: undefined|string, "fileIsNull"?: undefined|boolean, "fileIsNotNull"?: undefined|boolean, "parent"?: undefined|string, "parentNotEqual"?: undefined|string, "parentIn"?: undefined|(string)[]|QueryPart, "parentNotIn"?: undefined|(string)[]|QueryPart, "parentLike"?: undefined|string, "parentNotLike"?: undefined|string, "parentIsNull"?: undefined|boolean, "parentIsNotNull"?: undefined|boolean, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, "deletedAt"?: undefined|Date, "deletedAtNotEqual"?: undefined|Date, "deletedAtIn"?: undefined|(Date)[]|QueryPart, "deletedAtNotIn"?: undefined|(Date)[]|QueryPart, "deletedAtGreaterThan"?: undefined|Date, "deletedAtLowerThan"?: undefined|Date, "deletedAtIncludeNotNull"?: undefined|boolean, }|undefined}
  */
 export function anonymousValidator1823959232(
   value,
@@ -2736,7 +2736,7 @@ export function anonymousValidator102852585(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"$raw"?: QueryPart, "$or"?: (StoreJobWhere)[], "id"?: number, "idNotEqual"?: number, "idIn"?: (number)[]|QueryPart, "idNotIn"?: (number)[]|QueryPart, "idGreaterThan"?: number, "idLowerThan"?: number, "isComplete"?: boolean, "isCompleteIsNull"?: boolean, "isCompleteIsNotNull"?: boolean, "name"?: string, "nameNotEqual"?: string, "nameIn"?: (string)[]|QueryPart, "nameNotIn"?: (string)[]|QueryPart, "nameLike"?: string, "nameILike"?: string, "nameNotLike"?: string, "scheduledAt"?: Date, "scheduledAtNotEqual"?: Date, "scheduledAtIn"?: (Date)[]|QueryPart, "scheduledAtNotIn"?: (Date)[]|QueryPart, "scheduledAtGreaterThan"?: Date, "scheduledAtLowerThan"?: Date, "scheduledAtIsNull"?: boolean, "scheduledAtIsNotNull"?: boolean, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, }|undefined}
+ * @returns {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreJobWhere)[], "id"?: undefined|number, "idNotEqual"?: undefined|number, "idIn"?: undefined|(number)[]|QueryPart, "idNotIn"?: undefined|(number)[]|QueryPart, "idGreaterThan"?: undefined|number, "idLowerThan"?: undefined|number, "isComplete"?: undefined|boolean, "isCompleteIsNull"?: undefined|boolean, "isCompleteIsNotNull"?: undefined|boolean, "name"?: undefined|string, "nameNotEqual"?: undefined|string, "nameIn"?: undefined|(string)[]|QueryPart, "nameNotIn"?: undefined|(string)[]|QueryPart, "nameLike"?: undefined|string, "nameILike"?: undefined|string, "nameNotLike"?: undefined|string, "scheduledAt"?: undefined|Date, "scheduledAtNotEqual"?: undefined|Date, "scheduledAtIn"?: undefined|(Date)[]|QueryPart, "scheduledAtNotIn"?: undefined|(Date)[]|QueryPart, "scheduledAtGreaterThan"?: undefined|Date, "scheduledAtLowerThan"?: undefined|Date, "scheduledAtIsNull"?: undefined|boolean, "scheduledAtIsNotNull"?: undefined|boolean, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, }|undefined}
  */
 export function anonymousValidator1257773835(
   value,
@@ -3055,7 +3055,7 @@ export function anonymousValidator688866095(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"$raw"?: QueryPart, "$or"?: (StoreSessionWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "expires"?: Date, "expiresNotEqual"?: Date, "expiresIn"?: (Date)[]|QueryPart, "expiresNotIn"?: (Date)[]|QueryPart, "expiresGreaterThan"?: Date, "expiresLowerThan"?: Date, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, }|undefined}
+ * @returns {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreSessionWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "expires"?: undefined|Date, "expiresNotEqual"?: undefined|Date, "expiresIn"?: undefined|(Date)[]|QueryPart, "expiresNotIn"?: undefined|(Date)[]|QueryPart, "expiresGreaterThan"?: undefined|Date, "expiresLowerThan"?: undefined|Date, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, }|undefined}
  */
 export function anonymousValidator500057262(
   value,
@@ -3315,7 +3315,7 @@ export function anonymousValidator2119152283(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreFileGroupWhere, "limit"?: number, "offset"?: number, "viaFile"?: StoreFileQueryTraverser, "viaParent"?: StoreFileGroupQueryTraverser, "viaChildren"?: StoreFileGroupQueryTraverser, }|undefined}
+ * @returns {{"where"?: undefined|StoreFileGroupWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaFile"?: undefined|StoreFileQueryTraverser, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }|undefined}
  */
 export function anonymousValidator1274599578(
   value,
@@ -3415,7 +3415,7 @@ export function anonymousValidator1561713483(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreFileGroupViewWhere, "limit"?: number, "offset"?: number, "viaFile"?: StoreFileQueryTraverser, "viaParent"?: StoreFileGroupViewQueryTraverser, "viaChildren"?: StoreFileGroupViewQueryTraverser, }|undefined}
+ * @returns {{"where"?: undefined|StoreFileGroupViewWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaFile"?: undefined|StoreFileQueryTraverser, "viaParent"?: undefined|StoreFileGroupViewQueryTraverser, "viaChildren"?: undefined|StoreFileGroupViewQueryTraverser, }|undefined}
  */
 export function anonymousValidator1468307041(
   value,
@@ -3497,7 +3497,7 @@ export function anonymousValidator1166782134(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreFileWhere, "limit"?: number, "offset"?: number, "viaGroup"?: StoreFileGroupQueryTraverser, "viaGroupView"?: StoreFileGroupViewQueryTraverser, }|undefined}
+ * @returns {{"where"?: undefined|StoreFileWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, "viaGroupView"?: undefined|StoreFileGroupViewQueryTraverser, }|undefined}
  */
 export function anonymousValidator1069465749(
   value,
@@ -3574,7 +3574,7 @@ export function anonymousValidator1978760330(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreFileGroupWhere, "as"?: string, "limit"?: number, "offset"?: number, "file"?: StoreFileQueryBuilder, "viaFile"?: StoreFileQueryTraverser, "parent"?: StoreFileGroupQueryBuilder, "viaParent"?: StoreFileGroupQueryTraverser, "children"?: StoreFileGroupQueryBuilder, "viaChildren"?: StoreFileGroupQueryTraverser, }|undefined}
+ * @returns {{"where"?: undefined|StoreFileGroupWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "viaFile"?: undefined|StoreFileQueryTraverser, "parent"?: undefined|StoreFileGroupQueryBuilder, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "children"?: undefined|StoreFileGroupQueryBuilder, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }|undefined}
  */
 export function anonymousValidator1862233461(
   value,
@@ -3676,7 +3676,7 @@ export function anonymousValidator1996607136(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreFileGroupViewWhere, "as"?: string, "limit"?: number, "offset"?: number, "file"?: StoreFileQueryBuilder, "viaFile"?: StoreFileQueryTraverser, "parent"?: StoreFileGroupViewQueryBuilder, "viaParent"?: StoreFileGroupViewQueryTraverser, "children"?: StoreFileGroupViewQueryBuilder, "viaChildren"?: StoreFileGroupViewQueryTraverser, }|undefined}
+ * @returns {{"where"?: undefined|StoreFileGroupViewWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "viaFile"?: undefined|StoreFileQueryTraverser, "parent"?: undefined|StoreFileGroupViewQueryBuilder, "viaParent"?: undefined|StoreFileGroupViewQueryTraverser, "children"?: undefined|StoreFileGroupViewQueryBuilder, "viaChildren"?: undefined|StoreFileGroupViewQueryTraverser, }|undefined}
  */
 export function anonymousValidator2056027066(
   value,
@@ -3778,7 +3778,7 @@ export function anonymousValidator778129957(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreFileWhere, "as"?: string, "limit"?: number, "offset"?: number, "group"?: StoreFileGroupQueryBuilder, "viaGroup"?: StoreFileGroupQueryTraverser, "groupView"?: StoreFileGroupViewQueryBuilder, "viaGroupView"?: StoreFileGroupViewQueryTraverser, }|undefined}
+ * @returns {{"where"?: undefined|StoreFileWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "group"?: undefined|StoreFileGroupQueryBuilder, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, "groupView"?: undefined|StoreFileGroupViewQueryBuilder, "viaGroupView"?: undefined|StoreFileGroupViewQueryTraverser, }|undefined}
  */
 export function anonymousValidator310044624(
   value,
@@ -3870,7 +3870,7 @@ export function anonymousValidator634541376(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreJobWhere, "as"?: string, "limit"?: number, "offset"?: number, }|undefined}
+ * @returns {{"where"?: undefined|StoreJobWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, }|undefined}
  */
 export function anonymousValidator343387919(
   value,
@@ -3924,7 +3924,7 @@ export function anonymousValidator343387919(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreJobWhere, "limit"?: number, "offset"?: number, }|undefined}
+ * @returns {{"where"?: undefined|StoreJobWhere, "limit"?: undefined|number, "offset"?: undefined|number, }|undefined}
  */
 export function anonymousValidator1952914356(
   value,
@@ -3991,7 +3991,7 @@ export function anonymousValidator196488441(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreSessionWhere, "as"?: string, "limit"?: number, "offset"?: number, }|undefined}
+ * @returns {{"where"?: undefined|StoreSessionWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, }|undefined}
  */
 export function anonymousValidator647856360(
   value,
@@ -4045,7 +4045,7 @@ export function anonymousValidator647856360(
  * @param {string} propertyPath
  * @param {{ key: string, info: any }[]} errors
  * @param {string} parentType
- * @returns {{"where"?: StoreSessionWhere, "limit"?: number, "offset"?: number, }|undefined}
+ * @returns {{"where"?: undefined|StoreSessionWhere, "limit"?: undefined|number, "offset"?: undefined|number, }|undefined}
  */
 export function anonymousValidator1805657267(
   value,

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -32,6 +32,7 @@ const fileFieldSet = new Set([
 ]);
 /**
  * Get all fields for file
+ *
  * @param {string} [tableName="f."]
  * @param {{ excludePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -51,6 +52,7 @@ export function fileFields(tableName = "f.", options = {}) {
 }
 /**
  * Get 'ORDER BY ' for file
+ *
  * @param {string} [tableName="f."]
  * @returns {QueryPart}
  */
@@ -65,9 +67,10 @@ export function fileOrderBy(tableName = "f.") {
 }
 /**
  * Build 'WHERE ' part for file
+ *
  * @param {StoreFileWhere} [where={}]
  * @param {string} [tableName="f."]
- * @param {{ skipValidator?: boolean }=} options
+ * @param {{ skipValidator?: boolean|undefined }} [options={}]
  * @returns {QueryPart}
  */
 export function fileWhere(where = {}, tableName = "f.", options = {}) {
@@ -400,6 +403,7 @@ export function fileWhere(where = {}, tableName = "f.", options = {}) {
 }
 /**
  * Build 'VALUES ' part for file
+ *
  * @param {StoreFileInsertPartial|StoreFileInsertPartial[]} insert
  * @param {{ includePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -428,6 +432,7 @@ ${it.contentLength ?? null}, ${it.bucketName ?? null}, ${
 }
 /**
  * Build 'SET ' part for file
+ *
  * @param {StoreFileUpdatePartial} update
  * @returns {QueryPart}
  */
@@ -524,7 +529,7 @@ WHERE ${fileWhere(where)}
 /**
  * @param {Postgres} sql
  * @param {StoreFileInsertPartial|(StoreFileInsertPartial[])} insert
- * @param {{ withPrimaryKey: boolean }=} options
+ * @param {{ withPrimaryKey: boolean }} [options={}]
  * @returns {Promise<StoreFile[]>}
  */
 export async function fileInsert(sql, insert, options = {}) {
@@ -740,6 +745,7 @@ WHERE ${fileWhere(builder.where, "f.", { skipValidator: true })} ${wherePartial}
 /**
  * Query Builder for file
  * Note that nested limit and offset don't work yet.
+ *
  * @param {StoreFileQueryBuilder} [builder={}]
  * @returns {{
  *  exec: function(sql: Postgres): Promise<QueryResultStoreFile[]>,
@@ -795,8 +801,9 @@ ORDER BY ${fileOrderBy()}
  * NOTE: At the moment only intended for internal use by the generated queries!
  * Transform results from the query builder that adhere to the known structure
  * of 'file' and its relations.
+ *
  * @param {*[]} values
- * @param {StoreFileQueryBuilder=} builder
+ * @param {StoreFileQueryBuilder} [builder={}]
  */
 export function transformFile(values, builder = {}) {
   for (let i = 0; i < values.length; ++i) {

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -22,6 +22,7 @@ const fileGroupFieldSet = new Set([
 ]);
 /**
  * Get all fields for fileGroup
+ *
  * @param {string} [tableName="fg."]
  * @param {{ excludePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -41,6 +42,7 @@ export function fileGroupFields(tableName = "fg.", options = {}) {
 }
 /**
  * Get 'ORDER BY ' for fileGroup
+ *
  * @param {string} [tableName="fg."]
  * @returns {QueryPart}
  */
@@ -55,9 +57,10 @@ export function fileGroupOrderBy(tableName = "fg.") {
 }
 /**
  * Build 'WHERE ' part for fileGroup
+ *
  * @param {StoreFileGroupWhere} [where={}]
  * @param {string} [tableName="fg."]
- * @param {{ skipValidator?: boolean }=} options
+ * @param {{ skipValidator?: boolean|undefined }} [options={}]
  * @returns {QueryPart}
  */
 export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
@@ -449,6 +452,7 @@ export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
 }
 /**
  * Build 'VALUES ' part for fileGroup
+ *
  * @param {StoreFileGroupInsertPartial|StoreFileGroupInsertPartial[]} insert
  * @param {{ includePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -477,6 +481,7 @@ ${it.order ?? Math.floor(Date.now() / 1000000)}, ${it.file ?? null}, ${
 }
 /**
  * Build 'SET ' part for fileGroup
+ *
  * @param {StoreFileGroupUpdatePartial} update
  * @returns {QueryPart}
  */
@@ -573,7 +578,7 @@ WHERE ${fileGroupWhere(where)}
 /**
  * @param {Postgres} sql
  * @param {StoreFileGroupInsertPartial|(StoreFileGroupInsertPartial[])} insert
- * @param {{ withPrimaryKey: boolean }=} options
+ * @param {{ withPrimaryKey: boolean }} [options={}]
  * @returns {Promise<StoreFileGroup[]>}
  */
 export async function fileGroupInsert(sql, insert, options = {}) {
@@ -1075,6 +1080,7 @@ WHERE ${fileGroupWhere(builder.where, "fg.", {
 /**
  * Query Builder for fileGroup
  * Note that nested limit and offset don't work yet.
+ *
  * @param {StoreFileGroupQueryBuilder} [builder={}]
  * @returns {{
  *  exec: function(sql: Postgres): Promise<QueryResultStoreFileGroup[]>,
@@ -1136,8 +1142,9 @@ ORDER BY ${fileGroupOrderBy()}
  * NOTE: At the moment only intended for internal use by the generated queries!
  * Transform results from the query builder that adhere to the known structure
  * of 'fileGroup' and its relations.
+ *
  * @param {*[]} values
- * @param {StoreFileGroupQueryBuilder=} builder
+ * @param {StoreFileGroupQueryBuilder} [builder={}]
  */
 export function transformFileGroup(values, builder = {}) {
   for (let i = 0; i < values.length; ++i) {

--- a/packages/store/src/generated/database/fileGroupView.js
+++ b/packages/store/src/generated/database/fileGroupView.js
@@ -10,6 +10,7 @@ import {
 import { fileOrderBy, internalQueryFile, transformFile } from "./file.js";
 /**
  * Get all fields for fileGroupView
+ *
  * @param {string} [tableName="fgv."]
  * @param {{ excludePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -29,6 +30,7 @@ export function fileGroupViewFields(tableName = "fgv.", options = {}) {
 }
 /**
  * Get 'ORDER BY ' for fileGroupView
+ *
  * @param {string} [tableName="fgv."]
  * @returns {QueryPart}
  */
@@ -43,9 +45,10 @@ export function fileGroupViewOrderBy(tableName = "fgv.") {
 }
 /**
  * Build 'WHERE ' part for fileGroupView
+ *
  * @param {StoreFileGroupViewWhere} [where={}]
  * @param {string} [tableName="fgv."]
- * @param {{ skipValidator?: boolean }=} options
+ * @param {{ skipValidator?: boolean|undefined }} [options={}]
  * @returns {QueryPart}
  */
 export function fileGroupViewWhere(
@@ -941,6 +944,7 @@ WHERE ${fileGroupViewWhere(builder.where, "fgv.", {
 /**
  * Query Builder for fileGroupView
  * Note that nested limit and offset don't work yet.
+ *
  * @param {StoreFileGroupViewQueryBuilder} [builder={}]
  * @returns {{
  *  exec: function(sql: Postgres): Promise<QueryResultStoreFileGroupView[]>,
@@ -1002,8 +1006,9 @@ ORDER BY ${fileGroupViewOrderBy()}
  * NOTE: At the moment only intended for internal use by the generated queries!
  * Transform results from the query builder that adhere to the known structure
  * of 'fileGroupView' and its relations.
+ *
  * @param {*[]} values
- * @param {StoreFileGroupViewQueryBuilder=} builder
+ * @param {StoreFileGroupViewQueryBuilder} [builder={}]
  */
 export function transformFileGroupView(values, builder = {}) {
   for (let i = 0; i < values.length; ++i) {

--- a/packages/store/src/generated/database/job.js
+++ b/packages/store/src/generated/database/job.js
@@ -21,6 +21,7 @@ const jobFieldSet = new Set([
 ]);
 /**
  * Get all fields for job
+ *
  * @param {string} [tableName="j."]
  * @param {{ excludePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -40,6 +41,7 @@ export function jobFields(tableName = "j.", options = {}) {
 }
 /**
  * Get 'ORDER BY ' for job
+ *
  * @param {string} [tableName="j."]
  * @returns {QueryPart}
  */
@@ -54,9 +56,10 @@ export function jobOrderBy(tableName = "j.") {
 }
 /**
  * Build 'WHERE ' part for job
+ *
  * @param {StoreJobWhere} [where={}]
  * @param {string} [tableName="j."]
- * @param {{ skipValidator?: boolean }=} options
+ * @param {{ skipValidator?: boolean|undefined }} [options={}]
  * @returns {QueryPart}
  */
 export function jobWhere(where = {}, tableName = "j.", options = {}) {
@@ -397,6 +400,7 @@ export function jobWhere(where = {}, tableName = "j.", options = {}) {
 }
 /**
  * Build 'VALUES ' part for job
+ *
  * @param {StoreJobInsertPartial|StoreJobInsertPartial[]} insert
  * @param {{ includePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -425,6 +429,7 @@ ${it.isComplete ?? false}, ${it.priority ?? 0}, ${it.retryCount ?? 0}, ${
 }
 /**
  * Build 'SET ' part for job
+ *
  * @param {StoreJobUpdatePartial} update
  * @returns {QueryPart}
  */
@@ -520,7 +525,7 @@ WHERE ${jobWhere(where)}
 /**
  * @param {Postgres} sql
  * @param {StoreJobInsertPartial|(StoreJobInsertPartial[])} insert
- * @param {{ withPrimaryKey: boolean }=} options
+ * @param {{ withPrimaryKey: boolean }} [options={}]
  * @returns {Promise<StoreJob[]>}
  */
 export async function jobInsert(sql, insert, options = {}) {
@@ -573,6 +578,7 @@ WHERE ${jobWhere(builder.where, "j.", { skipValidator: true })} ${wherePartial}
 /**
  * Query Builder for job
  * Note that nested limit and offset don't work yet.
+ *
  * @param {StoreJobQueryBuilder} [builder={}]
  * @returns {{
  *  exec: function(sql: Postgres): Promise<QueryResultStoreJob[]>,
@@ -619,8 +625,9 @@ ORDER BY ${jobOrderBy()}
  * NOTE: At the moment only intended for internal use by the generated queries!
  * Transform results from the query builder that adhere to the known structure
  * of 'job' and its relations.
+ *
  * @param {*[]} values
- * @param {StoreJobQueryBuilder=} builder
+ * @param {StoreJobQueryBuilder} [builder={}]
  */
 export function transformJob(values, builder = {}) {
   for (let i = 0; i < values.length; ++i) {

--- a/packages/store/src/generated/database/session.js
+++ b/packages/store/src/generated/database/session.js
@@ -17,6 +17,7 @@ const sessionFieldSet = new Set([
 ]);
 /**
  * Get all fields for session
+ *
  * @param {string} [tableName="s."]
  * @param {{ excludePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -36,6 +37,7 @@ export function sessionFields(tableName = "s.", options = {}) {
 }
 /**
  * Get 'ORDER BY ' for session
+ *
  * @param {string} [tableName="s."]
  * @returns {QueryPart}
  */
@@ -50,9 +52,10 @@ export function sessionOrderBy(tableName = "s.") {
 }
 /**
  * Build 'WHERE ' part for session
+ *
  * @param {StoreSessionWhere} [where={}]
  * @param {string} [tableName="s."]
- * @param {{ skipValidator?: boolean }=} options
+ * @param {{ skipValidator?: boolean|undefined }} [options={}]
  * @returns {QueryPart}
  */
 export function sessionWhere(where = {}, tableName = "s.", options = {}) {
@@ -316,6 +319,7 @@ export function sessionWhere(where = {}, tableName = "s.", options = {}) {
 }
 /**
  * Build 'VALUES ' part for session
+ *
  * @param {StoreSessionInsertPartial|StoreSessionInsertPartial[]} insert
  * @param {{ includePrimaryKey: boolean }} [options={}]
  * @returns {QueryPart}
@@ -342,6 +346,7 @@ ${it.expires ?? null}, ${JSON.stringify(it.data ?? {})}, ${
 }
 /**
  * Build 'SET ' part for session
+ *
  * @param {StoreSessionUpdatePartial} update
  * @returns {QueryPart}
  */
@@ -421,7 +426,7 @@ WHERE ${sessionWhere(where)}
 /**
  * @param {Postgres} sql
  * @param {StoreSessionInsertPartial|(StoreSessionInsertPartial[])} insert
- * @param {{ withPrimaryKey: boolean }=} options
+ * @param {{ withPrimaryKey: boolean }} [options={}]
  * @returns {Promise<StoreSession[]>}
  */
 export async function sessionInsert(sql, insert, options = {}) {
@@ -478,6 +483,7 @@ WHERE ${sessionWhere(builder.where, "s.", {
 /**
  * Query Builder for session
  * Note that nested limit and offset don't work yet.
+ *
  * @param {StoreSessionQueryBuilder} [builder={}]
  * @returns {{
  *  exec: function(sql: Postgres): Promise<QueryResultStoreSession[]>,
@@ -524,8 +530,9 @@ ORDER BY ${sessionOrderBy()}
  * NOTE: At the moment only intended for internal use by the generated queries!
  * Transform results from the query builder that adhere to the known structure
  * of 'session' and its relations.
+ *
  * @param {*[]} values
- * @param {StoreSessionQueryBuilder=} builder
+ * @param {StoreSessionQueryBuilder} [builder={}]
  */
 export function transformSession(values, builder = {}) {
   for (let i = 0; i < values.length; ++i) {

--- a/packages/store/src/generated/types.js
+++ b/packages/store/src/generated/types.js
@@ -22,97 +22,99 @@ export const __generated__ = true;
  * @typedef import("@compas/store").Minio} Minio
  */
 /**
- * @typedef {{"bucketName": string, "contentLength": number, "contentType": string, "name": string, "meta": StoreFileMeta, "id": string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: Date, }} StoreFile
+ * @typedef {{"bucketName": string, "contentLength": number, "contentType": string, "name": string, "meta": StoreFileMeta, "id": string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: undefined|Date, }} StoreFile
  */
 /**
  * User definable, optional object to store whatever you want
+ *
  * @typedef {{}} StoreFileMeta
  */
 /**
- * @typedef {{"name"?: string, "order": number, "meta": StoreFileGroupMeta, "id": string, "file"?: string, "parent"?: string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: Date, }} StoreFileGroup
+ * @typedef {{"name"?: undefined|string, "order": number, "meta": StoreFileGroupMeta, "id": string, "file"?: undefined|string, "parent"?: undefined|string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: undefined|Date, }} StoreFileGroup
  */
 /**
  * User definable, optional object to store whatever you want
+ *
  * @typedef {StoreFileMeta} StoreFileGroupMeta
  */
 /**
- * @typedef {{"name"?: string, "order": number, "meta": StoreFileGroupMeta, "isDirectory": boolean, "id": string, "file"?: string, "parent"?: string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: Date, }} StoreFileGroupView
+ * @typedef {{"name"?: undefined|string, "order": number, "meta": StoreFileGroupMeta, "isDirectory": boolean, "id": string, "file"?: undefined|string, "parent"?: undefined|string, "createdAt": Date, "updatedAt": Date, "deletedAt"?: undefined|Date, }} StoreFileGroupView
  */
 /**
  * @typedef {{"id": number, "isComplete": boolean, "priority": number, "scheduledAt": Date, "name": string, "data": *, "retryCount": number, "createdAt": Date, "updatedAt": Date, }} StoreJob
  */
 /**
- * @typedef {{"years"?: number, "months"?: number, "days"?: number, "hours"?: number, "minutes"?: number, "seconds"?: number, }} StoreJobInterval
+ * @typedef {{"years"?: undefined|number, "months"?: undefined|number, "days"?: undefined|number, "hours"?: undefined|number, "minutes"?: undefined|number, "seconds"?: undefined|number, }} StoreJobInterval
  */
 /**
  * @typedef {{"expires": Date, "data": *, "id": string, "createdAt": Date, "updatedAt": Date, }} StoreSession
  */
 /**
- * @typedef {{"$raw"?: QueryPart, "$or"?: (StoreFileWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "bucketName"?: string, "bucketNameNotEqual"?: string, "bucketNameIn"?: (string)[]|QueryPart, "bucketNameNotIn"?: (string)[]|QueryPart, "bucketNameLike"?: string, "bucketNameILike"?: string, "bucketNameNotLike"?: string, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, "deletedAt"?: Date, "deletedAtNotEqual"?: Date, "deletedAtIn"?: (Date)[]|QueryPart, "deletedAtNotIn"?: (Date)[]|QueryPart, "deletedAtGreaterThan"?: Date, "deletedAtLowerThan"?: Date, "deletedAtIncludeNotNull"?: boolean, }} StoreFileWhere
+ * @typedef {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreFileWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "bucketName"?: undefined|string, "bucketNameNotEqual"?: undefined|string, "bucketNameIn"?: undefined|(string)[]|QueryPart, "bucketNameNotIn"?: undefined|(string)[]|QueryPart, "bucketNameLike"?: undefined|string, "bucketNameILike"?: undefined|string, "bucketNameNotLike"?: undefined|string, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, "deletedAt"?: undefined|Date, "deletedAtNotEqual"?: undefined|Date, "deletedAtIn"?: undefined|(Date)[]|QueryPart, "deletedAtNotIn"?: undefined|(Date)[]|QueryPart, "deletedAtGreaterThan"?: undefined|Date, "deletedAtLowerThan"?: undefined|Date, "deletedAtIncludeNotNull"?: undefined|boolean, }} StoreFileWhere
  */
 /**
- * @typedef {{"$raw"?: QueryPart, "$or"?: (StoreFileGroupWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "file"?: string, "fileNotEqual"?: string, "fileIn"?: (string)[]|QueryPart, "fileNotIn"?: (string)[]|QueryPart, "fileLike"?: string, "fileNotLike"?: string, "fileIsNull"?: boolean, "fileIsNotNull"?: boolean, "parent"?: string, "parentNotEqual"?: string, "parentIn"?: (string)[]|QueryPart, "parentNotIn"?: (string)[]|QueryPart, "parentLike"?: string, "parentNotLike"?: string, "parentIsNull"?: boolean, "parentIsNotNull"?: boolean, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, "deletedAt"?: Date, "deletedAtNotEqual"?: Date, "deletedAtIn"?: (Date)[]|QueryPart, "deletedAtNotIn"?: (Date)[]|QueryPart, "deletedAtGreaterThan"?: Date, "deletedAtLowerThan"?: Date, "deletedAtIncludeNotNull"?: boolean, }} StoreFileGroupWhere
+ * @typedef {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreFileGroupWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "file"?: undefined|string, "fileNotEqual"?: undefined|string, "fileIn"?: undefined|(string)[]|QueryPart, "fileNotIn"?: undefined|(string)[]|QueryPart, "fileLike"?: undefined|string, "fileNotLike"?: undefined|string, "fileIsNull"?: undefined|boolean, "fileIsNotNull"?: undefined|boolean, "parent"?: undefined|string, "parentNotEqual"?: undefined|string, "parentIn"?: undefined|(string)[]|QueryPart, "parentNotIn"?: undefined|(string)[]|QueryPart, "parentLike"?: undefined|string, "parentNotLike"?: undefined|string, "parentIsNull"?: undefined|boolean, "parentIsNotNull"?: undefined|boolean, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, "deletedAt"?: undefined|Date, "deletedAtNotEqual"?: undefined|Date, "deletedAtIn"?: undefined|(Date)[]|QueryPart, "deletedAtNotIn"?: undefined|(Date)[]|QueryPart, "deletedAtGreaterThan"?: undefined|Date, "deletedAtLowerThan"?: undefined|Date, "deletedAtIncludeNotNull"?: undefined|boolean, }} StoreFileGroupWhere
  */
 /**
- * @typedef {{"$raw"?: QueryPart, "$or"?: (StoreFileGroupViewWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "isDirectory"?: boolean, "file"?: string, "fileNotEqual"?: string, "fileIn"?: (string)[]|QueryPart, "fileNotIn"?: (string)[]|QueryPart, "fileLike"?: string, "fileNotLike"?: string, "fileIsNull"?: boolean, "fileIsNotNull"?: boolean, "parent"?: string, "parentNotEqual"?: string, "parentIn"?: (string)[]|QueryPart, "parentNotIn"?: (string)[]|QueryPart, "parentLike"?: string, "parentNotLike"?: string, "parentIsNull"?: boolean, "parentIsNotNull"?: boolean, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, "deletedAt"?: Date, "deletedAtNotEqual"?: Date, "deletedAtIn"?: (Date)[]|QueryPart, "deletedAtNotIn"?: (Date)[]|QueryPart, "deletedAtGreaterThan"?: Date, "deletedAtLowerThan"?: Date, "deletedAtIncludeNotNull"?: boolean, }} StoreFileGroupViewWhere
+ * @typedef {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreFileGroupViewWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "isDirectory"?: undefined|boolean, "file"?: undefined|string, "fileNotEqual"?: undefined|string, "fileIn"?: undefined|(string)[]|QueryPart, "fileNotIn"?: undefined|(string)[]|QueryPart, "fileLike"?: undefined|string, "fileNotLike"?: undefined|string, "fileIsNull"?: undefined|boolean, "fileIsNotNull"?: undefined|boolean, "parent"?: undefined|string, "parentNotEqual"?: undefined|string, "parentIn"?: undefined|(string)[]|QueryPart, "parentNotIn"?: undefined|(string)[]|QueryPart, "parentLike"?: undefined|string, "parentNotLike"?: undefined|string, "parentIsNull"?: undefined|boolean, "parentIsNotNull"?: undefined|boolean, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, "deletedAt"?: undefined|Date, "deletedAtNotEqual"?: undefined|Date, "deletedAtIn"?: undefined|(Date)[]|QueryPart, "deletedAtNotIn"?: undefined|(Date)[]|QueryPart, "deletedAtGreaterThan"?: undefined|Date, "deletedAtLowerThan"?: undefined|Date, "deletedAtIncludeNotNull"?: undefined|boolean, }} StoreFileGroupViewWhere
  */
 /**
- * @typedef {{"$raw"?: QueryPart, "$or"?: (StoreJobWhere)[], "id"?: number, "idNotEqual"?: number, "idIn"?: (number)[]|QueryPart, "idNotIn"?: (number)[]|QueryPart, "idGreaterThan"?: number, "idLowerThan"?: number, "isComplete"?: boolean, "isCompleteIsNull"?: boolean, "isCompleteIsNotNull"?: boolean, "name"?: string, "nameNotEqual"?: string, "nameIn"?: (string)[]|QueryPart, "nameNotIn"?: (string)[]|QueryPart, "nameLike"?: string, "nameILike"?: string, "nameNotLike"?: string, "scheduledAt"?: Date, "scheduledAtNotEqual"?: Date, "scheduledAtIn"?: (Date)[]|QueryPart, "scheduledAtNotIn"?: (Date)[]|QueryPart, "scheduledAtGreaterThan"?: Date, "scheduledAtLowerThan"?: Date, "scheduledAtIsNull"?: boolean, "scheduledAtIsNotNull"?: boolean, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, }} StoreJobWhere
+ * @typedef {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreJobWhere)[], "id"?: undefined|number, "idNotEqual"?: undefined|number, "idIn"?: undefined|(number)[]|QueryPart, "idNotIn"?: undefined|(number)[]|QueryPart, "idGreaterThan"?: undefined|number, "idLowerThan"?: undefined|number, "isComplete"?: undefined|boolean, "isCompleteIsNull"?: undefined|boolean, "isCompleteIsNotNull"?: undefined|boolean, "name"?: undefined|string, "nameNotEqual"?: undefined|string, "nameIn"?: undefined|(string)[]|QueryPart, "nameNotIn"?: undefined|(string)[]|QueryPart, "nameLike"?: undefined|string, "nameILike"?: undefined|string, "nameNotLike"?: undefined|string, "scheduledAt"?: undefined|Date, "scheduledAtNotEqual"?: undefined|Date, "scheduledAtIn"?: undefined|(Date)[]|QueryPart, "scheduledAtNotIn"?: undefined|(Date)[]|QueryPart, "scheduledAtGreaterThan"?: undefined|Date, "scheduledAtLowerThan"?: undefined|Date, "scheduledAtIsNull"?: undefined|boolean, "scheduledAtIsNotNull"?: undefined|boolean, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, }} StoreJobWhere
  */
 /**
- * @typedef {{"$raw"?: QueryPart, "$or"?: (StoreSessionWhere)[], "id"?: string, "idNotEqual"?: string, "idIn"?: (string)[]|QueryPart, "idNotIn"?: (string)[]|QueryPart, "idLike"?: string, "idNotLike"?: string, "expires"?: Date, "expiresNotEqual"?: Date, "expiresIn"?: (Date)[]|QueryPart, "expiresNotIn"?: (Date)[]|QueryPart, "expiresGreaterThan"?: Date, "expiresLowerThan"?: Date, "createdAt"?: Date, "createdAtNotEqual"?: Date, "createdAtIn"?: (Date)[]|QueryPart, "createdAtNotIn"?: (Date)[]|QueryPart, "createdAtGreaterThan"?: Date, "createdAtLowerThan"?: Date, "createdAtIsNull"?: boolean, "createdAtIsNotNull"?: boolean, "updatedAt"?: Date, "updatedAtNotEqual"?: Date, "updatedAtIn"?: (Date)[]|QueryPart, "updatedAtNotIn"?: (Date)[]|QueryPart, "updatedAtGreaterThan"?: Date, "updatedAtLowerThan"?: Date, "updatedAtIsNull"?: boolean, "updatedAtIsNotNull"?: boolean, }} StoreSessionWhere
+ * @typedef {{"$raw"?: undefined|QueryPart, "$or"?: undefined|(StoreSessionWhere)[], "id"?: undefined|string, "idNotEqual"?: undefined|string, "idIn"?: undefined|(string)[]|QueryPart, "idNotIn"?: undefined|(string)[]|QueryPart, "idLike"?: undefined|string, "idNotLike"?: undefined|string, "expires"?: undefined|Date, "expiresNotEqual"?: undefined|Date, "expiresIn"?: undefined|(Date)[]|QueryPart, "expiresNotIn"?: undefined|(Date)[]|QueryPart, "expiresGreaterThan"?: undefined|Date, "expiresLowerThan"?: undefined|Date, "createdAt"?: undefined|Date, "createdAtNotEqual"?: undefined|Date, "createdAtIn"?: undefined|(Date)[]|QueryPart, "createdAtNotIn"?: undefined|(Date)[]|QueryPart, "createdAtGreaterThan"?: undefined|Date, "createdAtLowerThan"?: undefined|Date, "createdAtIsNull"?: undefined|boolean, "createdAtIsNotNull"?: undefined|boolean, "updatedAt"?: undefined|Date, "updatedAtNotEqual"?: undefined|Date, "updatedAtIn"?: undefined|(Date)[]|QueryPart, "updatedAtNotIn"?: undefined|(Date)[]|QueryPart, "updatedAtGreaterThan"?: undefined|Date, "updatedAtLowerThan"?: undefined|Date, "updatedAtIsNull"?: undefined|boolean, "updatedAtIsNotNull"?: undefined|boolean, }} StoreSessionWhere
  */
 /**
- * @typedef {{"id"?: string, "contentLength": number, "bucketName": string, "contentType": string, "name": string, "meta"?: {}, "createdAt"?: Date, "updatedAt"?: Date, "deletedAt"?: Date, }} StoreFileInsertPartial
+ * @typedef {{"id"?: undefined|string, "contentLength": number, "bucketName": string, "contentType": string, "name": string, "meta"?: undefined|{}, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, "deletedAt"?: undefined|Date, }} StoreFileInsertPartial
  */
 /**
- * @typedef {{"contentLength"?: number, "bucketName"?: string, "contentType"?: string, "name"?: string, "meta"?: {}, "createdAt"?: Date, "updatedAt"?: Date, "deletedAt"?: null|Date, }} StoreFileUpdatePartial
+ * @typedef {{"contentLength"?: undefined|number, "bucketName"?: undefined|string, "contentType"?: undefined|string, "name"?: undefined|string, "meta"?: undefined|{}, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, "deletedAt"?: undefined|null|Date, }} StoreFileUpdatePartial
  */
 /**
- * @typedef {{"id"?: string, "order"?: number, "file"?: string, "parent"?: string, "name"?: string, "meta"?: {}, "createdAt"?: Date, "updatedAt"?: Date, "deletedAt"?: Date, }} StoreFileGroupInsertPartial
+ * @typedef {{"id"?: undefined|string, "order"?: undefined|number, "file"?: undefined|string, "parent"?: undefined|string, "name"?: undefined|string, "meta"?: undefined|{}, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, "deletedAt"?: undefined|Date, }} StoreFileGroupInsertPartial
  */
 /**
- * @typedef {{"order"?: number, "file"?: null|string, "parent"?: null|string, "name"?: null|string, "meta"?: {}, "createdAt"?: Date, "updatedAt"?: Date, "deletedAt"?: null|Date, }} StoreFileGroupUpdatePartial
+ * @typedef {{"order"?: undefined|number, "file"?: undefined|null|string, "parent"?: undefined|null|string, "name"?: undefined|null|string, "meta"?: undefined|{}, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, "deletedAt"?: undefined|null|Date, }} StoreFileGroupUpdatePartial
  */
 /**
- * @typedef {{"id"?: number, "isComplete"?: boolean, "priority"?: number, "retryCount"?: number, "name": string, "scheduledAt"?: Date, "data"?: *, "createdAt"?: Date, "updatedAt"?: Date, }} StoreJobInsertPartial
+ * @typedef {{"id"?: undefined|number, "isComplete"?: undefined|boolean, "priority"?: undefined|number, "retryCount"?: undefined|number, "name": string, "scheduledAt"?: undefined|Date, "data"?: undefined|*, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, }} StoreJobInsertPartial
  */
 /**
- * @typedef {{"isComplete"?: boolean, "priority"?: number, "retryCount"?: number, "name"?: string, "scheduledAt"?: Date, "data"?: *, "createdAt"?: Date, "updatedAt"?: Date, }} StoreJobUpdatePartial
+ * @typedef {{"isComplete"?: undefined|boolean, "priority"?: undefined|number, "retryCount"?: undefined|number, "name"?: undefined|string, "scheduledAt"?: undefined|Date, "data"?: undefined|*, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, }} StoreJobUpdatePartial
  */
 /**
- * @typedef {{"id"?: string, "expires": Date, "data"?: *, "createdAt"?: Date, "updatedAt"?: Date, }} StoreSessionInsertPartial
+ * @typedef {{"id"?: undefined|string, "expires": Date, "data"?: undefined|*, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, }} StoreSessionInsertPartial
  */
 /**
- * @typedef {{"expires"?: Date, "data"?: *, "createdAt"?: Date, "updatedAt"?: Date, }} StoreSessionUpdatePartial
+ * @typedef {{"expires"?: undefined|Date, "data"?: undefined|*, "createdAt"?: undefined|Date, "updatedAt"?: undefined|Date, }} StoreSessionUpdatePartial
  */
 /**
- * @typedef {{"where"?: StoreFileWhere, "as"?: string, "limit"?: number, "offset"?: number, "group"?: StoreFileGroupQueryBuilder, "viaGroup"?: StoreFileGroupQueryTraverser, "groupView"?: StoreFileGroupViewQueryBuilder, "viaGroupView"?: StoreFileGroupViewQueryTraverser, }} StoreFileQueryBuilder
+ * @typedef {{"where"?: undefined|StoreFileWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "group"?: undefined|StoreFileGroupQueryBuilder, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, "groupView"?: undefined|StoreFileGroupViewQueryBuilder, "viaGroupView"?: undefined|StoreFileGroupViewQueryTraverser, }} StoreFileQueryBuilder
  */
 /**
- * @typedef {{"where"?: StoreFileGroupWhere, "as"?: string, "limit"?: number, "offset"?: number, "file"?: StoreFileQueryBuilder, "viaFile"?: StoreFileQueryTraverser, "parent"?: StoreFileGroupQueryBuilder, "viaParent"?: StoreFileGroupQueryTraverser, "children"?: StoreFileGroupQueryBuilder, "viaChildren"?: StoreFileGroupQueryTraverser, }} StoreFileGroupQueryBuilder
+ * @typedef {{"where"?: undefined|StoreFileGroupWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "viaFile"?: undefined|StoreFileQueryTraverser, "parent"?: undefined|StoreFileGroupQueryBuilder, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "children"?: undefined|StoreFileGroupQueryBuilder, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }} StoreFileGroupQueryBuilder
  */
 /**
- * @typedef {{"where"?: StoreFileWhere, "limit"?: number, "offset"?: number, "viaGroup"?: StoreFileGroupQueryTraverser, "viaGroupView"?: StoreFileGroupViewQueryTraverser, }} StoreFileQueryTraverser
+ * @typedef {{"where"?: undefined|StoreFileWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, "viaGroupView"?: undefined|StoreFileGroupViewQueryTraverser, }} StoreFileQueryTraverser
  */
 /**
- * @typedef {{"where"?: StoreFileGroupWhere, "limit"?: number, "offset"?: number, "viaFile"?: StoreFileQueryTraverser, "viaParent"?: StoreFileGroupQueryTraverser, "viaChildren"?: StoreFileGroupQueryTraverser, }} StoreFileGroupQueryTraverser
+ * @typedef {{"where"?: undefined|StoreFileGroupWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaFile"?: undefined|StoreFileQueryTraverser, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }} StoreFileGroupQueryTraverser
  */
 /**
- * @typedef {{"where"?: StoreFileGroupViewWhere, "limit"?: number, "offset"?: number, "viaFile"?: StoreFileQueryTraverser, "viaParent"?: StoreFileGroupViewQueryTraverser, "viaChildren"?: StoreFileGroupViewQueryTraverser, }} StoreFileGroupViewQueryTraverser
+ * @typedef {{"where"?: undefined|StoreFileGroupViewWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaFile"?: undefined|StoreFileQueryTraverser, "viaParent"?: undefined|StoreFileGroupViewQueryTraverser, "viaChildren"?: undefined|StoreFileGroupViewQueryTraverser, }} StoreFileGroupViewQueryTraverser
  */
 /**
- * @typedef {{"where"?: StoreFileGroupViewWhere, "as"?: string, "limit"?: number, "offset"?: number, "file"?: StoreFileQueryBuilder, "viaFile"?: StoreFileQueryTraverser, "parent"?: StoreFileGroupViewQueryBuilder, "viaParent"?: StoreFileGroupViewQueryTraverser, "children"?: StoreFileGroupViewQueryBuilder, "viaChildren"?: StoreFileGroupViewQueryTraverser, }} StoreFileGroupViewQueryBuilder
+ * @typedef {{"where"?: undefined|StoreFileGroupViewWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "viaFile"?: undefined|StoreFileQueryTraverser, "parent"?: undefined|StoreFileGroupViewQueryBuilder, "viaParent"?: undefined|StoreFileGroupViewQueryTraverser, "children"?: undefined|StoreFileGroupViewQueryBuilder, "viaChildren"?: undefined|StoreFileGroupViewQueryTraverser, }} StoreFileGroupViewQueryBuilder
  */
 /**
- * @typedef {{"where"?: StoreJobWhere, "as"?: string, "limit"?: number, "offset"?: number, }} StoreJobQueryBuilder
+ * @typedef {{"where"?: undefined|StoreJobWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, }} StoreJobQueryBuilder
  */
 /**
- * @typedef {{"where"?: StoreJobWhere, "limit"?: number, "offset"?: number, }} StoreJobQueryTraverser
+ * @typedef {{"where"?: undefined|StoreJobWhere, "limit"?: undefined|number, "offset"?: undefined|number, }} StoreJobQueryTraverser
  */
 /**
- * @typedef {{"where"?: StoreSessionWhere, "as"?: string, "limit"?: number, "offset"?: number, }} StoreSessionQueryBuilder
+ * @typedef {{"where"?: undefined|StoreSessionWhere, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, }} StoreSessionQueryBuilder
  */
 /**
- * @typedef {{"where"?: StoreSessionWhere, "limit"?: number, "offset"?: number, }} StoreSessionQueryTraverser
+ * @typedef {{"where"?: undefined|StoreSessionWhere, "limit"?: undefined|number, "offset"?: undefined|number, }} StoreSessionQueryTraverser
  */

--- a/packages/store/src/generated/validators.js
+++ b/packages/store/src/generated/validators.js
@@ -44,6 +44,7 @@ export function validateStoreFileGroup(value, propertyPath = "$") {
 }
 /**
  * User definable, optional object to store whatever you want
+ *
  * @param {undefined|*} value
  * @param {string|undefined} [propertyPath]
  * @returns {StoreFileGroupMeta}
@@ -61,6 +62,7 @@ export function validateStoreFileGroupView(value, propertyPath = "$") {
 }
 /**
  * User definable, optional object to store whatever you want
+ *
  * @param {undefined|*} value
  * @param {string|undefined} [propertyPath]
  * @returns {StoreFileMeta}

--- a/packages/store/src/queue.js
+++ b/packages/store/src/queue.js
@@ -353,9 +353,7 @@ export async function addJobToQueue(sql, job) {
  * @since 0.1.0
  *
  * @param {Postgres} sql
- * @param {string} name
- * @param {number} [priority]
- * @param {StoreJobInterval} interval
+ * @param {{ name: string, priority?: number|undefined, interval: StoreJobInterval }} job
  * @returns {Promise<void>}
  */
 export async function addRecurringJobToQueue(
@@ -492,6 +490,7 @@ export async function handleCompasRecurring(event, sql, job) {
 
 /**
  * Adds the interval to the provided scheduledAt date
+ *
  * @param {Date} scheduledAt
  * @param {StoreJobInterval} interval
  * @returns {Date}

--- a/packages/store/src/testing.js
+++ b/packages/store/src/testing.js
@@ -9,6 +9,7 @@ import {
 
 /**
  * If set, new databases are derived from this database
+ *
  * @type {undefined}
  */
 let testDatabase = undefined;

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -37,6 +37,7 @@ async function main(logger) {
 /**
  * Uses `git log` to quickly get the first commit line of all commits since the provided
  * version
+ *
  * @param {Logger} logger
  * @param {string} version
  * @returns {Promise<string[]>}
@@ -61,6 +62,7 @@ async function getListOfCommitsSinceTag(logger, version) {
 
 /**
  * Get changelog header including front matter
+ *
  * @param {string} changelog
  * @returns {{ header: string, source: string }}
  */
@@ -76,6 +78,7 @@ function getChangelogHeaderAndSource(changelog) {
 
 /**
  * Remove initial changelog contents, including the already existing 'unreleased' part
+ *
  * @param {string} changelog
  * @returns {string}
  */
@@ -94,6 +97,7 @@ function stripChangelogOfUnreleased(changelog) {
 /**
  * Tries to combine the dependency bump commits
  * Resorts before returning the new array
+ *
  * @param {string[]} commits
  * @returns {string[]}
  */
@@ -189,6 +193,7 @@ function makeChangelog(logger, commits) {
 
 /**
  * Basic semver check, does not work for all cases
+ *
  * @param first
  * @param second
  */

--- a/test/repo/code-gen.test.js
+++ b/test/repo/code-gen.test.js
@@ -49,6 +49,7 @@ test("repo/code-gen", async (t) => {
 
 /**
  * Quick hack to count the amount of exports in a file
+ *
  * @param {string} input
  * @returns {number}
  */
@@ -105,6 +106,7 @@ async function getGeneratedFileMap(fileFilter) {
 /**
  * Traverser the generated/testing output directory to read the necessary files and count
  * the number of exports.
+ *
  * @param {string[]} fileFilter
  * @returns {Object<string, number>}
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,6 +1819,11 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+comment-parser@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.1.2.tgz#e5317d7a2ec22b470dcb54a29b25426c30bf39d8"
+  integrity sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==
+
 compare-func@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/compare-func/-/compare-func-2.0.0.tgz#fb65e75edbddfd2e568554e8b5b05fff7a51fcb3"
@@ -2105,6 +2110,13 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
   integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
 
@@ -2467,6 +2479,19 @@ eslint-plugin-import@2.22.1:
     read-pkg-up "^2.0.0"
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
+
+eslint-plugin-jsdoc@32.1.0:
+  version "32.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.1.0.tgz#30ba4d7b7e5fa00ebb3b980c66d6478f68ccc226"
+  integrity sha512-nCdKF8QQvAZ6RsnNoEK4kPF0aD9E6XURdjLx88oIqF+txmPNXAo2rNvu2WwV77R78vnhAGJkeOgmxmYdRRpgaQ==
+  dependencies:
+    comment-parser "1.1.2"
+    debug "^4.3.1"
+    jsdoctypeparser "^9.0.0"
+    lodash "^4.17.20"
+    regextras "^0.7.1"
+    semver "^7.3.4"
+    spdx-expression-parse "^3.0.1"
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -3754,6 +3779,11 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
+jsdoctypeparser@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz#8c97e2fb69315eb274b0f01377eaa5c940bd7b26"
+  integrity sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -4117,6 +4147,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 macos-release@^2.2.0:
   version "2.4.1"
@@ -5411,6 +5448,11 @@ regexpp@^3.1.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
 
+regextras@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/regextras/-/regextras-0.7.1.tgz#be95719d5f43f9ef0b9fa07ad89b7c606995a3b2"
+  integrity sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==
+
 remove-accents@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
@@ -5596,6 +5638,13 @@ semver@^7.2.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -5778,7 +5827,7 @@ spdx-exceptions@^2.1.0:
   resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
   integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
-spdx-expression-parse@^3.0.0:
+spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
   integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
@@ -6603,6 +6652,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^15.0.1:
   version "15.0.1"


### PR DESCRIPTION
This is currently mostly stylish linting, will enforce proper types and stuff later.

The JSDoc linting is currently only enabled in with `CI=true`, since it is slow.

References #568