### PR TITLE
fix(store): require ssl by default for the postgres connection in production

### DIFF
--- a/packages/store/src/postgres.js
+++ b/packages/store/src/postgres.js
@@ -66,9 +66,9 @@ export async function newPostgresConnection(opts) {
       {
         connection: {
           application_name: environment.APP_NAME,
-          ssl: isProduction(),
         },
         no_prepare: true,
+        ssl: isProduction() ? 'require' : 'prefer',
       },
       opts,
     ),

--- a/packages/store/src/postgres.js
+++ b/packages/store/src/postgres.js
@@ -68,7 +68,7 @@ export async function newPostgresConnection(opts) {
           application_name: environment.APP_NAME,
         },
         no_prepare: true,
-        ssl: isProduction() ? 'require' : 'prefer',
+        ssl: isProduction() ? "require" : "prefer",
       },
       opts,
     ),


### PR DESCRIPTION
This PR will enable SSL for connections.
For production environments it will be required, and elsewhere it's preferred.