### PR TITLE
feat(code-gen): add sql upsert on primary key support

### DIFF
--- a/packages/code-gen/test/sql.test.js
+++ b/packages/code-gen/test/sql.test.js
@@ -199,6 +199,33 @@ test("code-gen/e2e/sql", (t) => {
     t.equal(dbUser.deletedAt, undefined);
   });
 
+  t.test("upsert user nick name", async (t) => {
+    const id = uuid();
+    const [insert] = await queries.userUpsertOnId(sql, {
+      id,
+      email: "test",
+      authKey: uuid(),
+      nickName: "foo",
+    });
+
+    t.equal(insert.id, id);
+
+    const [upsert] = await queries.userUpsertOnId(sql, {
+      id,
+      email: "test2",
+      authKey: uuid(),
+      nickName: "foo",
+    });
+
+    t.equal(upsert.id, insert.id);
+    t.deepEqual(upsert.createdAt, insert.createdAt);
+    t.equal(upsert.email, "test2");
+
+    await queries.userDeletePermanent(sql, {
+      id,
+    });
+  });
+
   t.test("query filter by 'in' statements", async (t) => {
     await queryUser({
       where: {

--- a/packages/store/src/testing.js
+++ b/packages/store/src/testing.js
@@ -1,4 +1,4 @@
-import { newLogger, environment, isNil, uuid } from "@compas/stdlib";
+import { environment, isNil, newLogger, uuid } from "@compas/stdlib";
 import {
   createDatabaseIfNotExists,
   newPostgresConnection,
@@ -67,7 +67,8 @@ export async function cleanupPostgresDatabaseTemplate() {
  *
  * @since 0.1.0
  *
- * @param {boolean} [verboseSql=false] If true, creates a new logger and prints all queries.
+ * @param {boolean} [verboseSql=false] If true, creates a new logger and prints all
+ *   queries.
  * @param {object} [connectionOptions]
  * @returns {Promise<Postgres>}
  */


### PR DESCRIPTION
- The primary key & createdAt fields are skipped when upserting
- Optional values from the existing row are kept, even if the provided insert values have an explicit null value.

Closes #1080