### PR TITLE
feat(code-gen): expose baseKeys for generated hooks

### DIFF
--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -81,6 +81,12 @@ options: UseQueryOptions<{{= responseType }}, AppErrorResponse> = {},
 
 ((newline))
 /**
+ * Base key used by {{= funcName }}.queryKey()
+ */
+{{= funcName }}.baseKey = (): QueryKey => "{{= item.uniqueName }}";
+
+((newline))
+/**
  * Query key used by {{= funcName }}
  */
 {{= funcName }}.queryKey = function(
@@ -95,7 +101,7 @@ body: T.{{= getTypeNameForType(item.body.reference, typeSuffix.apiInput, { useDe
 {{ } }}
 ): QueryKey {
   return [
-      "{{= item.uniqueName }}",
+      {{= funcName }}.baseKey(),
      {{ if (item.params) { }}
      params,
      {{ } }}


### PR DESCRIPTION
This allows operations on queries with less exact predicates. This is useful, for example, when the exact query parameters aren't directly accessible inside components.

E.g.

```
queryClient.invalidateQueries([useSellerSignupOrderSummary.baseKey]);
```

See https://react-query.tanstack.com/guides/query-invalidation for more examples