### PR TITLE
feat(code-gen): add 'routerClearMemoizedHandlers' to router output

### DIFF
--- a/packages/code-gen/src/generator/router/templates/routerFile.tmpl
+++ b/packages/code-gen/src/generator/router/templates/routerFile.tmpl
@@ -68,6 +68,21 @@ const _composed = {
   {{ } }}
 };
 ((newline))
+((newline))
+/**
+ * Clear composed handlers.
+ *
+ * All handlers are composed via a koa-compose like and then memoized. When overwriting an
+ * handler when the route is already called, the overwritten handlers will not be
+ * executed till this function is called.
+ */
+export function routerClearMemoizedHandlers() {
+  for (const key of Object.keys(_composed)) {
+    _composed[key] = undefined;
+  }
+}
+((newline))
+((newline))
 
 const handlers = {
   {{ for (const groupName of Object.keys(structure)) { }}


### PR DESCRIPTION
This allows to overwrite the handlers at runtime, when requests did already hit the old handler. This clears the cache for all handlers synchronously, and may give a performance penalty for the first few calls for that handler.

Closes #958