### PR TITLE
fix(cli): prevent ESLint from throwing errors when no JS files are found

### DIFF
--- a/packages/cli/scripts/lint.js
+++ b/packages/cli/scripts/lint.js
@@ -14,7 +14,13 @@ mainFn(import.meta, async () => {
 
   const { exitCode: lint } = await spawn(
     "./node_modules/.bin/eslint",
-    ["./**/*.js", "--ignore-pattern", "node_modules", "--fix"],
+    [
+      "./**/*.js",
+      "--ignore-pattern",
+      "node_modules",
+      "--fix",
+      "--no-error-on-unmatched-pattern",
+    ],
     eslintOptions,
   );
 


### PR DESCRIPTION
Closes #777