### PR TITLE
feat(cli): support `--jsdoc` flag on `compas lint`

### DIFF
--- a/packages/cli/scripts/lint.js
+++ b/packages/cli/scripts/lint.js
@@ -1,12 +1,22 @@
 import { mainFn, spawn, environment } from "@compas/stdlib";
 
 mainFn(import.meta, async () => {
-  const { exitCode: lint } = await spawn("./node_modules/.bin/eslint", [
-    "./**/*.js",
-    "--ignore-pattern",
-    "node_modules",
-    "--fix",
-  ]);
+  const [arg] = process.argv.slice(2);
+  const jsdocEnabled = arg === "--jsdoc";
+  const eslintOptions = jsdocEnabled
+    ? {
+        env: {
+          ...environment,
+          LINT_JSDOC: true,
+        },
+      }
+    : {};
+
+  const { exitCode: lint } = await spawn(
+    "./node_modules/.bin/eslint",
+    ["./**/*.js", "--ignore-pattern", "node_modules", "--fix"],
+    eslintOptions,
+  );
 
   const prettierCommand =
     environment.CI === "true" ? ["--check"] : ["--write", "--list-different"];

--- a/packages/cli/src/commands/lint.js
+++ b/packages/cli/src/commands/lint.js
@@ -17,7 +17,7 @@ export function lintCommand(logger, command) {
     command.verbose,
     command.watch,
     "node",
-    [...command.nodeArguments, lintFile],
+    [...command.nodeArguments, lintFile, ...command.execArguments],
     {},
   );
 }

--- a/packages/lint-config/index.js
+++ b/packages/lint-config/index.js
@@ -93,7 +93,7 @@ const jsdocSettings = {
  * @type {object} Eslint settings
  */
 module.exports =
-  process.env.CI === "true"
+  process.env.CI === "true" || process.env.LINT_JSDOC === "true"
     ? {
         ...settings,
         ...jsdocSettings,


### PR DESCRIPTION
This enables the JSDoc ESLint rules