### PR TITLE
feat(cli): add option to enforce at least one test assertion

### DIFF
--- a/packages/cli/src/commands/visualise.test.js
+++ b/packages/cli/src/commands/visualise.test.js
@@ -7,6 +7,7 @@ mainTestFn(import.meta);
 test("cli/commands/visualise", (t) => {
   if (environment.CI === "true") {
     t.log.info("CI detected, skipping visualise tests");
+    t.pass();
     return;
   }
 

--- a/packages/cli/src/migrate/migrate.test.js
+++ b/packages/cli/src/migrate/migrate.test.js
@@ -43,7 +43,8 @@ test("cli/docker/migrate", async (t) => {
     }
   });
 
-  t.test("teardown", async () => {
+  t.test("teardown", async (t) => {
     await rm("./packages/cli/tmp", { recursive: true, force: true });
+    t.pass();
   });
 });

--- a/packages/cli/src/testing/config.js
+++ b/packages/cli/src/testing/config.js
@@ -1,7 +1,12 @@
 import { existsSync } from "fs";
 import { pathToFileURL } from "url";
-import { pathJoin } from "@compas/stdlib";
-import { setGlobalSetup, setGlobalTeardown, setTestTimeout } from "./state.js";
+import { isNil, pathJoin } from "@compas/stdlib";
+import {
+  setEnforceSingleAssertion,
+  setGlobalSetup,
+  setGlobalTeardown,
+  setTestTimeout,
+} from "./state.js";
 
 const configPath = pathJoin(process.cwd(), "test/config.js");
 
@@ -28,6 +33,10 @@ export async function loadTestConfig() {
       );
     }
     setTestTimeout(config.timeout);
+  }
+
+  if (!isNil(config?.enforceSingleAssertion)) {
+    setEnforceSingleAssertion(config.enforceSingleAssertion);
   }
 
   setGlobalSetup(config?.setup);

--- a/packages/cli/src/testing/state.js
+++ b/packages/cli/src/testing/state.js
@@ -16,6 +16,11 @@ export let areTestsRunning = false;
 export let timeout = 2500;
 
 /**
+ * @type {boolean}
+ */
+export let enforceSingleAssertion = false;
+
+/**
  * @type {function(): (void|Promise<void>)}
  */
 export let globalSetup = noop;
