### PR TITLE
fix(code-gen): react-query should work for routes without a response

### DIFF
--- a/gen/testing.js
+++ b/gen/testing.js
@@ -203,6 +203,10 @@ export function applyTestingServerStructure(app) {
       .response({
         success: true,
       }),
+
+    R.get("/empty-response", "emptyResponse").query({
+      foo: T.string().optional(),
+    }),
   );
 }
 

--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -1,6 +1,6 @@
 {{ /* Keep in sync with apiClientFn */ }}
 {{ const funcName = "use" + upperCaseFirst(item.uniqueName); }}
-{{ const responseType = item.response ? `T.${getTypeNameForType(item.response.reference, typeSuffix.apiResponse, { isJSON: true, fileTypeIO: "outputClient" })}` : any; }}
+{{ const responseType = item.response ? `T.${getTypeNameForType(item.response.reference, typeSuffix.apiResponse, { isJSON: true, fileTypeIO: "outputClient" })}` : `any`; }}
 
 {{ if (item.method === "GET" || item.idempotent) { }}
 


### PR DESCRIPTION
Fixed quoting in a path that was never hit previously

Closes #991 