### PR TITLE
feat(store): add support for JS migration files

### DIFF
--- a/__fixtures__/store/996-js-migration.js
+++ b/__fixtures__/store/996-js-migration.js
@@ -1,0 +1,8 @@
+export async function migrate(sql) {
+  await sql.unsafe(`
+    CREATE TABLE "testTable"
+    (
+      value int
+    );
+  `);
+}

--- a/__fixtures__/store/997-test.sql
+++ b/__fixtures__/store/997-test.sql
@@ -1,5 +1,1 @@
-CREATE TABLE "testTable" (
-  value INT
-);
-
 INSERT INTO "testTable" (value) VALUES (1), (2), (3);

--- a/packages/store/src/migrations.js
+++ b/packages/store/src/migrations.js
@@ -239,7 +239,7 @@ async function runMigration(sql, migration) {
       if (typeof migrate !== "function") {
         throw AppError.serverError({
           message:
-            "JavaScript migration files should contain the following signature: 'export async function migrate(sql)",
+            "JavaScript migration files should contain the following signature: 'export async function migrate(sql)'.",
         });
       }
 

--- a/packages/store/src/migrations.test.js
+++ b/packages/store/src/migrations.test.js
@@ -27,19 +27,19 @@ test("store/migrations", (t) => {
   t.test("run full migration", async (t) => {
     const mc = await newMigrateContext(sql, `./__fixtures__/store`);
 
-    t.equal(mc.files.length, 3);
+    t.equal(mc.files.length, 4);
 
     const { migrationQueue: list } = getMigrationsToBeApplied(mc);
-    t.equal(list.length, 3);
+    t.equal(list.length, 4);
 
-    t.ok(list[0].repeatable === false);
-    t.ok(list[0].number === 997);
+    t.ok(list[1].repeatable === false);
+    t.ok(list[1].number === 997);
 
-    t.ok(list[1].repeatable === true);
-    t.ok(list[1].number === 998);
+    t.ok(list[2].repeatable === true);
+    t.ok(list[2].number === 998);
 
-    t.ok(list[2].repeatable === false);
-    t.ok(list[2].number === 999);
+    t.ok(list[3].repeatable === false);
+    t.ok(list[3].number === 999);
 
     await runMigrations(mc);
     const testResult = await sql`


### PR DESCRIPTION
By exporting a migrate function, the users have more flexibility to do some business / conditional logic based on for example env values.

Closes #1092