### PR TITLE
fix(store): syncDeletedFiles permanently delete transformed

### DIFF
--- a/packages/store/src/files.js
+++ b/packages/store/src/files.js
@@ -183,8 +183,9 @@ export async function copyFile(
  */
 export async function syncDeletedFiles(sql, minio, bucketName) {
   // Delete transformed copies of deleted files
-  await queries.fileDelete(sql, {
+  await queries.fileDeletePermanent(sql, {
     $raw: query`meta->>'transformedFromOriginal' IS NOT NULL AND NOT EXISTS (SELECT FROM "file" f2 WHERE f2.id = (meta->>'transformedFromOriginal')::uuid)`,
+    deletedAtIncludeNotNull: true,
   });
 
   const minioObjectsPromise = listObjects(minio, bucketName);


### PR DESCRIPTION
Transformed artifacts generated via for example `sendTransformedImage` are now permanently deleted if the original is removed.