### PR TITLE
feat(store): add must-revalidate to default cacheControlHeader

### DIFF
--- a/packages/store/src/file-cache.js
+++ b/packages/store/src/file-cache.js
@@ -22,7 +22,8 @@ export class FileCache {
     this.bucketName = bucketName;
 
     this.inMemoryThreshold = options?.inMemoryThreshold ?? 8 * 1024;
-    this.cacheControlHeader = options?.cacheControlHeader ?? "max-age=1200";
+    this.cacheControlHeader =
+      options?.cacheControlHeader ?? "max-age=120, must-revalidate";
 
     this.memoryCache = new Map();
     this.fileCache = new Set();


### PR DESCRIPTION
We use a low max age since files may change relatively fast if a job picks it up. By adding `must-revalidate` we hope that the browser tries to use `if-modified-since`, and thus skips the complete content download.

BREAKING CHANGE:
- The default has changed from `max-age=1200` to `max-age=120, must-revalidate`. Provide your own as the last argument of `new FileCache()` if necessary.