### PR TITLE
feat(cli): support `--parallel-count n` in the test runner

### DIFF
--- a/packages/cli/src/commands/help.js
+++ b/packages/cli/src/commands/help.js
@@ -39,7 +39,7 @@ Usage:
 - proxy             : compas proxy [--verbose]
 - run (explicit)    : compas run [--watch] [--verbose] [--any-node-arg] {scriptName|path/to/file.js} [--script-arg]
 - run (implicit)    : compas [--watch] [--verbose] [--any-node-arg] {scriptName|path/to/file.js} [--script-arg]
-- test              : compas test [--watch] [--verbose] [--node-arg]
+- test              : compas test [--watch] [--verbose] [--node-arg] [--serial] [--parallel-count 2]
 - bench             : compas bench [--watch] [--verbose] [--node-arg]
 - coverage          : compas coverage [--watch] [--verbose] [--any-node-arg] [-- --c8-arg]
 - lint              : compas lint [--watch] [--verbose] [--any-node-arg]

--- a/packages/cli/test/command-test.test.js
+++ b/packages/cli/test/command-test.test.js
@@ -1,0 +1,43 @@
+import { dirnameForModule, exec, pathJoin } from "@compas/stdlib";
+import { mainTestFn, test } from "../index.js";
+
+mainTestFn(import.meta);
+
+test("cli/commands/test", (t) => {
+  // Use working directory without tests in it, to prevent recursive test runs
+  const workingDir = pathJoin(
+    dirnameForModule(import.meta),
+    "../../../.github/",
+  );
+
+  // Use executable, since `yarn compas` uses the root of the repo as the working
+  // directory for its spawned 'compas'.
+  const compasExecutable = pathJoin(
+    dirnameForModule(import.meta),
+    "../src/cli.js",
+  );
+
+  t.test("--serial spawns single worker", async (t) => {
+    const { exitCode, stdout } = await exec(
+      `${compasExecutable} test --serial`,
+      {
+        cwd: workingDir,
+      },
+    );
+
+    t.equal(exitCode, 0);
+    t.ok(stdout.includes("in serial."));
+  });
+
+  t.test("--parallel-count spawns number of workers", async (t) => {
+    const { exitCode, stdout } = await exec(
+      `${compasExecutable} test --parallel-count 5`,
+      {
+        cwd: workingDir,
+      },
+    );
+
+    t.equal(exitCode, 0);
+    t.ok(stdout.includes("parallel with 5 runners"));
+  });
+});


### PR DESCRIPTION
Usable in high core count machines.

Closes #993