### PR TITLE
feat(stdlib): calculate event duration on abort or eventStop

### DIFF
--- a/packages/stdlib/index.d.ts
+++ b/packages/stdlib/index.d.ts
@@ -410,8 +410,23 @@ export function printProcessMemoryUsage(logger: Logger): void;
  */
 export type InsightEventCall =
   | {
-      type: "start" | "stop" | "aborted";
+      type: "stop" | "aborted";
       name: string;
+
+      /**
+       * Time in milliseconds since some kind of epoch, this may be unix epoch or process start
+       */
+      time: number;
+    }
+  | {
+      type: "start";
+      name: string;
+
+      /**
+       * Duration in milliseconds between (end|aborted) and start time. This is filled when an
+       * event is aborted or stopped via `eventStop`.
+       */
+      duration?: number;
 
       /**
        * Time in milliseconds since some kind of epoch, this may be unix epoch or process start


### PR DESCRIPTION
The duration is added to the 'start' object in the callStack.

Closes #979