### PR TITLE
feat(code-gen): improve generated router performance

### DIFF
--- a/packages/code-gen/src/generator/router/index.js
+++ b/packages/code-gen/src/generator/router/index.js
@@ -31,12 +31,7 @@ export function generateRouterFiles(context) {
     }
 
     const contents = executeTemplate("routerGroupFile", {
-      routeTrie,
-      routeTags,
-      extension: context.extension,
-      importExtension: context.extension,
       groupStructure,
-      options: context.options,
       groupName: group,
     });
 

--- a/packages/code-gen/src/generator/router/templates/routerFile.tmpl
+++ b/packages/code-gen/src/generator/router/templates/routerFile.tmpl
@@ -132,10 +132,12 @@ const handlers = {
 ((newline))
 
 export function router(ctx, next) {
-  let triePath = ctx.method + ctx.path;
-  if (triePath.endsWith("/")) {
-    triePath = triePath.substring(0, triePath.length - 1);
+  let triePath = ctx.path.substring(1);
+  // Also handle `/` requests
+  if (!triePath.endsWith("/") && triePath.length !== 0) {
+   triePath += "/";
   }
+  triePath += ctx.method;
 
   const params = Object.create(null);
   let route = undefined;

--- a/packages/code-gen/src/generator/router/trie.js
+++ b/packages/code-gen/src/generator/router/trie.js
@@ -10,9 +10,12 @@ export const buildTrie = (data) => {
   for (const group of Object.values(data)) {
     for (const item of Object.values(group)) {
       if (item.type === "route") {
+        const fullPath = item.path.endsWith("/")
+          ? `${item.path}${item.method}`
+          : `${item.path}/${item.method}`;
         routeTrieInput.push({
           uniqueName: item.uniqueName,
-          fullPath: `${item.method}/${item.path}`,
+          fullPath,
         });
       }
     }
@@ -26,7 +29,6 @@ export const buildTrie = (data) => {
  */
 function buildRouteTrie(input) {
   const trie = createNode("");
-  addHttpMethods(trie);
 
   for (const r of input) {
     addRoute(
@@ -36,15 +38,7 @@ function buildRouteTrie(input) {
     );
   }
 
-  // Don't collapse top level
-  for (const child of trie.children) {
-    cleanTrieAndCollapse(child);
-  }
-
-  // Remove unneeded 'HTTP-method' children
-  trie.children = trie.children.filter(
-    (it) => it.children.length > 0 || it.uniqueName !== undefined,
-  );
+  cleanTrieAndCollapse(trie);
 
   sortTrie(trie);
 
@@ -104,21 +98,6 @@ function addChildNodes(parent, ...children) {
     child.parent = parent;
     parent.children.push(child);
   }
-}
-
-/**
- * @param trie
- */
-function addHttpMethods(trie) {
-  addChildNodes(
-    trie,
-    createNode("GET"),
-    createNode("POST"),
-    createNode("PUT"),
-    createNode("PATCH"),
-    createNode("DELETE"),
-    createNode("HEAD"),
-  );
 }
 
 /**


### PR DESCRIPTION
By postfix the request method instead of prefixing, a lot of branching happens at the root, based on defined routes names, instead of nested per method.
 This gives a 10 to 40 percent performance improvement, depending on the amount of routes registered.

/cc @tjonger 