### PR TITLE
feat(code-gen,server): change requestId behaviour

### DIFF
--- a/packages/cli/src/commands/proxy.js
+++ b/packages/cli/src/commands/proxy.js
@@ -86,7 +86,6 @@ export function proxyCommand(logger, command) {
       res.setHeader("Access-Control-Allow-Origin", origin);
       res.setHeader("Access-Control-Allow-Credentials", "true");
       res.setHeader("Access-Control-Allow-Methods", allowMethods);
-      res.setHeader("Access-Control-Expose-Headers", "x-request-id");
 
       if (req.headers["access-control-request-headers"]) {
         res.setHeader(

--- a/packages/code-gen/src/generator/common.js
+++ b/packages/code-gen/src/generator/common.js
@@ -80,37 +80,6 @@ function generateCommonApiClientFile(context) {
     contents += `import { AxiosInstance } from "axios";`;
   }
 
-  contents += js`
-      export function addRequestIdInterceptors(instance
-
-      ${context.options.useTypescript ? ": AxiosInstance" : ""}
-      )
-      {
-         let requestId
-         ${
-           context.options.useTypescript ? ": string | undefined" : ""
-         } = undefined;
-         instance.interceptors.request.use((config) => {
-            if (requestId) {
-               config.headers["x-request-id"] = requestId;
-            }
-            return config;
-         });
-
-         instance.interceptors.response.use((response) => {
-            if (response.headers["x-request-id"]) {
-               requestId = response.headers["x-request-id"];
-            }
-            return response;
-         }, (error) => {
-            if (error.response && error.response.headers["x-request-id"]) {
-               requestId = error.response.headers["x-request-id"];
-            }
-            return Promise.reject(error);
-         });
-      }
-   `;
-
   return contents;
 }
 
@@ -159,8 +128,8 @@ export type AppErrorResponse = AxiosError<{
       stack?: string[];
     };
     [key: string]: any;
-  };
-}>;
+  }
+}>
 
 export type UseQueryOptions<Response, Error, TData = Response> = ReactUseQueryOptions<Response, Error, TData> & { cancelToken?: CancelTokenSource };
 `;

--- a/packages/code-gen/test/e2e-server.test.js
+++ b/packages/code-gen/test/e2e-server.test.js
@@ -13,9 +13,6 @@ import Axios from "axios";
 mainTestFn(import.meta);
 
 test("code-gen/e2e-server", async (t) => {
-  const commonApiClientImport = await import(
-    "../../../generated/testing/server/common/apiClient.js"
-  );
   const serverApiClientImport = await import(
     "../../../generated/testing/server/server/apiClient.js"
   );
@@ -29,8 +26,6 @@ test("code-gen/e2e-server", async (t) => {
   const app = await buildTestApp();
   const axiosInstance = Axios.create({});
   await createTestAppAndClient(app, axiosInstance);
-
-  commonApiClientImport.addRequestIdInterceptors(axiosInstance);
 
   t.test("client - request cancellation works", async (t) => {
     try {

--- a/packages/server/src/app.test.js
+++ b/packages/server/src/app.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 import { mainTestFn, test } from "@compas/cli";
-import { AppError, isPlainObject, uuid } from "@compas/stdlib";
+import { AppError, isPlainObject } from "@compas/stdlib";
 import Axios from "axios";
 import { closeTestApp, createTestAppAndClient, getApp } from "../index.js";
 
@@ -86,34 +86,6 @@ test("server/app", (t) => {
       t.equal(formatted.axios.requestPath, "/wrap-500");
       t.equal(formatted.axios.requestMethod, "GET");
     }
-  });
-
-  t.test("consistent x-request-id handling", async (t) => {
-    const response = await client.get("/200");
-    const header = response.headers["x-request-id"];
-
-    t.ok(uuid.isValid(header));
-
-    const secondResponse = await client.get("/200", {
-      headers: { "x-request-id": header },
-    });
-
-    t.equal(header, secondResponse.headers["x-request-id"]);
-  });
-
-  t.test("consistent x-request-id with generated api client", async (t) => {
-    const commonApiClientImport = await import(
-      "./../../../generated/testing/server/common/apiClient.js"
-    );
-
-    commonApiClientImport.addRequestIdInterceptors(client);
-
-    const response = await client.get("/200");
-    const secondResponse = await client.get("/200");
-    t.equal(
-      response.headers["x-request-id"],
-      secondResponse.headers["x-request-id"],
-    );
   });
 
   t.test("close _server", async (t) => {

--- a/packages/server/src/middleware/cors.js
+++ b/packages/server/src/middleware/cors.js
@@ -31,7 +31,7 @@ import { environment, isStaging } from "@compas/stdlib";
 const defaultOptions = {
   allowMethods: ["GET", "PUT", "POST", "PATCH", "DELETE", "HEAD", "OPTIONS"],
   credentials: true,
-  exposeHeaders: ["x-request-id"],
+  exposeHeaders: [],
 };
 
 /**

--- a/packages/server/src/middleware/log.js
+++ b/packages/server/src/middleware/log.js
@@ -2,9 +2,9 @@ import { Transform } from "stream";
 import {
   eventStart,
   eventStop,
+  isNil,
   newEvent,
   newLogger,
-  isNil,
   uuid,
 } from "@compas/stdlib";
 
@@ -48,17 +48,10 @@ export function logMiddleware(options) {
 
   return async (ctx, next) => {
     const startTime = process.hrtime.bigint();
-
-    let requestId = ctx.get("x-request-id");
-    if (isNil(requestId) || requestId.length === 0) {
-      requestId = uuid();
-    }
-    ctx.set("x-request-id", requestId);
-
     ctx.log = newLogger({
       ctx: {
         type: "http",
-        requestId,
+        requestId: uuid(),
       },
     });
 


### PR DESCRIPTION
The existing behaviour was to try to propagate the request id over requests, but that didn't work with requests happening from server side rendering. And it's also not privacy-friendly.

So now we use a requestId in the backend to find request related logs, and nothing more.

BREAKING CHANGE:
- Removed `addRequestIdInterceptors` from `$generatedDir/common/apiClient`