@@ -59,6 +64,15 @@ export function setTestLogger(logger) {
  */
 export function setTestTimeout(value) {
   timeout = value;
+}
+
+/**
+ * Set enforcement of an passing assertion in test callbacks
+ *
+ * @param {boolean} enforce
+ */
+export function setEnforceSingleAssertion(enforce) {
+  enforceSingleAssertion = enforce;
 }
 
 /**

--- a/packages/cli/src/testing/state.test.js
+++ b/packages/cli/src/testing/state.test.js
@@ -23,6 +23,7 @@ test("cli/test/state", (t) => {
     t.timeout = 1000;
     t.test("timeout is correct", (t) => {
       t.equal(timeout, 1000);
+      t.pass();
     });
   });
 

--- a/packages/cli/src/utils.test.js
+++ b/packages/cli/src/utils.test.js
@@ -47,15 +47,17 @@ test("cli/utils", (t) => {
     (t) => {
       try {
         watchOptionsWithDefaults({ extensions: false });
-        t.fail("Should throw");
         // eslint-disable-next-line no-empty
-      } catch {}
+      } catch {
+        t.pass();
+      }
 
       try {
         watchOptionsWithDefaults({ ignoredPatterns: false });
-        t.fail("Should throw");
         // eslint-disable-next-line no-empty
-      } catch {}
+      } catch {
+        t.pass();
+      }
     },
   );
 

--- a/packages/code-gen/test/e2e-server.test.js
+++ b/packages/code-gen/test/e2e-server.test.js
@@ -256,8 +256,9 @@ test("code-gen/e2e-server", async (t) => {
     }
   });
 
-  t.test("Cleanup server", async () => {
+  t.test("teardown", async (t) => {
     await closeTestApp(app);
+    t.pass();
   });
 });
 

--- a/packages/code-gen/test/sql.test.js
+++ b/packages/code-gen/test/sql.test.js
@@ -190,7 +190,7 @@ test("code-gen/e2e/sql", async (t) => {
     t.equal(dbUser.deletedAt, undefined);
   });
 
-  t.test("query filter by 'in' statements", async () => {
+  t.test("query filter by 'in' statements", async (t) => {
     await queriesImport.queries.userSelect(sql, {
       createdAtIn: [new Date()],
       emailIn: ["Test@test.com"],
@@ -203,6 +203,7 @@ test("code-gen/e2e/sql", async (t) => {
       createdAtIn: [],
       emailIn: ["Test@test.com"],
     });
+    t.pass();
   });
 
   t.test("query filter empty 'notIn' statement", async (t) => {
@@ -233,10 +234,11 @@ test("code-gen/e2e/sql", async (t) => {
     },
   );
 
-  t.test("query filter by 'in' sub query", async () => {
+  t.test("query filter by 'in' sub query", async (t) => {
     await queriesImport.queries.userSelect(sql, {
       emailIn: query`SELECT 'test@test.com' as foo`,
     });
+    t.pass();
   });
 
   t.test("query filter by 'ILIKE'", async (t) => {
@@ -273,7 +275,7 @@ test("code-gen/e2e/sql", async (t) => {
     t.equal(categories.length, 0);
   });
 
-  t.test("query same 'shortName' originally", async () => {
+  t.test("query same 'shortName' originally", async (t) => {
     await userEntityImport
       .queryUser({
         posts: {
@@ -289,6 +291,7 @@ test("code-gen/e2e/sql", async (t) => {
         },
       })
       .exec(sql);
+    t.pass();
   });
 
   t.test("user QueryBuilder", async (t) => {
@@ -352,7 +355,7 @@ test("code-gen/e2e/sql", async (t) => {
     t.equal(categories[0].posts[0].post.author.id, user.id);
   });
 
-  t.test("query builder calls", async () => {
+  t.test("query builder calls", async (t) => {
     await postEntityImport
       .queryPost({
         postages: {
@@ -386,6 +389,8 @@ test("code-gen/e2e/sql", async (t) => {
         },
       })
       .exec(sql);
+
+    t.pass();
   });
 
   t.test("traverse via queryUser", async (t) => {

--- a/packages/server/src/middleware/body.test.js
+++ b/packages/server/src/middleware/body.test.js
@@ -89,7 +89,8 @@ test("server/middleware/body", async (t) => {
     }
   });
 
-  t.test("teardown", async () => {
+  t.test("teardown", async (t) => {
     await closeTestApp(app);
+    t.pass();
   });
 });

--- a/packages/server/src/middleware/compose.test.js
+++ b/packages/server/src/middleware/compose.test.js
@@ -119,6 +119,7 @@ test("Koa Compose", (t) => {
   t.test("should work with 0 middleware", async (t) => {
     try {
       await compose([])({});
+      t.pass();
     } catch (e) {
       t.fail("should not throw on empty array");
     }

--- a/packages/server/src/middleware/session.test.js
+++ b/packages/server/src/middleware/session.test.js
@@ -18,7 +18,7 @@ test("server/session", (t) => {
   let sql;
   let cookieVal;
 
-  t.test("setup", async () => {
+  t.test("setup", async (t) => {
     sql = await createTestPostgresDatabase();
     app.use(
       session(app, {
@@ -40,6 +40,7 @@ test("server/session", (t) => {
     });
 
     await createTestAppAndClient(app, client);
+    t.pass();
   });
 
   t.test("set cookie", async (t) => {
@@ -64,9 +65,10 @@ test("server/session", (t) => {
     });
   });
 
-  t.test("teardown", async () => {
+  t.test("teardown", async (t) => {
     await cleanupTestPostgresDatabase(sql);
     await closeTestApp(app);
+    t.pass();
   });
 });
 
@@ -77,7 +79,7 @@ test("server/session synced cookie", (t) => {
   let sql;
   let cookieVal;
 
-  t.test("setup", async () => {
+  t.test("setup", async (t) => {
     sql = await createTestPostgresDatabase();
     app.use(
       session(app, {
@@ -104,6 +106,7 @@ test("server/session synced cookie", (t) => {
     });
 
     await createTestAppAndClient(app, client);
+    t.pass();
   });
 
   t.test("set cookie", async (t) => {
@@ -137,8 +140,9 @@ test("server/session synced cookie", (t) => {
     t.ok(cookieVal[0].indexOf("1970") !== -1, "reset date to unix epoch");
   });
 
-  t.test("teardown", async () => {
+  t.test("teardown", async (t) => {
     await cleanupTestPostgresDatabase(sql);
     await closeTestApp(app);
+    t.pass();
   });
 });

--- a/packages/stdlib/src/utils.test.js
+++ b/packages/stdlib/src/utils.test.js
@@ -11,6 +11,7 @@ test("stdlib/utils", (t) => {
   t.test("gc", (t) => {
     try {
       gc();
+      t.pass();
     } catch (e) {
       t.fail("Should not throw");
       t.log.error(e);

--- a/packages/store/src/file-cache.test.js
+++ b/packages/store/src/file-cache.test.js
@@ -55,49 +55,49 @@ test("store/file-cache", async (t) => {
     t.equal(result[0].sum, 3);
   });
 
-  t.test("create FileCache", () => {
+  t.test("create FileCache", (t) => {
     cache = new FileCache(sql, minio, bucketName, {
       cacheControlHeader: "test",
       inMemoryThreshold: 5,
     });
+    t.pass();
   });
 
   // noinspection DuplicatedCode
-  t.test("write fixtures to disk", () => {
+  t.test("write fixtures to disk", (t) => {
     mkdirSync(basePath, { recursive: true });
     writeFileSync(pathJoin(basePath, "small"), files.small);
     writeFileSync(pathJoin(basePath, "medium"), files.medium);
     writeFileSync(pathJoin(basePath, "large"), files.large);
+    t.pass();
   });
 
   t.test("populate file table", async (t) => {
-    try {
-      files.small = await createOrUpdateFile(
-        sql,
-        minio,
-        bucketName,
-        { name: "small" },
-        pathJoin(basePath, "small"),
-      );
+    files.small = await createOrUpdateFile(
+      sql,
+      minio,
+      bucketName,
+      { name: "small" },
+      pathJoin(basePath, "small"),
+    );
 
-      files.medium = await createOrUpdateFile(
-        sql,
-        minio,
-        bucketName,
-        { name: "medium" },
-        pathJoin(basePath, "medium"),
-      );
+    files.medium = await createOrUpdateFile(
+      sql,
+      minio,
+      bucketName,
+      { name: "medium" },
+      pathJoin(basePath, "medium"),
+    );
 
-      files.large = await createOrUpdateFile(
-        sql,
-        minio,
-        bucketName,
-        { name: "large" },
-        pathJoin(basePath, "large"),
-      );
-    } catch (e) {
-      t.fail(e);
-    }
+    files.large = await createOrUpdateFile(
+      sql,
+      minio,
+      bucketName,
+      { name: "large" },
+      pathJoin(basePath, "large"),
+    );
+
+    t.pass();
   });
 
   t.test("get a small file", async (t) => {
@@ -142,8 +142,9 @@ test("store/file-cache", async (t) => {
     );
   });
 
-  t.test("clear file removes from cache", () => {
+  t.test("clear file removes from cache", (t) => {
     cache.clear(files.large.id);
+    t.pass();
   });
 
   t.test("create file again after clear", async (t) => {
@@ -194,11 +195,12 @@ test("store/file-cache check memory usage", async (t) => {
   const logMemory = (t) => {
     t.test("print memory usage", (t) => {
       printProcessMemoryUsage(t.log);
+      t.pass();
     });
   };
 
   const runFileStreamRounds = (t) => {
-    t.test("run a decent number of rounds", async () => {
+    t.test("run a decent number of rounds", async (t) => {
       console.time("file-cache");
       for (let i = 0; i < 1000; ++i) {
         const pArr = [];
@@ -214,6 +216,7 @@ test("store/file-cache check memory usage", async (t) => {
         }
       }
       console.timeEnd("file-cache");
+      t.pass();
     });
   };
 
@@ -231,51 +234,51 @@ test("store/file-cache check memory usage", async (t) => {
 
   logMemory(t);
 
-  t.test("create FileCache", () => {
+  t.test("create FileCache", (t) => {
     cache = new FileCache(sql, minio, bucketName, {
       cacheControlHeader: "test",
       inMemoryThreshold: 3500,
     });
+    t.pass();
   });
 
   logMemory(t);
 
   // noinspection DuplicatedCode
-  t.test("write fixtures to disk", () => {
+  t.test("write fixtures to disk", (t) => {
     mkdirSync(basePath, { recursive: true });
     writeFileSync(pathJoin(basePath, "small"), files.small);
     writeFileSync(pathJoin(basePath, "medium"), files.medium);
     writeFileSync(pathJoin(basePath, "large"), files.large);
+    t.pass();
   });
 
   t.test("populate file table", async (t) => {
-    try {
-      files.small = await createOrUpdateFile(
-        sql,
-        minio,
-        bucketName,
-        { name: "small" },
-        pathJoin(basePath, "small"),
-      );
+    files.small = await createOrUpdateFile(
+      sql,
+      minio,
+      bucketName,
+      { name: "small" },
+      pathJoin(basePath, "small"),
+    );
 
-      files.medium = await createOrUpdateFile(
-        sql,
-        minio,
-        bucketName,
-        { name: "medium" },
-        pathJoin(basePath, "medium"),
-      );
+    files.medium = await createOrUpdateFile(
+      sql,
+      minio,
+      bucketName,
+      { name: "medium" },
+      pathJoin(basePath, "medium"),
+    );
 
-      files.large = await createOrUpdateFile(
-        sql,
-        minio,
-        bucketName,
-        { name: "large" },
-        pathJoin(basePath, "large"),
-      );
-    } catch (e) {
-      t.fail(e);
-    }
+    files.large = await createOrUpdateFile(
+      sql,
+      minio,
+      bucketName,
+      { name: "large" },
+      pathJoin(basePath, "large"),
+    );
+
+    t.pass();
   });
 
   logMemory(t);
@@ -283,22 +286,23 @@ test("store/file-cache check memory usage", async (t) => {
   logMemory(t);
   runFileStreamRounds(t);
 
-  t.test("run gc", async () => {
+  t.test("run gc", async (t) => {
     gc();
     await new Promise((r) => {
       setTimeout(r, 10);
     });
+    t.pass();
   });
 
   logMemory(t);
 
   t.test("remove minio bucket", async (t) => {
     await removeBucketAndObjectsInBucket(minio, bucketName);
-    t.ok(true, "removed minio bucket");
+    t.pass();
   });
 
   t.test("destroy test db", async (t) => {
     await cleanupTestPostgresDatabase(sql);
-    t.ok(true, "closed postgres connection");
+    t.pass();
   });
 });

--- a/packages/store/src/file-group.test.js
+++ b/packages/store/src/file-group.test.js
@@ -37,7 +37,7 @@ test("store/file-group", async (t) => {
 
   const files = [];
 
-  t.test("insert files", async () => {
+  t.test("insert files", async (t) => {
     files.push(
       ...(await Promise.all([
         createOrUpdateFile(sql, minio, bucketName, { name }, filePath),
@@ -45,11 +45,13 @@ test("store/file-group", async (t) => {
         createOrUpdateFile(sql, minio, bucketName, { name }, filePath),
       ])),
     );
+
+    t.pass();
   });
 
   const groups = {};
 
-  t.test("create groups and insert files", async () => {
+  t.test("create groups and insert files", async (t) => {
     const [top1] = await queries.fileGroupInsert(sql, {
       name: "Test1",
     });
@@ -79,6 +81,8 @@ test("store/file-group", async (t) => {
     groups.top1 = top1.id;
     groups.top2 = top2.id;
     groups.sub1 = sub1.id;
+
+    t.pass();
   });
 
   t.test("set order of files of top2 group", async (t) => {
@@ -99,8 +103,9 @@ test("store/file-group", async (t) => {
     }
   });
 
-  t.test("set order of top level groups", async () => {
+  t.test("set order of top level groups", async (t) => {
     await updateFileGroupOrder(sql, [groups.top1, groups.top2]);
+    t.pass();
   });
 
   t.test("getNestedFiles without files, but preserve order", async (t) => {

--- a/packages/store/src/files.test.js
+++ b/packages/store/src/files.test.js
@@ -156,8 +156,9 @@ test("store/files", async (t) => {
     t.equal(result.length, 2);
   });
 
-  t.test("deleteFile", async () => {
+  t.test("deleteFile", async (t) => {
     await queries.fileDeletePermanent(sql, { id: storedFiles[0].id });
+    t.pass();
   });
 
   t.test("sync deleted files", async (t) => {

--- a/packages/store/src/minio.test.js
+++ b/packages/store/src/minio.test.js
@@ -9,13 +9,16 @@ test("store/minio", (t) => {
   const bucketName = uuid();
   const region = "us-east-1";
 
-  t.test("creating a bucket", async () => {
+  t.test("creating a bucket", async (t) => {
     await ensureBucket(client, bucketName, region);
     // doesn't throw because bucket exists, else should throw for not providing a region
     await ensureBucket(client, bucketName);
+
+    t.pass();
   });
 
-  t.test("deleting a bucket", async () => {
+  t.test("deleting a bucket", async (t) => {
     await removeBucket(client, bucketName);
+    t.pass();
   });
 });

--- a/packages/store/src/postgres.test.js
+++ b/packages/store/src/postgres.test.js
@@ -54,10 +54,11 @@ test("store/postgres", (t) => {
     t.equal(process.env.POSTGRES_DATABASE, "compas", "process.env");
   });
 
-  t.test("teardown", () => {
+  t.test("teardown", (t) => {
     process.env.POSTGRES_URI = oldPostgresUri;
     process.env.POSTGRES_DATABASE = oldPostgresDatabase;
     process.env.APP_NAME = oldAppName;
     refreshEnvironmentCache();
+    t.pass();
   });
 });

--- a/packages/store/src/query.test.js
+++ b/packages/store/src/query.test.js
@@ -122,8 +122,9 @@ test("store/query", (t) => {
 test("store/analyze-query", (t) => {
   let sql;
 
-  t.test("setup", async () => {
+  t.test("setup", async (t) => {
     sql = await createTestPostgresDatabase();
+    t.pass();
   });
 
   t.test("analyze select query - string plan", async (t) => {
@@ -138,8 +139,9 @@ test("store/analyze-query", (t) => {
     t.ok(isPlainObject(result));
   });
 
-  t.test("create test table", async () => {
+  t.test("create test table", async (t) => {
     await sql`CREATE TABLE "temp" (value int not null);`;
+    t.pass();
   });
 
   t.test("analyze insert does not insert", async (t) => {
@@ -164,7 +166,8 @@ test("store/analyze-query", (t) => {
     }
   });
 
-  t.test("teardown", async () => {
+  t.test("teardown", async (t) => {
     await cleanupTestPostgresDatabase(sql);
+    t.pass();
   });
 });

--- a/packages/store/src/queue.test.js
+++ b/packages/store/src/queue.test.js
@@ -423,8 +423,9 @@ test("store/queue - recurring jobs ", (t) => {
     },
   );
 
-  t.test("cleanup jobs", async () => {
+  t.test("cleanup jobs", async (t) => {
     await queries.jobDelete(sql);
+    t.pass();
   });
 
   t.test(

--- a/test/config.js
+++ b/test/config.js
@@ -8,6 +8,8 @@ import {
 
 export const timeout = 2000;
 
+export const enforceSingleAssertion = true;
+
 export async function setup() {
   const sql = await createTestPostgresDatabase();
   await setPostgresDatabaseTemplate(sql);


### PR DESCRIPTION
Configurable via test/config.js by exporting a constant boolean 'enforceSingleAssertion'. This is enforced when a `test` or `t.test` does not have any children via `t.test` and also does no assertions. And will result in the same handling as caught exceptions. It defaults currently to 'false', but may be switched to 'true' later.

This changes try / catch testing a bit from:

```js
test("err", t => {
  try {
    shouldThrow();
    t.fail("Should throw");
  } catch (e) {
    // Assert on 'e' or ignore
  }
});
```

to:

```js
test("err", t => {
  try {
    shouldThrow();
  } catch (e) {
    // Assert on 'e' or
    t.pass();
  }
});
```

Closes #820 