### PR TITLE
fix(code-gen): transformation for idIn and via combination

### DIFF
--- a/packages/code-gen/src/generator/sql/query-builder.js
+++ b/packages/code-gen/src/generator/sql/query-builder.js
@@ -441,8 +441,8 @@ if (!isNil(builder.${key}.limit)) {
                builder.where.${ownKey}In.length > 0) {
                builder.where.${ownKey}In = query([
                                                     "(SELECT value::${sqlCastType} FROM(values (",
-                                                    ...builder.where.${ownKey}In.map(
-                                                       () => "").join("), ("),
+                                                    ...Array.from({ length: builder.where.${ownKey}In.length - 1 }).map(
+                                                       () => "), ("),
                                                     ")) as ids(value)) INTERSECT "
                                                  ], ...builder.where.${ownKey}In)
             } else {

--- a/packages/code-gen/test/sql.test.js
+++ b/packages/code-gen/test/sql.test.js
@@ -419,6 +419,23 @@ test("code-gen/e2e/sql", async (t) => {
     t.equal(dbUser.id, user.id);
   });
 
+  t.test("traverse with 'via' and multiple idIn", async (t) => {
+    const [dbUser] = await userEntityImport
+      .queryUser({
+        where: {
+          idIn: [post.writer, uuid()],
+        },
+        viaPosts: {
+          where: {
+            id: post.id,
+          },
+        },
+      })
+      .exec(sql);
+
+    t.equal(dbUser.id, user.id);
+  });
+
   t.test("traverse via queryCategory", async (t) => {
     const builder = {
       viaPosts: {

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -637,7 +637,9 @@ export function internalQueryFile(builder = {}, wherePartial) {
       builder.where.idIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.idIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.idIn,
@@ -671,7 +673,9 @@ ${offsetLimitQb}
       builder.where.idIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.idIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.idIn,

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -755,7 +755,9 @@ export function internalQueryFileGroup2(builder = {}, wherePartial) {
       builder.where.fileIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.fileIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.fileIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.fileIn,
@@ -789,7 +791,9 @@ ${offsetLimitQb}
       builder.where.parentIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.parentIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.parentIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.parentIn,
@@ -823,7 +827,9 @@ ${offsetLimitQb}
       builder.where.idIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.idIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.idIn,
@@ -982,7 +988,9 @@ export function internalQueryFileGroup(builder = {}, wherePartial) {
       builder.where.fileIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.fileIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.fileIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.fileIn,
@@ -1016,7 +1024,9 @@ ${offsetLimitQb}
       builder.where.parentIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.parentIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.parentIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.parentIn,
@@ -1050,7 +1060,9 @@ ${offsetLimitQb}
       builder.where.idIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.idIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.idIn,

--- a/packages/store/src/generated/database/fileGroupView.js
+++ b/packages/store/src/generated/database/fileGroupView.js
@@ -541,7 +541,9 @@ export function internalQueryFileGroupView2(builder = {}, wherePartial) {
       builder.where.fileIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.fileIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.fileIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.fileIn,
@@ -575,7 +577,9 @@ ${offsetLimitQb}
       builder.where.parentIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.parentIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.parentIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.parentIn,
@@ -609,7 +613,9 @@ ${offsetLimitQb}
       builder.where.idIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.idIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.idIn,
@@ -774,7 +780,9 @@ export function internalQueryFileGroupView(builder = {}, wherePartial) {
       builder.where.fileIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.fileIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.fileIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.fileIn,
@@ -808,7 +816,9 @@ ${offsetLimitQb}
       builder.where.parentIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.parentIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.parentIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.parentIn,
@@ -842,7 +852,9 @@ ${offsetLimitQb}
       builder.where.idIn = query(
         [
           "(SELECT value::uuid FROM(values (",
-          ...builder.where.idIn.map(() => "").join("), ("),
+          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
+            () => "), (",
+          ),
           ")) as ids(value)) INTERSECT ",
         ],
         ...builder.where.idIn,


### PR DESCRIPTION
When a 'via' is used, whe automatically transform the existing 'idIn' array so we can use it in a 'INTERSECT' query, to give the 'AND' guarantee. This was not tested propertly with multiple values in the 'idIn' array

References #886