### PR TITLE
feat(cli): run tests in parallel by default while collecting coverage

### DIFF
--- a/packages/cli/scripts/test.js
+++ b/packages/cli/scripts/test.js
@@ -26,6 +26,9 @@ const workerFile = new URL(
 mainFn(import.meta, main);
 
 async function main(logger) {
+  // Note that the arguments are also used for coverage. So if an argument is added or
+  // changed. The filter in commands/coverage.js needs to change as well.
+
   if (!isMainThread) {
     logger.error("Test runner can only run as main thread");
     process.exit(1);

--- a/packages/cli/src/commands/coverage.js
+++ b/packages/cli/src/commands/coverage.js
@@ -13,18 +13,27 @@ const c8Path = pathJoin(
  * @returns {Promise<void>}
  */
 export function coverageCommand(logger, command) {
+  const c8Args = [];
+  const testArgs = [];
+
+  let wasParallelCount = false;
+  for (const arg of command.execArguments) {
+    // Hardcode on known test arguments
+    if (arg === "--serial" || arg === "--parallel-count" || wasParallelCount) {
+      testArgs.push(arg);
+      wasParallelCount = arg === "--parallel-count";
+    } else {
+      wasParallelCount = false;
+      c8Args.push(arg);
+    }
+  }
+
   return executeCommand(
     logger,
     command.verbose,
     command.watch,
     c8Path,
-    [
-      ...command.execArguments,
-      "node",
-      ...command.nodeArguments,
-      testFile,
-      "--serial",
-    ],
+    [...c8Args, "node", ...command.nodeArguments, testFile, ...testArgs],
     {},
   );
 }

--- a/packages/cli/src/commands/help.js
+++ b/packages/cli/src/commands/help.js
@@ -41,7 +41,7 @@ Usage:
 - run (implicit)    : compas [--watch] [--verbose] [--any-node-arg] {scriptName|path/to/file.js} [--script-arg]
 - test              : compas test [--watch] [--verbose] [--node-arg] [--serial] [--parallel-count 2]
 - bench             : compas bench [--watch] [--verbose] [--node-arg]
-- coverage          : compas coverage [--watch] [--verbose] [--any-node-arg] [-- --c8-arg]
+- coverage          : compas coverage [--watch] [--verbose] [--any-node-arg] [--c8-arg] [--serial] [--parallel-count 2]
 - lint              : compas lint [--watch] [--verbose] [--any-node-arg]
 - code-mod          : compas code-mod [--verbose] [list,exec] [code-mod-name]
 - visualise         : compas visualise [sql,router] {path/to/generated/index.js} [--format png|svg|webp|pdf] [--output ./path/to/output.ext]


### PR DESCRIPTION
Closes #1022

BREAKING CHANGE:
- `compas coverage` by defaults executes tests with the default settings (parallel)
- `compas coverage` now also accepts all arguments of `compas test` like `--serial` and `--parallel-count`. To get the old behaviour run `compas coverage --serial`