### PR TITLE
test(code-gen): add e2e tests for handled errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ coverage
 /benchmark_output.txt
 
 **/generated/common/structure.sql
+
+__fixtures__/tmp

--- a/packages/code-gen/src/App.js
+++ b/packages/code-gen/src/App.js
@@ -1,8 +1,8 @@
 import {
-  newLogger,
-  printProcessMemoryUsage,
   isNil,
   merge,
+  newLogger,
+  printProcessMemoryUsage,
 } from "@compas/stdlib";
 import { ReferenceType } from "./builders/ReferenceType.js";
 import { buildOrInfer } from "./builders/utils.js";
@@ -240,10 +240,7 @@ export class App {
       options.enabledGenerators.indexOf("router") !== -1
     ) {
       Object.assign(opts, defaultGenerateOptionsNodeServer);
-    } else if (
-      options.isNode ||
-      options.enabledGenerators.indexOf("reactQuery") === -1
-    ) {
+    } else if (options.isNode) {
       Object.assign(opts, defaultGenerateOptionsNode);
     }
 
@@ -256,7 +253,7 @@ export class App {
     opts.enabledGenerators =
       options.enabledGenerators.length > 0
         ? options.enabledGenerators
-        : opts.enabledGenerators;
+        : opts.enabledGenerators ?? [];
 
     // Quick hack so we can test if we have generated
     // before running the tests.

--- a/packages/code-gen/src/generator/errors.test.js
+++ b/packages/code-gen/src/generator/errors.test.js
@@ -1,0 +1,181 @@
+import { mainTestFn, test } from "@compas/cli";
+import { generateAndRunForBuilders } from "../../test/utils.test.js";
+import { TypeCreator } from "../builders/TypeCreator.js";
+
+mainTestFn(import.meta);
+
+test("code-gen/errors", (t) => {
+  t.test("sqlEnableValidator", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [T.object("foo").keys({}).enableQueries()],
+      {
+        enabledGenerators: ["sql"],
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(stdout.includes("Validator generator not enabled"));
+  });
+
+  t.test("sqlThrowingValidators", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [T.object("foo").keys({}).enableQueries()],
+      {
+        enabledGenerators: ["sql", "validator"],
+        throwingValidators: false,
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(stdout.includes("Option 'throwingValidators' not enabled"));
+  });
+
+  t.test("sqlMissingPrimaryKey", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [
+        T.object("foo").keys({}).enableQueries({
+          withPrimaryKey: false,
+        }),
+      ],
+      {
+        isNodeServer: true,
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(stdout.includes("Type 'foo' is missing a primary key"));
+  });
+
+  t.test(
+    "sqlMissingPrimaryKey - via reference that has no queries enabled",
+    async (t) => {
+      const T = new TypeCreator("app");
+      const { stdout, exitCode } = await generateAndRunForBuilders(
+        [
+          T.object("foo")
+            .keys({})
+            .enableQueries({})
+            .relations(T.oneToOne("bar", T.reference("app", "bar"), "foo")),
+
+          T.object("bar").keys({}),
+        ],
+        {
+          isNodeServer: true,
+        },
+      );
+
+      t.equal(exitCode, 1);
+      t.ok(stdout.includes("Type 'bar' is missing a primary key"));
+    },
+  );
+
+  t.test("sqlForgotEnableQueries", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [
+        T.object("foo")
+          .keys({})
+          .enableQueries({})
+          .relations(T.oneToOne("bar", T.reference("app", "bar"), "foo")),
+
+        T.object("bar").keys({
+          // Needs a primary key, else a missing primary key error will be thrown
+          id: T.uuid().primary(),
+        }),
+      ],
+      {
+        isNodeServer: true,
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(stdout.includes("Type 'bar' did not call 'enableQueries'"));
+  });
+
+  t.test("sqlMissingOneToMany", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [
+        T.object("foo")
+          .keys({})
+          .enableQueries({})
+          .relations(T.manyToOne("bar", T.reference("app", "bar"), "foo")),
+
+        T.object("bar").keys({}).enableQueries(),
+      ],
+      {
+        isNodeServer: true,
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(
+      stdout.includes(
+        "Relation from 'foo' is missing the inverse 'T.oneToMany()'",
+      ),
+    );
+  });
+
+  t.test("sqlUnusedOneToMany", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [
+        T.object("foo").keys({}).enableQueries({}),
+
+        T.object("bar")
+          .keys({})
+          .enableQueries()
+          .relations(T.oneToMany("foo", T.reference("app", "foo"))),
+      ],
+      {
+        isNodeServer: true,
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(stdout.includes("Relation defined for 'bar', referencing 'foo'"));
+  });
+
+  t.test("sqlDuplicateShortName", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [
+        T.object("foo").keys({}).enableQueries({}).shortName("test"),
+
+        T.object("bar").keys({}).enableQueries().shortName("test"),
+      ],
+      {
+        isNodeServer: true,
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(stdout.includes("Short name 'test' is used by both"));
+  });
+
+  t.test("sqlReservedRelationKey", async (t) => {
+    const T = new TypeCreator("app");
+    const { stdout, exitCode } = await generateAndRunForBuilders(
+      [
+        T.object("foo")
+          .keys({})
+          .enableQueries({})
+          .relations(
+            T.oneToOne("select", T.reference("app", "bar"), "orderBy"),
+          ),
+
+        T.object("bar").keys({}).enableQueries(),
+      ],
+      {
+        isNodeServer: true,
+      },
+    );
+
+    t.equal(exitCode, 1);
+    t.ok(stdout.includes("Relation name 'select' from type 'foo'"));
+    t.ok(stdout.includes("Relation name 'orderBy' from type 'bar'"));
+  });
+});

--- a/packages/code-gen/src/generator/index.js
+++ b/packages/code-gen/src/generator/index.js
@@ -74,73 +74,78 @@ export function generate(logger, options, structure) {
 
   exitOnErrorsOrReturn(context);
 
-  // Linkup all references, so we don't necessarily have to worry about them in all other
-  // places.
-  linkupReferencesInStructure(context);
-  addFieldsOfRelations(context);
-
-  exitOnErrorsOrReturn(context);
-
-  const copy = {};
-  copyAndSort(context.structure, copy);
-  context.structure = copy;
-
-  templateContext.globals.getTypeNameForType = getTypeNameForType.bind(
-    undefined,
-    context,
-  );
-  templateContext.globals.typeSuffix = getTypeSuffixForUseCase(context.options);
-
-  setupMemoizedTypes(context);
-  exitOnErrorsOrReturn(context);
-
-  checkReservedGroupNames(context);
-  exitOnErrorsOrReturn(context);
-
-  // Do initial sql checks and load in the types
-  // This way the validators are generated
-  if (context.options.enabledGenerators.indexOf("sql") !== -1) {
-    doSqlChecks(context);
-    exitOnErrorsOrReturn(context);
-
-    addShortNamesToQueryEnabledObjects(context);
-    exitOnErrorsOrReturn(context);
-
-    generateSqlStructure(context);
-
-    createWhereTypes(context);
-    createOrderByTypes(context);
-    createPartialTypes(context);
-    createQueryBuilderTypes(context);
+  // Don't execute any logic, we can just write the structure out only
+  if (context.options.enabledGenerators.length > 0) {
+    // Linkup all references, so we don't necessarily have to worry about them in all other
+    // places.
+    linkupReferencesInStructure(context);
+    addFieldsOfRelations(context);
 
     exitOnErrorsOrReturn(context);
-  }
 
-  generateCommonFiles(context);
+    const copy = {};
+    copyAndSort(context.structure, copy);
+    context.structure = copy;
 
-  if (context.options.enabledGenerators.indexOf("validator") !== -1) {
-    generateValidatorFile(context);
-    exitOnErrorsOrReturn(context);
-  }
-  if (context.options.enabledGenerators.indexOf("router") !== -1) {
-    generateRouterFiles(context);
-    exitOnErrorsOrReturn(context);
-  }
-  if (context.options.enabledGenerators.indexOf("apiClient") !== -1) {
-    generateApiClientFiles(context);
-    exitOnErrorsOrReturn(context);
-  }
-  if (context.options.enabledGenerators.indexOf("reactQuery") !== -1) {
-    generateReactQueryFiles(context);
-    exitOnErrorsOrReturn(context);
-  }
-  if (context.options.enabledGenerators.indexOf("sql") !== -1) {
-    generateModelFiles(context);
-    exitOnErrorsOrReturn(context);
-  }
+    templateContext.globals.getTypeNameForType = getTypeNameForType.bind(
+      undefined,
+      context,
+    );
+    templateContext.globals.typeSuffix = getTypeSuffixForUseCase(
+      context.options,
+    );
 
-  if (context.options.enabledGenerators.indexOf("type") !== -1) {
-    generateTypeFile(context);
+    setupMemoizedTypes(context);
+    exitOnErrorsOrReturn(context);
+
+    checkReservedGroupNames(context);
+    exitOnErrorsOrReturn(context);
+
+    // Do initial sql checks and load in the types
+    // This way the validators are generated
+    if (context.options.enabledGenerators.indexOf("sql") !== -1) {
+      doSqlChecks(context);
+      exitOnErrorsOrReturn(context);
+
+      addShortNamesToQueryEnabledObjects(context);
+      exitOnErrorsOrReturn(context);
+
+      generateSqlStructure(context);
+
+      createWhereTypes(context);
+      createOrderByTypes(context);
+      createPartialTypes(context);
+      createQueryBuilderTypes(context);
+
+      exitOnErrorsOrReturn(context);
+    }
+
+    generateCommonFiles(context);
+
+    if (context.options.enabledGenerators.indexOf("validator") !== -1) {
+      generateValidatorFile(context);
+      exitOnErrorsOrReturn(context);
+    }
+    if (context.options.enabledGenerators.indexOf("router") !== -1) {
+      generateRouterFiles(context);
+      exitOnErrorsOrReturn(context);
+    }
+    if (context.options.enabledGenerators.indexOf("apiClient") !== -1) {
+      generateApiClientFiles(context);
+      exitOnErrorsOrReturn(context);
+    }
+    if (context.options.enabledGenerators.indexOf("reactQuery") !== -1) {
+      generateReactQueryFiles(context);
+      exitOnErrorsOrReturn(context);
+    }
+    if (context.options.enabledGenerators.indexOf("sql") !== -1) {
+      generateModelFiles(context);
+      exitOnErrorsOrReturn(context);
+    }
+
+    if (context.options.enabledGenerators.indexOf("type") !== -1) {
+      generateTypeFile(context);
+    }
   }
   // Add provided file headers to all files
   annotateFilesWithHeader(context);

--- a/packages/code-gen/src/generator/sql/add-fields.js
+++ b/packages/code-gen/src/generator/sql/add-fields.js
@@ -51,14 +51,21 @@ export function addFieldsForRelation(context, type, relation) {
     return;
   }
 
-  const { field } = getPrimaryKeyWithType(relation.reference.reference);
-  type.keys[relation.ownKey] = {
-    ...field,
-    sql: {
-      searchable: true,
-    },
-    isOptional: relation.isOptional,
-  };
+  try {
+    const { field } = getPrimaryKeyWithType(relation.reference.reference);
+    type.keys[relation.ownKey] = {
+      ...field,
+      sql: {
+        searchable: true,
+      },
+      isOptional: relation.isOptional,
+    };
+  } catch {
+    context.errors.push({
+      key: "sqlMissingPrimaryKey",
+      typeName: relation.reference.reference.name,
+    });
+  }
 }
 
 /**

--- a/packages/code-gen/test/utils.test.js
+++ b/packages/code-gen/test/utils.test.js
@@ -1,0 +1,76 @@
+import { spawn as cpSpawn } from "child_process";
+import { rm, writeFile } from "fs/promises";
+import { pathJoin, uuid } from "../../stdlib/index.js";
+import { App } from "../src/App.js";
+
+/**
+ * Try to generate with the provided builders in a temporary directory.
+ * - First dump the structure
+ * - Create a file that imports structure and tries to generate
+ * - Execute file via spawn to get the stdout
+ * - Return stdout and exitCode
+ *
+ * @param {TypeBuilder[]} builders
+ * @param {GenerateOpts} [opts]
+ * @returns {Promise<{ stdout: string, exitCode: number }>}
+ */
+export async function generateAndRunForBuilders(builders, opts = {}) {
+  const tmpDirectory = pathJoin(process.cwd(), `/__fixtures__/tmp/${uuid()}`);
+  const tmpDirectoryStructure = pathJoin(tmpDirectory, "/structure");
+  const tmpDirectoryGenerate = pathJoin(tmpDirectory, "/generated");
+
+  const app = new App();
+  app.add(...builders);
+
+  // Disable all (inferred) generators
+  await app.generate({
+    ...opts,
+    outputDirectory: tmpDirectoryStructure,
+    dumpStructure: true,
+    enabledGenerators: [],
+    isNodeServer: false,
+    isNode: false,
+    isBrowser: false,
+  });
+
+  const genFile = `
+import { mainFn } from "@compas/stdlib";
+import { App } from "@compas/code-gen";
+import { structure } from "${tmpDirectoryStructure}/common/structure.js";
+
+mainFn(import.meta, main);
+
+async function main() {
+  const app = new App();
+  
+  app.extend(structure);
+  
+  await app.generate({
+    ...JSON.parse('${JSON.stringify(opts)}'),
+    outputDirectory: "${tmpDirectoryGenerate}",
+  });
+}
+  `;
+
+  const testFilePath = pathJoin(tmpDirectory, `${uuid().substr(0, 6)}.js`);
+
+  await writeFile(testFilePath, genFile, "utf-8");
+
+  const sp = cpSpawn(`node`, [testFilePath], { stdio: "pipe" });
+
+  const stdoutBuffers = [];
+  sp.stdout.on("data", (data) => {
+    stdoutBuffers.push(data);
+  });
+
+  const exitCode = await new Promise((r) => {
+    sp.once("exit", (e) => r(e ?? 0));
+  });
+
+  await rm(tmpDirectory, { recursive: true, force: true });
+
+  return {
+    stdout: Buffer.concat(stdoutBuffers).toString("utf-8"),
+    exitCode,
+  };
+}


### PR DESCRIPTION
Also fixes some minor issues with `isNode` being to greedy, and supporting the case that no generator is enabled.

Closes #1021