### PR TITLE
perf(code-gen): improve generated query builder performance

### DIFF
--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -948,18 +948,17 @@ ${offsetLimitQb}
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
-SELECT array_remove(array_agg(to_jsonb(fg.*) || jsonb_build_object(${query([
+SELECT ARRAY (SELECT to_jsonb(fg.*) || jsonb_build_object(${query([
       joinedKeys.join(","),
-    ])}) ORDER BY ${fileGroupOrderBy(
+    ])})
+${internalQueryFileGroup(builder.children, query`AND fg."parent" = fg2."id"`)}
+ORDER BY ${fileGroupOrderBy(
       builder.children.orderBy,
       builder.children.orderBySpec,
       "fg.",
-    )}), NULL) as "result"
-${internalQueryFileGroup(builder.children, query`AND fg."parent" = fg2."id"`)}
-GROUP BY fg2."id"
-ORDER BY fg2."id"
+    )}
 ${offsetLimitQb}
-) as "fg_fg_1" ON TRUE`);
+) as result) as "fg_fg_1" ON TRUE`);
   }
   return query`
 FROM "fileGroup" fg2
@@ -1181,18 +1180,17 @@ ${offsetLimitQb}
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
-SELECT array_remove(array_agg(to_jsonb(fg2.*) || jsonb_build_object(${query([
+SELECT ARRAY (SELECT to_jsonb(fg2.*) || jsonb_build_object(${query([
       joinedKeys.join(","),
-    ])}) ORDER BY ${fileGroupOrderBy(
+    ])})
+${internalQueryFileGroup2(builder.children, query`AND fg2."parent" = fg."id"`)}
+ORDER BY ${fileGroupOrderBy(
       builder.children.orderBy,
       builder.children.orderBySpec,
       "fg2.",
-    )}), NULL) as "result"
-${internalQueryFileGroup2(builder.children, query`AND fg2."parent" = fg."id"`)}
-GROUP BY fg."id"
-ORDER BY fg."id"
+    )}
 ${offsetLimitQb}
-) as "fg_fg_1" ON TRUE`);
+) as result) as "fg_fg_1" ON TRUE`);
   }
   return query`
 FROM "fileGroup" fg

--- a/packages/store/src/generated/database/fileGroupView.js
+++ b/packages/store/src/generated/database/fileGroupView.js
@@ -737,21 +737,20 @@ ${offsetLimitQb}
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
-SELECT array_remove(array_agg(to_jsonb(fgv.*) || jsonb_build_object(${query([
+SELECT ARRAY (SELECT to_jsonb(fgv.*) || jsonb_build_object(${query([
       joinedKeys.join(","),
-    ])}) ORDER BY ${fileGroupViewOrderBy(
-      builder.children.orderBy,
-      builder.children.orderBySpec,
-      "fgv.",
-    )}), NULL) as "result"
+    ])})
 ${internalQueryFileGroupView(
   builder.children,
   query`AND fgv."parent" = fgv2."id"`,
 )}
-GROUP BY fgv2."id"
-ORDER BY fgv2."id"
+ORDER BY ${fileGroupViewOrderBy(
+      builder.children.orderBy,
+      builder.children.orderBySpec,
+      "fgv.",
+    )}
 ${offsetLimitQb}
-) as "fgv_fgv_1" ON TRUE`);
+) as result) as "fgv_fgv_1" ON TRUE`);
   }
   return query`
 FROM "fileGroupView" fgv2
@@ -976,21 +975,20 @@ ${offsetLimitQb}
       );
     }
     joinQb.append(query`LEFT JOIN LATERAL (
-SELECT array_remove(array_agg(to_jsonb(fgv2.*) || jsonb_build_object(${query([
+SELECT ARRAY (SELECT to_jsonb(fgv2.*) || jsonb_build_object(${query([
       joinedKeys.join(","),
-    ])}) ORDER BY ${fileGroupViewOrderBy(
-      builder.children.orderBy,
-      builder.children.orderBySpec,
-      "fgv2.",
-    )}), NULL) as "result"
+    ])})
 ${internalQueryFileGroupView2(
   builder.children,
   query`AND fgv2."parent" = fgv."id"`,
 )}
-GROUP BY fgv."id"
-ORDER BY fgv."id"
+ORDER BY ${fileGroupViewOrderBy(
+      builder.children.orderBy,
+      builder.children.orderBySpec,
+      "fgv2.",
+    )}
 ${offsetLimitQb}
-) as "fgv_fgv_1" ON TRUE`);
+) as result) as "fgv_fgv_1" ON TRUE`);
   }
   return query`
 FROM "fileGroupView" fgv


### PR DESCRIPTION
Using the array constructor instead of array_remove(array_agg())

Same performance on simple queries, 10 percent improvement for nested aggregates