### PR TITLE
feat(code-gen): add additional query generics to react query codgen

### DIFF
--- a/packages/code-gen/src/generator/common.js
+++ b/packages/code-gen/src/generator/common.js
@@ -162,6 +162,6 @@ export type AppErrorResponse = AxiosError<{
   };
 }>;
 
-export type UseQueryOptions<Response, Error> = ReactUseQueryOptions<Response, Error> & { cancelToken?: CancelTokenSource };
+export type UseQueryOptions<Response, Error, TData = Response> = ReactUseQueryOptions<Response, Error, TData> & { cancelToken?: CancelTokenSource };
 `;
 }

--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -11,7 +11,7 @@
   {{ if (item.idempotent) { }}* Note that a custom options.enabled may be beneficial for your use case{{ } }}
  * Docs: {{= item.docString.replace(/\n/g, "\n  * ") }}
  */
-export function {{= funcName }}(
+export function {{= funcName }}<TData = {{= responseType }}>(
 {{ if (item.params) { }}
 params: T.{{= getTypeNameForType(item.params.reference, typeSuffix.apiInput, { useDefaults: false }) }},
 {{ } }}
@@ -21,8 +21,8 @@ query: T.{{= getTypeNameForType(item.query.reference, typeSuffix.apiInput, { use
 {{ if (item.body) { }}
 body: T.{{= getTypeNameForType(item.body.reference, typeSuffix.apiInput, { useDefaults: false }) }},
 {{ } }}
-options: UseQueryOptions<{{= responseType }}, AppErrorResponse> = {},
-): UseQueryResult<{{= responseType }}, AppErrorResponse> {
+options: UseQueryOptions<{{= responseType }}, AppErrorResponse, TData> = {},
+) {
   const axiosInstance = useApi();
 
   options.enabled = (


### PR DESCRIPTION
Adds the third generic support to `useQueryOptions` and removes the `UseQueryResult` casting as it should get automatically inferred based on the return type and `useQueryOptions`

This will allow for correctly inferring data when the selector option is used

```javascript
 // Data correctly inferred as data type
const { data } = useSomeQuery()

 // Data correctly inferred as someOtherValue type
const { data } = useSomeQuery({ select: (data) => data.someOtherValue })
```