### PR TITLE
feat(stdlib): support formatting Error#clause in AppError#format

### DIFF
--- a/packages/stdlib/src/error.js
+++ b/packages/stdlib/src/error.js
@@ -155,6 +155,7 @@ export class AppError extends Error {
       name: e.name,
       message: e.message,
       stack,
+      cause: e.cause ? AppError.format(e.cause) : undefined,
     };
   }
 

--- a/packages/stdlib/src/error.test.js
+++ b/packages/stdlib/src/error.test.js
@@ -118,4 +118,16 @@ test("stdlib/error", (t) => {
       t.ok(Array.isArray(formatted.originalError.stack));
     }
   });
+
+  t.test("AppError#format with Error#cause property", (t) => {
+    try {
+      const err = AppError.validationError("foo");
+      throw new Error("Bar", { cause: err });
+    } catch (e) {
+      const formatted = AppError.format(e);
+      t.ok(AppError.instanceOf(formatted.cause));
+      t.equal(formatted.message, "Bar");
+      t.equal(formatted.cause.key, "foo");
+    }
+  });
 });


### PR DESCRIPTION
Note that for consistency reasons we may want to rename 'originalError' to 'cause' at some point

Closes #1181