### PR TITLE
feat(store): add job name filter to JobQueueWorker

### DIFF
--- a/packages/cli/src/commands/visualise.js
+++ b/packages/cli/src/commands/visualise.js
@@ -92,7 +92,7 @@ export async function visualiseCommand(logger, command) {
 
   // Execute and write
 
-  let graph;
+  let graph = "";
   if (subCommand === "sql") {
     graph = formatGraphOfSql(codeGen, structure);
   } else if (subCommand === "router") {

--- a/packages/store/src/queue.d.ts
+++ b/packages/store/src/queue.d.ts
@@ -164,20 +164,15 @@ export function getUncompletedJobsByName(sql: Postgres): Promise<{
 export class JobQueueWorker {
   /**
    * @param {Postgres} sql
-   * @param {string|JobQueueWorkerOptions} nameOrOptions
-   * @param {JobQueueWorkerOptions} [options]
+   * @param {JobQueueWorkerOptions} options
    */
-  constructor(
-    sql: Postgres,
-    nameOrOptions: string | JobQueueWorkerOptions,
-    options?: JobQueueWorkerOptions | undefined,
-  );
+  constructor(sql: Postgres, options: JobQueueWorkerOptions);
   sql: import("../types/advanced-types").Postgres;
-  newJobQuery: (sql: any) => any;
-  name: string | undefined;
   pollInterval: number;
   maxRetryCount: number;
   handlerTimeout: number;
+  /** @type {StoreJobWhere} */
+  where: StoreJobWhere;
   workers: any[];
   /** @type {any} */
   timeout: any;
@@ -191,8 +186,7 @@ export class JobQueueWorker {
             handler: JobQueueHandlerFunction;
             timeout: number;
           }
-      >
-    | undefined;
+      >;
   logger: import("@compas/stdlib/types/advanced-types").Logger;
   start(): void;
   stop(): void;
@@ -282,5 +276,15 @@ export type JobQueueWorkerOptions = {
    * fulfill a job in milliseconds Defaults to 30 seconds.
    */
   handlerTimeout?: number | undefined;
+  /**
+   * Included job names for this job worker,
+   * ignores all other jobs.
+   */
+  includedNames?: string[] | undefined;
+  /**
+   * Excluded job names for this job worker,
+   * picks up all other jobs.
+   */
+  excludedNames?: string[] | undefined;
 };
 //# sourceMappingURL=queue.d.ts.map

--- a/packages/store/src/queue.test.js
+++ b/packages/store/src/queue.test.js
@@ -58,6 +58,7 @@ test("store/queue", (t) => {
       parallelCount: 1,
       pollInterval: 10,
       handler,
+      excludedNames: ["job.excludedName"],
     });
 
     t.equal(handlerCalls.length, 0);
@@ -259,6 +260,17 @@ test("store/queue", (t) => {
     }).exec(sql);
 
     t.equal(job3.isComplete, true);
+  });
+
+  t.test("pendingQueue - excludedNames", async (t) => {
+    const start = await qw.pendingQueueSize();
+    await addJobToQueue(sql, {
+      name: "job.excludedName",
+    });
+
+    const end = await qw.pendingQueueSize();
+
+    t.deepEqual(start, end);
   });
 
   t.test("addEventToQueue", async (t) => {


### PR DESCRIPTION
Added `includedNames` & `excludedNames` options. Only one can be specified.

The `pendingQueueSize() & averageTimeToCompletion()` methods on the `JobQueueWorker` also respect these filters.

Closes #1223

BREAKING CHANGE:
- Removed support for specifying a specific job name in the `JobQueueWorker` constructor. Please migrate to the `{ includedNames: ["job.name"] }` syntax.