### PR TITLE
feat(cli): remove `newTestEvent` options

### DIFF
--- a/packages/cli/index.d.ts
+++ b/packages/cli/index.d.ts
@@ -14,10 +14,7 @@ export function mainTestFn(meta: ImportMeta): void;
  * Create a test event.
  * event.log.info is a noop by default, but can be enabled via the passed in options.
  */
-export function newTestEvent(
-  t: TestRunner,
-  options?: { enabledLogs?: boolean },
-): InsightEvent;
+export function newTestEvent(t: TestRunner): InsightEvent;
 
 /**
  * Available assertions and the option of doing nested tests

--- a/packages/cli/src/testing/events.js
+++ b/packages/cli/src/testing/events.js
@@ -6,18 +6,8 @@ import { newEvent } from "@compas/stdlib";
  * @since 0.1.0
  *
  * @param {TestRunner} t
- * @param {{ enableLogs?: boolean }} [options={}]
  * @returns {InsightEvent}
  */
-export function newTestEvent(t, options = {}) {
-  options.enableLogs = options.enableLogs ?? false;
-
-  let logger = t.log;
-
-  // Disable info logging
-  if (!options.enableLogs) {
-    logger = { ...logger, info: () => {} };
-  }
-
-  return newEvent(logger, t.signal);
+export function newTestEvent(t) {
+  return newEvent(t.log, t.signal);
 }


### PR DESCRIPTION
Closes #1030

BREAKING CHANGE:
- Removed the `options` argument on `newTestEvent`. This was more confusing than a few extra logs in the test output.