### PR TITLE
feat(code-gen): rename `ctx.event` in matched handlers with a `router.` prefix

### DIFF
--- a/packages/code-gen/src/generator/router/templates/routerFile.tmpl
+++ b/packages/code-gen/src/generator/router/templates/routerFile.tmpl
@@ -96,7 +96,7 @@ const handlers = {
 
       {{= item.uniqueName }}: {{ if (item.body || item.query || item.files) { }} async {{ } }} (params, ctx, next) => {
         if (ctx.event) {
-          eventRename(ctx.event, `{{= item.group }}.{{= item.name }}`);
+          eventRename(ctx.event, `router.{{= item.group }}.{{= item.name }}`);
         }
 
         ctx.request.params = params;


### PR DESCRIPTION
This way it's obvious which event is which, when the executed function has the same event name