### PR TITLE
fix(server): handle body parser errors correctly

### DIFF
--- a/packages/code-gen/src/generator/router/templates/routerFile.tmpl
+++ b/packages/code-gen/src/generator/router/templates/routerFile.tmpl
@@ -19,14 +19,8 @@ let internalBodyParsers = undefined;
  */
 export function setBodyParsers(parsers) {
   internalBodyParsers = {
-    body: (ctx) =>
-      new Promise((r) => {
-        parsers.bodyParser(ctx, r).then(r);
-      }),
-    files: (ctx) =>
-      new Promise((r) => {
-        parsers.multipartBodyParser(ctx, r).then(r);
-      }),
+    body: parsers.bodyParser,
+    files: parsers.multipartBodyParser,
   };
 }
 ((newline))

--- a/packages/code-gen/test/e2e-server.test.js
+++ b/packages/code-gen/test/e2e-server.test.js
@@ -187,6 +187,29 @@ test("code-gen/e2e-server", async (t) => {
     }
   });
 
+  t.test("server - invalid json payload", async (t) => {
+    try {
+      await axiosInstance.request({
+        url: "/validate",
+        method: "POST",
+        data: `{ 
+        "foo": "bar",
+        "bar": {
+           "baz": true,
+           }
+         }`,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    } catch (e) {
+      t.ok(e.isAxiosError);
+      t.log.info(e.response);
+      t.equal(e.response.status, 400);
+      t.equal(e.response.data.key, "error.server.unsupportedBodyFormat");
+    }
+  });
+
   t.test("Cleanup server", async () => {
     await closeTestApp(app);
   });

--- a/packages/server/index.d.ts
+++ b/packages/server/index.d.ts
@@ -1246,8 +1246,11 @@ export interface GetAppOptions {
 export function getApp(opts?: GetAppOptions): Application;
 
 export interface BodyParserPair {
-  bodyParser: Middleware;
-  multipartBodyParser: Middleware;
+  bodyParser: (context: Context, next?: Next | undefined) => Promise<void>;
+  multipartBodyParser: (
+    context: Context,
+    next?: Next | undefined,
+  ) => Promise<void>;
 }
 
 /**

--- a/packages/server/src/middleware/body.js
+++ b/packages/server/src/middleware/body.js
@@ -112,7 +112,9 @@ function koaBody(opts = {}) {
 
     ctx.request.body = bodyResult;
 
-    return next();
+    if (typeof next === "function") {
+      return next();
+    }
   };
 }
 
@@ -160,7 +162,9 @@ function koaFormidable(opts = {}) {
       });
       form.parse(ctx.req);
     }).then(() => {
-      return next();
+      if (typeof next === "function") {
+        return next();
+      }
     });
   };
 }

--- a/packages/server/src/middleware/body.test.js
+++ b/packages/server/src/middleware/body.test.js
@@ -7,7 +7,7 @@ import { createBodyParsers } from "./body.js";
 mainTestFn(import.meta);
 
 test("server/middleware/body", async (t) => {
-  const app = getApp({ disableHeaders: true, disableHealthRoute: true });
+  const app = getApp({ disableHealthRoute: true });
 
   const parsers = createBodyParsers({}, {});
 
@@ -61,6 +61,29 @@ test("server/middleware/body", async (t) => {
       });
     } catch (e) {
       t.ok(e.isAxiosError);
+      t.equal(e.response.status, 400);
+      t.equal(e.response.data.key, "error.server.unsupportedBodyFormat");
+    }
+  });
+
+  t.test("invalid json payload", async (t) => {
+    try {
+      await client.request({
+        url: "/",
+        method: "POST",
+        data: `{ 
+        "foo": "bar",
+        "bar": {
+           "baz": true,
+           }
+         }`,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    } catch (e) {
+      t.ok(e.isAxiosError);
+      t.log.info(e.response);
       t.equal(e.response.status, 400);
       t.equal(e.response.data.key, "error.server.unsupportedBodyFormat");
     }


### PR DESCRIPTION
We used library based Koa middleware for body parsing, but now moved to internally developed middleware. So we don't need the promise wrapper anymore to ensure next is called. This promise wrapper caused unhandled promise rejections, that crashed the app.

By handling the case where `next` is missing in the body parsers, we can just call the middleware like any other function