### PR TITLE
fix(code-gen): fix empty where xxIn behaviour in the sql generator

### DIFF
--- a/packages/code-gen/src/generator/sql/where-type.js
+++ b/packages/code-gen/src/generator/sql/where-type.js
@@ -209,17 +209,16 @@ export function getWherePartial(context, type) {
             if (isQueryPart(where.${field.name})) {
               strings.push(\` AND $\{tableName}"${field.key}" = ANY(\`, ")");
               values.push(where.${field.name}, undefined);
-            } else if (Array.isArray(where.${field.name}) && where.${field.name}.length > 0) {
+            } else if (Array.isArray(where.${field.name})) {
               strings.push(\` AND $\{tableName}"${field.key}" = ANY(ARRAY[\`);
               for (let i = 0; i < where.${field.name}.length; ++i) {
                 values.push(where.${field.name}[i]);
-                if (i === where.${field.name}.length - 1) {
-                  strings.push("]::${fieldType}[])");
-                  values.push(undefined);
-                } else {
+                if (i !== where.${field.name}.length - 1) {
                   strings.push(", ");
                 }
               }
+              strings.push("]::${fieldType}[])");
+              values.push(undefined);
             }
           `;
           break;
@@ -228,17 +227,16 @@ export function getWherePartial(context, type) {
             if (isQueryPart(where.${field.name})) {
               strings.push(\` AND $\{tableName}"${field.key}" != ANY(\`, ")");
               values.push(where.${field.name}, undefined);
-            } else if (Array.isArray(where.${field.name}) && where.${field.name}.length > 0) {
+            } else if (Array.isArray(where.${field.name})) {
               strings.push(\` AND $\{tableName}"${field.key}" != ANY(ARRAY[\`);
               for (let i = 0; i < where.${field.name}.length; ++i) {
                 values.push(where.${field.name}[i]);
-                if (i === where.${field.name}.length - 1) {
-                  strings.push("]::${fieldType}[])");
-                  values.push(undefined);
-                } else {
+                if (i !== where.${field.name}.length - 1) {
                   strings.push(", ");
                 }
               }
+              strings.push("]::${fieldType}[])");
+              values.push(undefined);
             }
           `;
           break;

--- a/packages/code-gen/test/sql.test.js
+++ b/packages/code-gen/test/sql.test.js
@@ -206,6 +206,14 @@ test("code-gen/e2e/sql", async (t) => {
     t.equal(dbUser.email, "test@test.com");
   });
 
+  t.test("query filter with empty idIn", async (t) => {
+    const categories = await client.queries.categorySelect(sql, {
+      idIn: [],
+    });
+
+    t.equal(categories.length, 0);
+  });
+
   t.test("query same 'shortName' originally", async () => {
     await client
       .queryUser({

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -97,34 +97,32 @@ export function fileWhere(where = {}, tableName = "f.", options = {}) {
     if (isQueryPart(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(`, ")");
       values.push(where.idIn, undefined);
-    } else if (Array.isArray(where.idIn) && where.idIn.length > 0) {
+    } else if (Array.isArray(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(ARRAY[`);
       for (let i = 0; i < where.idIn.length; ++i) {
         values.push(where.idIn[i]);
-        if (i === where.idIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idNotIn !== undefined) {
     if (isQueryPart(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(`, ")");
       values.push(where.idNotIn, undefined);
-    } else if (Array.isArray(where.idNotIn) && where.idNotIn.length > 0) {
+    } else if (Array.isArray(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(ARRAY[`);
       for (let i = 0; i < where.idNotIn.length; ++i) {
         values.push(where.idNotIn[i]);
-        if (i === where.idNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idLike !== undefined) {
@@ -147,40 +145,32 @@ export function fileWhere(where = {}, tableName = "f.", options = {}) {
     if (isQueryPart(where.bucketNameIn)) {
       strings.push(` AND ${tableName}"bucketName" = ANY(`, ")");
       values.push(where.bucketNameIn, undefined);
-    } else if (
-      Array.isArray(where.bucketNameIn) &&
-      where.bucketNameIn.length > 0
-    ) {
+    } else if (Array.isArray(where.bucketNameIn)) {
       strings.push(` AND ${tableName}"bucketName" = ANY(ARRAY[`);
       for (let i = 0; i < where.bucketNameIn.length; ++i) {
         values.push(where.bucketNameIn[i]);
-        if (i === where.bucketNameIn.length - 1) {
-          strings.push("]::varchar[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.bucketNameIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::varchar[])");
+      values.push(undefined);
     }
   }
   if (where.bucketNameNotIn !== undefined) {
     if (isQueryPart(where.bucketNameNotIn)) {
       strings.push(` AND ${tableName}"bucketName" != ANY(`, ")");
       values.push(where.bucketNameNotIn, undefined);
-    } else if (
-      Array.isArray(where.bucketNameNotIn) &&
-      where.bucketNameNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.bucketNameNotIn)) {
       strings.push(` AND ${tableName}"bucketName" != ANY(ARRAY[`);
       for (let i = 0; i < where.bucketNameNotIn.length; ++i) {
         values.push(where.bucketNameNotIn[i]);
-        if (i === where.bucketNameNotIn.length - 1) {
-          strings.push("]::varchar[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.bucketNameNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::varchar[])");
+      values.push(undefined);
     }
   }
   if (where.bucketNameLike !== undefined) {
@@ -207,40 +197,32 @@ export function fileWhere(where = {}, tableName = "f.", options = {}) {
     if (isQueryPart(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(`, ")");
       values.push(where.createdAtIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtIn) &&
-      where.createdAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtIn.length; ++i) {
         values.push(where.createdAtIn[i]);
-        if (i === where.createdAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtNotIn !== undefined) {
     if (isQueryPart(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(`, ")");
       values.push(where.createdAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtNotIn) &&
-      where.createdAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtNotIn.length; ++i) {
         values.push(where.createdAtNotIn[i]);
-        if (i === where.createdAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtGreaterThan !== undefined) {
@@ -271,40 +253,32 @@ export function fileWhere(where = {}, tableName = "f.", options = {}) {
     if (isQueryPart(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(`, ")");
       values.push(where.updatedAtIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtIn) &&
-      where.updatedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtIn.length; ++i) {
         values.push(where.updatedAtIn[i]);
-        if (i === where.updatedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtNotIn !== undefined) {
     if (isQueryPart(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(`, ")");
       values.push(where.updatedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtNotIn) &&
-      where.updatedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtNotIn.length; ++i) {
         values.push(where.updatedAtNotIn[i]);
-        if (i === where.updatedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtGreaterThan !== undefined) {
@@ -335,40 +309,32 @@ export function fileWhere(where = {}, tableName = "f.", options = {}) {
     if (isQueryPart(where.deletedAtIn)) {
       strings.push(` AND ${tableName}"deletedAt" = ANY(`, ")");
       values.push(where.deletedAtIn, undefined);
-    } else if (
-      Array.isArray(where.deletedAtIn) &&
-      where.deletedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.deletedAtIn)) {
       strings.push(` AND ${tableName}"deletedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.deletedAtIn.length; ++i) {
         values.push(where.deletedAtIn[i]);
-        if (i === where.deletedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.deletedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.deletedAtNotIn !== undefined) {
     if (isQueryPart(where.deletedAtNotIn)) {
       strings.push(` AND ${tableName}"deletedAt" != ANY(`, ")");
       values.push(where.deletedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.deletedAtNotIn) &&
-      where.deletedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.deletedAtNotIn)) {
       strings.push(` AND ${tableName}"deletedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.deletedAtNotIn.length; ++i) {
         values.push(where.deletedAtNotIn[i]);
-        if (i === where.deletedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.deletedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.deletedAtGreaterThan !== undefined) {

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -87,34 +87,32 @@ export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
     if (isQueryPart(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(`, ")");
       values.push(where.idIn, undefined);
-    } else if (Array.isArray(where.idIn) && where.idIn.length > 0) {
+    } else if (Array.isArray(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(ARRAY[`);
       for (let i = 0; i < where.idIn.length; ++i) {
         values.push(where.idIn[i]);
-        if (i === where.idIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idNotIn !== undefined) {
     if (isQueryPart(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(`, ")");
       values.push(where.idNotIn, undefined);
-    } else if (Array.isArray(where.idNotIn) && where.idNotIn.length > 0) {
+    } else if (Array.isArray(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(ARRAY[`);
       for (let i = 0; i < where.idNotIn.length; ++i) {
         values.push(where.idNotIn[i]);
-        if (i === where.idNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idLike !== undefined) {
@@ -137,34 +135,32 @@ export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
     if (isQueryPart(where.fileIn)) {
       strings.push(` AND ${tableName}"file" = ANY(`, ")");
       values.push(where.fileIn, undefined);
-    } else if (Array.isArray(where.fileIn) && where.fileIn.length > 0) {
+    } else if (Array.isArray(where.fileIn)) {
       strings.push(` AND ${tableName}"file" = ANY(ARRAY[`);
       for (let i = 0; i < where.fileIn.length; ++i) {
         values.push(where.fileIn[i]);
-        if (i === where.fileIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.fileIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.fileNotIn !== undefined) {
     if (isQueryPart(where.fileNotIn)) {
       strings.push(` AND ${tableName}"file" != ANY(`, ")");
       values.push(where.fileNotIn, undefined);
-    } else if (Array.isArray(where.fileNotIn) && where.fileNotIn.length > 0) {
+    } else if (Array.isArray(where.fileNotIn)) {
       strings.push(` AND ${tableName}"file" != ANY(ARRAY[`);
       for (let i = 0; i < where.fileNotIn.length; ++i) {
         values.push(where.fileNotIn[i]);
-        if (i === where.fileNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.fileNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.fileLike !== undefined) {
@@ -195,37 +191,32 @@ export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
     if (isQueryPart(where.parentIn)) {
       strings.push(` AND ${tableName}"parent" = ANY(`, ")");
       values.push(where.parentIn, undefined);
-    } else if (Array.isArray(where.parentIn) && where.parentIn.length > 0) {
+    } else if (Array.isArray(where.parentIn)) {
       strings.push(` AND ${tableName}"parent" = ANY(ARRAY[`);
       for (let i = 0; i < where.parentIn.length; ++i) {
         values.push(where.parentIn[i]);
-        if (i === where.parentIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.parentIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.parentNotIn !== undefined) {
     if (isQueryPart(where.parentNotIn)) {
       strings.push(` AND ${tableName}"parent" != ANY(`, ")");
       values.push(where.parentNotIn, undefined);
-    } else if (
-      Array.isArray(where.parentNotIn) &&
-      where.parentNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.parentNotIn)) {
       strings.push(` AND ${tableName}"parent" != ANY(ARRAY[`);
       for (let i = 0; i < where.parentNotIn.length; ++i) {
         values.push(where.parentNotIn[i]);
-        if (i === where.parentNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.parentNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.parentLike !== undefined) {
@@ -256,40 +247,32 @@ export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
     if (isQueryPart(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(`, ")");
       values.push(where.createdAtIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtIn) &&
-      where.createdAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtIn.length; ++i) {
         values.push(where.createdAtIn[i]);
-        if (i === where.createdAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtNotIn !== undefined) {
     if (isQueryPart(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(`, ")");
       values.push(where.createdAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtNotIn) &&
-      where.createdAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtNotIn.length; ++i) {
         values.push(where.createdAtNotIn[i]);
-        if (i === where.createdAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtGreaterThan !== undefined) {
@@ -320,40 +303,32 @@ export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
     if (isQueryPart(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(`, ")");
       values.push(where.updatedAtIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtIn) &&
-      where.updatedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtIn.length; ++i) {
         values.push(where.updatedAtIn[i]);
-        if (i === where.updatedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtNotIn !== undefined) {
     if (isQueryPart(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(`, ")");
       values.push(where.updatedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtNotIn) &&
-      where.updatedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtNotIn.length; ++i) {
         values.push(where.updatedAtNotIn[i]);
-        if (i === where.updatedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtGreaterThan !== undefined) {
@@ -384,40 +359,32 @@ export function fileGroupWhere(where = {}, tableName = "fg.", options = {}) {
     if (isQueryPart(where.deletedAtIn)) {
       strings.push(` AND ${tableName}"deletedAt" = ANY(`, ")");
       values.push(where.deletedAtIn, undefined);
-    } else if (
-      Array.isArray(where.deletedAtIn) &&
-      where.deletedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.deletedAtIn)) {
       strings.push(` AND ${tableName}"deletedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.deletedAtIn.length; ++i) {
         values.push(where.deletedAtIn[i]);
-        if (i === where.deletedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.deletedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.deletedAtNotIn !== undefined) {
     if (isQueryPart(where.deletedAtNotIn)) {
       strings.push(` AND ${tableName}"deletedAt" != ANY(`, ")");
       values.push(where.deletedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.deletedAtNotIn) &&
-      where.deletedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.deletedAtNotIn)) {
       strings.push(` AND ${tableName}"deletedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.deletedAtNotIn.length; ++i) {
         values.push(where.deletedAtNotIn[i]);
-        if (i === where.deletedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.deletedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.deletedAtGreaterThan !== undefined) {

--- a/packages/store/src/generated/database/fileGroupView.js
+++ b/packages/store/src/generated/database/fileGroupView.js
@@ -79,34 +79,32 @@ export function fileGroupViewWhere(
     if (isQueryPart(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(`, ")");
       values.push(where.idIn, undefined);
-    } else if (Array.isArray(where.idIn) && where.idIn.length > 0) {
+    } else if (Array.isArray(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(ARRAY[`);
       for (let i = 0; i < where.idIn.length; ++i) {
         values.push(where.idIn[i]);
-        if (i === where.idIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idNotIn !== undefined) {
     if (isQueryPart(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(`, ")");
       values.push(where.idNotIn, undefined);
-    } else if (Array.isArray(where.idNotIn) && where.idNotIn.length > 0) {
+    } else if (Array.isArray(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(ARRAY[`);
       for (let i = 0; i < where.idNotIn.length; ++i) {
         values.push(where.idNotIn[i]);
-        if (i === where.idNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idLike !== undefined) {
@@ -133,34 +131,32 @@ export function fileGroupViewWhere(
     if (isQueryPart(where.fileIn)) {
       strings.push(` AND ${tableName}"file" = ANY(`, ")");
       values.push(where.fileIn, undefined);
-    } else if (Array.isArray(where.fileIn) && where.fileIn.length > 0) {
+    } else if (Array.isArray(where.fileIn)) {
       strings.push(` AND ${tableName}"file" = ANY(ARRAY[`);
       for (let i = 0; i < where.fileIn.length; ++i) {
         values.push(where.fileIn[i]);
-        if (i === where.fileIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.fileIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.fileNotIn !== undefined) {
     if (isQueryPart(where.fileNotIn)) {
       strings.push(` AND ${tableName}"file" != ANY(`, ")");
       values.push(where.fileNotIn, undefined);
-    } else if (Array.isArray(where.fileNotIn) && where.fileNotIn.length > 0) {
+    } else if (Array.isArray(where.fileNotIn)) {
       strings.push(` AND ${tableName}"file" != ANY(ARRAY[`);
       for (let i = 0; i < where.fileNotIn.length; ++i) {
         values.push(where.fileNotIn[i]);
-        if (i === where.fileNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.fileNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.fileLike !== undefined) {
@@ -191,37 +187,32 @@ export function fileGroupViewWhere(
     if (isQueryPart(where.parentIn)) {
       strings.push(` AND ${tableName}"parent" = ANY(`, ")");
       values.push(where.parentIn, undefined);
-    } else if (Array.isArray(where.parentIn) && where.parentIn.length > 0) {
+    } else if (Array.isArray(where.parentIn)) {
       strings.push(` AND ${tableName}"parent" = ANY(ARRAY[`);
       for (let i = 0; i < where.parentIn.length; ++i) {
         values.push(where.parentIn[i]);
-        if (i === where.parentIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.parentIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.parentNotIn !== undefined) {
     if (isQueryPart(where.parentNotIn)) {
       strings.push(` AND ${tableName}"parent" != ANY(`, ")");
       values.push(where.parentNotIn, undefined);
-    } else if (
-      Array.isArray(where.parentNotIn) &&
-      where.parentNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.parentNotIn)) {
       strings.push(` AND ${tableName}"parent" != ANY(ARRAY[`);
       for (let i = 0; i < where.parentNotIn.length; ++i) {
         values.push(where.parentNotIn[i]);
-        if (i === where.parentNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.parentNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.parentLike !== undefined) {
@@ -252,40 +243,32 @@ export function fileGroupViewWhere(
     if (isQueryPart(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(`, ")");
       values.push(where.createdAtIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtIn) &&
-      where.createdAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtIn.length; ++i) {
         values.push(where.createdAtIn[i]);
-        if (i === where.createdAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtNotIn !== undefined) {
     if (isQueryPart(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(`, ")");
       values.push(where.createdAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtNotIn) &&
-      where.createdAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtNotIn.length; ++i) {
         values.push(where.createdAtNotIn[i]);
-        if (i === where.createdAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtGreaterThan !== undefined) {
@@ -316,40 +299,32 @@ export function fileGroupViewWhere(
     if (isQueryPart(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(`, ")");
       values.push(where.updatedAtIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtIn) &&
-      where.updatedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtIn.length; ++i) {
         values.push(where.updatedAtIn[i]);
-        if (i === where.updatedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtNotIn !== undefined) {
     if (isQueryPart(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(`, ")");
       values.push(where.updatedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtNotIn) &&
-      where.updatedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtNotIn.length; ++i) {
         values.push(where.updatedAtNotIn[i]);
-        if (i === where.updatedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtGreaterThan !== undefined) {
@@ -380,40 +355,32 @@ export function fileGroupViewWhere(
     if (isQueryPart(where.deletedAtIn)) {
       strings.push(` AND ${tableName}"deletedAt" = ANY(`, ")");
       values.push(where.deletedAtIn, undefined);
-    } else if (
-      Array.isArray(where.deletedAtIn) &&
-      where.deletedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.deletedAtIn)) {
       strings.push(` AND ${tableName}"deletedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.deletedAtIn.length; ++i) {
         values.push(where.deletedAtIn[i]);
-        if (i === where.deletedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.deletedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.deletedAtNotIn !== undefined) {
     if (isQueryPart(where.deletedAtNotIn)) {
       strings.push(` AND ${tableName}"deletedAt" != ANY(`, ")");
       values.push(where.deletedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.deletedAtNotIn) &&
-      where.deletedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.deletedAtNotIn)) {
       strings.push(` AND ${tableName}"deletedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.deletedAtNotIn.length; ++i) {
         values.push(where.deletedAtNotIn[i]);
-        if (i === where.deletedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.deletedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.deletedAtGreaterThan !== undefined) {

--- a/packages/store/src/generated/database/job.js
+++ b/packages/store/src/generated/database/job.js
@@ -86,34 +86,32 @@ export function jobWhere(where = {}, tableName = "j.", options = {}) {
     if (isQueryPart(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(`, ")");
       values.push(where.idIn, undefined);
-    } else if (Array.isArray(where.idIn) && where.idIn.length > 0) {
+    } else if (Array.isArray(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(ARRAY[`);
       for (let i = 0; i < where.idIn.length; ++i) {
         values.push(where.idIn[i]);
-        if (i === where.idIn.length - 1) {
-          strings.push("]::int[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::int[])");
+      values.push(undefined);
     }
   }
   if (where.idNotIn !== undefined) {
     if (isQueryPart(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(`, ")");
       values.push(where.idNotIn, undefined);
-    } else if (Array.isArray(where.idNotIn) && where.idNotIn.length > 0) {
+    } else if (Array.isArray(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(ARRAY[`);
       for (let i = 0; i < where.idNotIn.length; ++i) {
         values.push(where.idNotIn[i]);
-        if (i === where.idNotIn.length - 1) {
-          strings.push("]::int[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::int[])");
+      values.push(undefined);
     }
   }
   if (where.idGreaterThan !== undefined) {
@@ -148,34 +146,32 @@ export function jobWhere(where = {}, tableName = "j.", options = {}) {
     if (isQueryPart(where.nameIn)) {
       strings.push(` AND ${tableName}"name" = ANY(`, ")");
       values.push(where.nameIn, undefined);
-    } else if (Array.isArray(where.nameIn) && where.nameIn.length > 0) {
+    } else if (Array.isArray(where.nameIn)) {
       strings.push(` AND ${tableName}"name" = ANY(ARRAY[`);
       for (let i = 0; i < where.nameIn.length; ++i) {
         values.push(where.nameIn[i]);
-        if (i === where.nameIn.length - 1) {
-          strings.push("]::varchar[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.nameIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::varchar[])");
+      values.push(undefined);
     }
   }
   if (where.nameNotIn !== undefined) {
     if (isQueryPart(where.nameNotIn)) {
       strings.push(` AND ${tableName}"name" != ANY(`, ")");
       values.push(where.nameNotIn, undefined);
-    } else if (Array.isArray(where.nameNotIn) && where.nameNotIn.length > 0) {
+    } else if (Array.isArray(where.nameNotIn)) {
       strings.push(` AND ${tableName}"name" != ANY(ARRAY[`);
       for (let i = 0; i < where.nameNotIn.length; ++i) {
         values.push(where.nameNotIn[i]);
-        if (i === where.nameNotIn.length - 1) {
-          strings.push("]::varchar[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.nameNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::varchar[])");
+      values.push(undefined);
     }
   }
   if (where.nameLike !== undefined) {
@@ -202,40 +198,32 @@ export function jobWhere(where = {}, tableName = "j.", options = {}) {
     if (isQueryPart(where.scheduledAtIn)) {
       strings.push(` AND ${tableName}"scheduledAt" = ANY(`, ")");
       values.push(where.scheduledAtIn, undefined);
-    } else if (
-      Array.isArray(where.scheduledAtIn) &&
-      where.scheduledAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.scheduledAtIn)) {
       strings.push(` AND ${tableName}"scheduledAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.scheduledAtIn.length; ++i) {
         values.push(where.scheduledAtIn[i]);
-        if (i === where.scheduledAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.scheduledAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.scheduledAtNotIn !== undefined) {
     if (isQueryPart(where.scheduledAtNotIn)) {
       strings.push(` AND ${tableName}"scheduledAt" != ANY(`, ")");
       values.push(where.scheduledAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.scheduledAtNotIn) &&
-      where.scheduledAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.scheduledAtNotIn)) {
       strings.push(` AND ${tableName}"scheduledAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.scheduledAtNotIn.length; ++i) {
         values.push(where.scheduledAtNotIn[i]);
-        if (i === where.scheduledAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.scheduledAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.scheduledAtGreaterThan !== undefined) {
@@ -266,40 +254,32 @@ export function jobWhere(where = {}, tableName = "j.", options = {}) {
     if (isQueryPart(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(`, ")");
       values.push(where.createdAtIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtIn) &&
-      where.createdAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtIn.length; ++i) {
         values.push(where.createdAtIn[i]);
-        if (i === where.createdAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtNotIn !== undefined) {
     if (isQueryPart(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(`, ")");
       values.push(where.createdAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtNotIn) &&
-      where.createdAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtNotIn.length; ++i) {
         values.push(where.createdAtNotIn[i]);
-        if (i === where.createdAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtGreaterThan !== undefined) {
@@ -330,40 +310,32 @@ export function jobWhere(where = {}, tableName = "j.", options = {}) {
     if (isQueryPart(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(`, ")");
       values.push(where.updatedAtIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtIn) &&
-      where.updatedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtIn.length; ++i) {
         values.push(where.updatedAtIn[i]);
-        if (i === where.updatedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtNotIn !== undefined) {
     if (isQueryPart(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(`, ")");
       values.push(where.updatedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtNotIn) &&
-      where.updatedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtNotIn.length; ++i) {
         values.push(where.updatedAtNotIn[i]);
-        if (i === where.updatedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtGreaterThan !== undefined) {

--- a/packages/store/src/generated/database/session.js
+++ b/packages/store/src/generated/database/session.js
@@ -82,34 +82,32 @@ export function sessionWhere(where = {}, tableName = "s.", options = {}) {
     if (isQueryPart(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(`, ")");
       values.push(where.idIn, undefined);
-    } else if (Array.isArray(where.idIn) && where.idIn.length > 0) {
+    } else if (Array.isArray(where.idIn)) {
       strings.push(` AND ${tableName}"id" = ANY(ARRAY[`);
       for (let i = 0; i < where.idIn.length; ++i) {
         values.push(where.idIn[i]);
-        if (i === where.idIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idNotIn !== undefined) {
     if (isQueryPart(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(`, ")");
       values.push(where.idNotIn, undefined);
-    } else if (Array.isArray(where.idNotIn) && where.idNotIn.length > 0) {
+    } else if (Array.isArray(where.idNotIn)) {
       strings.push(` AND ${tableName}"id" != ANY(ARRAY[`);
       for (let i = 0; i < where.idNotIn.length; ++i) {
         values.push(where.idNotIn[i]);
-        if (i === where.idNotIn.length - 1) {
-          strings.push("]::uuid[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.idNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::uuid[])");
+      values.push(undefined);
     }
   }
   if (where.idLike !== undefined) {
@@ -132,37 +130,32 @@ export function sessionWhere(where = {}, tableName = "s.", options = {}) {
     if (isQueryPart(where.expiresIn)) {
       strings.push(` AND ${tableName}"expires" = ANY(`, ")");
       values.push(where.expiresIn, undefined);
-    } else if (Array.isArray(where.expiresIn) && where.expiresIn.length > 0) {
+    } else if (Array.isArray(where.expiresIn)) {
       strings.push(` AND ${tableName}"expires" = ANY(ARRAY[`);
       for (let i = 0; i < where.expiresIn.length; ++i) {
         values.push(where.expiresIn[i]);
-        if (i === where.expiresIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.expiresIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.expiresNotIn !== undefined) {
     if (isQueryPart(where.expiresNotIn)) {
       strings.push(` AND ${tableName}"expires" != ANY(`, ")");
       values.push(where.expiresNotIn, undefined);
-    } else if (
-      Array.isArray(where.expiresNotIn) &&
-      where.expiresNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.expiresNotIn)) {
       strings.push(` AND ${tableName}"expires" != ANY(ARRAY[`);
       for (let i = 0; i < where.expiresNotIn.length; ++i) {
         values.push(where.expiresNotIn[i]);
-        if (i === where.expiresNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.expiresNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.expiresGreaterThan !== undefined) {
@@ -185,40 +178,32 @@ export function sessionWhere(where = {}, tableName = "s.", options = {}) {
     if (isQueryPart(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(`, ")");
       values.push(where.createdAtIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtIn) &&
-      where.createdAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtIn)) {
       strings.push(` AND ${tableName}"createdAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtIn.length; ++i) {
         values.push(where.createdAtIn[i]);
-        if (i === where.createdAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtNotIn !== undefined) {
     if (isQueryPart(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(`, ")");
       values.push(where.createdAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.createdAtNotIn) &&
-      where.createdAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.createdAtNotIn)) {
       strings.push(` AND ${tableName}"createdAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.createdAtNotIn.length; ++i) {
         values.push(where.createdAtNotIn[i]);
-        if (i === where.createdAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.createdAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.createdAtGreaterThan !== undefined) {
@@ -249,40 +234,32 @@ export function sessionWhere(where = {}, tableName = "s.", options = {}) {
     if (isQueryPart(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(`, ")");
       values.push(where.updatedAtIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtIn) &&
-      where.updatedAtIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtIn)) {
       strings.push(` AND ${tableName}"updatedAt" = ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtIn.length; ++i) {
         values.push(where.updatedAtIn[i]);
-        if (i === where.updatedAtIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtNotIn !== undefined) {
     if (isQueryPart(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(`, ")");
       values.push(where.updatedAtNotIn, undefined);
-    } else if (
-      Array.isArray(where.updatedAtNotIn) &&
-      where.updatedAtNotIn.length > 0
-    ) {
+    } else if (Array.isArray(where.updatedAtNotIn)) {
       strings.push(` AND ${tableName}"updatedAt" != ANY(ARRAY[`);
       for (let i = 0; i < where.updatedAtNotIn.length; ++i) {
         values.push(where.updatedAtNotIn[i]);
-        if (i === where.updatedAtNotIn.length - 1) {
-          strings.push("]::timestamptz[])");
-          values.push(undefined);
-        } else {
+        if (i !== where.updatedAtNotIn.length - 1) {
           strings.push(", ");
         }
       }
+      strings.push("]::timestamptz[])");
+      values.push(undefined);
     }
   }
   if (where.updatedAtGreaterThan !== undefined) {


### PR DESCRIPTION
For some reason we skipped over empty `xxIn` arrays in the where generator. Now we handle the empty case correctly.