### PR TITLE
feat(code-gen): generate a code splittable api client

### DIFF
--- a/packages/code-gen/src/generator/apiClient/templates/apiClientFile.tmpl
+++ b/packages/code-gen/src/generator/apiClient/templates/apiClientFile.tmpl
@@ -1,6 +1,7 @@
 {{ if (options.isNode) { }}
 import FormData from "form-data";
 {{ } }}
+
 {{ if (options.useTypescript) { }}
 import * as T from "./types";
 import { CancelToken, AxiosInstance } from "axios";
@@ -52,63 +53,34 @@ function handleError(e, group, name) {
 }
 {{ } }}
 
-{{ if (options.isBrowser) { }}
-/**
- * Should set an axios compatible api client
- *
- * @param {AxiosInstance} instance
- */
-export function newApiClient(instance {{= options.useTypescript ? ": AxiosInstance" : "" }}) {
-{{ } else { }}
-function checkApiClient() {
-  if (_internalClient === undefined) {
-    throw new Error("Initialize api client with createApiClient");
-  }
-}
-{{ } }}
-
-let _internalClient {{= options.useTypescript ? ": AxiosInstance | undefined" : "" }}  = undefined;
-let requestId {{= options.useTypescript ? ": string | undefined" : "" }} = undefined;
 ((newline))
 
-/**
- * Should set an axios compatible api client
- *
- * @param {AxiosInstance} instance
- */
-{{ if (!options.isBrowser) { }}export {{ } }} function createApiClient(instance {{= options.useTypescript ? ": AxiosInstance" : "" }}) {
-  _internalClient = instance;
-
-  _internalClient.interceptors.request.use((config) => {
-      if (requestId) {
-        config.headers["x-request-id"] = requestId;
-      }
-      return config;
+export function addRequestIdInterceptors(instance{{= options.useTypescript ? ": AxiosInstance" : "" }}) {
+  let requestId {{= options.useTypescript ? ": string | undefined" : "" }} = undefined;
+  instance.interceptors.request.use((config) => {
+    if (requestId) {
+      config.headers["x-request-id"] = requestId;
+    }
+    return config;
   });
 
-  _internalClient.interceptors.response.use((response) => {
+  instance.interceptors.response.use((response) => {
     if (response.headers["x-request-id"]) {
       requestId = response.headers["x-request-id"];
     }
     return response;
-  },
-  (error) => {
-    if (error.response && error.response.headers["x-request-id"]) {
-      requestId = error.response.headers["x-request-id"];
-    }
-    return Promise.reject(error);
+    },
+    (error) => {
+      if (error.response && error.response.headers["x-request-id"]) {
+        requestId = error.response.headers["x-request-id"];
+      }
+      return Promise.reject(error);
   });
 }
+
 ((newline))
 
 {{ for (const groupName of Object.keys(structure)) { }}
-
-  {{ if (!options.isBrowser) { }}
-  export const {{= groupName }}Api = {
-  {{ } else { }}
-  const {{= groupName }} = {
-  {{ } }}
-
   {{ for (const itemName of Object.keys(structure[groupName])) { }}
     {{ const item = structure[groupName][itemName]; }}
 
@@ -119,22 +91,7 @@ let requestId {{= options.useTypescript ? ": string | undefined" : "" }} = undef
 
     {{= apiClientFn({ options, item }) }}
 ((newline))
-
   {{ } }}
-
-  };
 ((newline))
-
 {{ } }}
 
-{{ if (options.isBrowser) { }}
-
-  createApiClient(instance);
-
-  return {
-    {{ for (const group of Object.keys(structure)) { }}
-    {{= group }},
-    {{ } }}
-  };
-}
-{{ } }}

--- a/packages/code-gen/src/generator/apiClient/templates/apiClientFn.tmpl
+++ b/packages/code-gen/src/generator/apiClient/templates/apiClientFn.tmpl
@@ -6,6 +6,7 @@
  {{ if (item.docString && item.docString.length > 0) { }}* Docs: {{= item.docString }}{{ } }}
  *
 {{ if (!options.useTypescript) { }}
+    * @param {AxiosInstance} instance
     {{ if (item.params) { }}
      * @param { {{= getTypeNameForType(item.params.reference, typeSuffix.apiInput, { useDefaults: false }) }} } params
     {{ } }}
@@ -26,8 +27,9 @@
     {{ } }}
 {{ } }}
  */
-{{= item.name }}: async function (
+export async function api{{= item.uniqueName }}(
 {{ if (options.useTypescript) { }}
+    instance: AxiosInstance,
     {{ if (item.params) { }}
     params: T.{{= getTypeNameForType(item.params.reference, typeSuffix.apiInput, { useDefaults: false, }) }},
     {{ } }}
@@ -41,6 +43,7 @@
     files: T.{{= getTypeNameForType(item.files.reference, typeSuffix.apiInput, { useDefaults: false, fileTypeIO: "input", }) }},
     {{ } }}
 {{ } else { }}
+    instance,
     {{ if (item.params) { }}
     params,
     {{ } }}
@@ -60,10 +63,6 @@ options: { cancelToken?: CancelToken } = {},
 options = {},
 {{ } }}
 {{= options.useTypescript && item.response ? `): Promise<T.${getTypeNameForType(item.response.reference, typeSuffix.apiResponse, { isJSON: true, fileTypeIO: "outputClient", })}> {` : ") {" }}
-    {{ if (!options.isBrowser) { }}
-    checkApiClient();
-    {{ } }}
-
     {{ if (item.files) { }}
       // eslint-disable-next-line
       const data = new FormData();
@@ -82,7 +81,7 @@ options = {},
     try {
     {{ } }}
 
-    const response = await _internalClient{{= options.useTypescript ? "!" : "" }}.request({
+    const response = await instance.request({
       url: `{{= url }}`,
       method: "{{= item.method.toLowerCase() }}",
       params: {{ if (item.query) { }}query{{ } else { }}{}{{ } }},
@@ -115,5 +114,5 @@ options = {},
 
     {{ } }}
 
-},
+}
 ((newline))

--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFile.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFile.tmpl
@@ -1,4 +1,4 @@
-import { AxiosError, CancelTokenSource } from "axios";
+import { AxiosError, AxiosInstance, CancelTokenSource } from "axios";
 import { createContext, PropsWithChildren, useContext } from "react";
 import {
   QueryKey,
@@ -9,8 +9,22 @@ import {
   useMutation,
   useQuery,
 } from "react-query";
-import { newApiClient } from "./apiClient";
 import * as T from "./types";
+import {
+{{ for (const groupName of Object.keys(structure)) { }}
+  {{ for (const itemName of Object.keys(structure[groupName])) { }}
+    {{ const item = structure[groupName][itemName]; }}
+
+    {{ if (item.type !== "route") { }}
+    {{ continue; }}
+    {{ } }}
+
+    api{{= item.uniqueName }},
+((newline))
+
+  {{ } }}
+{{ } }}
+} from "./apiClient";
 ((newline))
 
 interface CancellablePromise<T> extends Promise<T> {
@@ -18,13 +32,13 @@ interface CancellablePromise<T> extends Promise<T> {
 }
 ((newline))
 
-const ApiContext = createContext<ReturnType<typeof newApiClient> | undefined>(undefined);
+const ApiContext = createContext<AxiosInstance | undefined>(undefined);
 ((newline))
 
-export function ApiProvider<T extends ReturnType<typeof newApiClient>>({
+export function ApiProvider({
   instance, children,
 }: PropsWithChildren<{
-  instance: T;
+  instance: AxiosInstance;
 }>) {
   return <ApiContext.Provider value={instance}>{children}</ApiContext.Provider>;
 }

--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -23,7 +23,7 @@ body: T.{{= getTypeNameForType(item.body.reference, typeSuffix.apiInput, { useDe
 {{ } }}
 options: UseQueryOptions<{{= responseType }}, AppErrorResponse> = {},
 ): UseQueryResult<{{= responseType }}, AppErrorResponse> {
-  const { {{= item.group }} } = useApi();
+  const axiosInstance = useApi();
 
   options.enabled = (
     options.enabled === true || (options.enabled !== false
@@ -62,7 +62,8 @@ options: UseQueryOptions<{{= responseType }}, AppErrorResponse> = {},
     {{ } }}
     ),
     () => {
-      const promise: CancellablePromise<{{= responseType }}> = {{= item.group }}.{{= item.name }}(
+      const promise: CancellablePromise<{{= responseType }}> = api{{= item.uniqueName }}(
+        axiosInstance,
         {{= item.params ? "params, " : ""}}
         {{= item.query ? "query, " : "" }}
         {{= item.body ? "body, " : "" }}
@@ -139,10 +140,11 @@ interface {{= upperCaseFirst(funcName) }}Props {
 export function {{= funcName }}(
   options: UseMutationOptions<{{= responseType }}, AppErrorResponse, {{= upperCaseFirst(funcName) }}Props> = {},
 ): UseMutationResult<{{= responseType }}, AppErrorResponse, {{= upperCaseFirst(funcName) }}Props, unknown> {
-  const { {{= item.group }} } = useApi();
+  const axiosInstance = useApi();
 
   return useMutation(
-    (variables) => {{= item.group }}.{{= item.name }}(
+    (variables) => api{{= item.uniqueName }}(
+      axiosInstance,
       {{= item.params ? "variables.params, " : ""}}
       {{= item.query ? "variables.query, " : "" }}
       {{= item.body ? "variables.body, " : "" }}

--- a/packages/server/src/app.test.js
+++ b/packages/server/src/app.test.js
@@ -104,7 +104,8 @@ test("server/app", (t) => {
     const imp = await import(
       "./../../../generated/testing/server/apiClient.js"
     );
-    imp.createApiClient(client);
+
+    imp.addRequestIdInterceptors(client);
 
     const response = await client.get("/200");
     const secondResponse = await client.get("/200");


### PR DESCRIPTION
This is a breaking change. The `useApi` hook now stores an axios instance instead of the api client object. This also removes some of the 'isBrowser' checks that we had in here.
The generated react-query hooks also import the specific api functions, so pages should only include the api calls that they use in the bundles.

Closes #730