### PR TITLE
fix(code-gen): resolve typescript union on compas reference object

### DIFF
--- a/gen/testing.js
+++ b/gen/testing.js
@@ -135,6 +135,14 @@ export function applyTestingServerStructure(app) {
   const T = new TypeCreator("server");
   const R = T.router("/");
 
+  // Reference (validate TS output)
+  app.add(
+    T.string("options").oneOf("A", "B", "C"),
+    T.generic("answers")
+      .keys(T.reference("server", "options"))
+      .values(T.string()),
+  );
+
   app.add(
     R.get("/:id", "getId")
       .params({

--- a/packages/code-gen/src/generator/types.js
+++ b/packages/code-gen/src/generator/types.js
@@ -263,6 +263,9 @@ export function generateTypeDefinition(
         if (Array.isArray(type.keys.oneOf)) {
           result += `{ [ key in `;
           result += generateTypeDefinition(context, type.keys, recurseSettings);
+        } else if (Array.isArray(type.keys.reference?.oneOf)) {
+          result += `{ [ K in `;
+          result += generateTypeDefinition(context, type.keys, recurseSettings);
         } else {
           result += `{ [ key: `;
           result += generateTypeDefinition(context, type.keys, recurseSettings);


### PR DESCRIPTION
before:
```ts
export type ServerAnswers = { [ key: ServerOptions]:string};
export type ServerOptions = "A"|"B"|"C";
```

after:
```ts
export type ServerAnswers = { [ K in ServerOptions]:string};
export type ServerOptions = "A"|"B"|"C";
```