### PR TITLE
feat(server): log middleware also handles Koa error events

### DIFF
--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -82,7 +82,7 @@ export function getApp(opts = {}) {
     app.use(healthHandler());
   }
 
-  app.use(logMiddleware(opts.logOptions ?? {}));
+  app.use(logMiddleware(app, opts.logOptions ?? {}));
   app.use(errorHandler(opts.errorOptions ?? {}));
   app.use(notFoundHandler());
 

--- a/packages/server/src/middleware/log.d.ts
+++ b/packages/server/src/middleware/log.d.ts
@@ -1,9 +1,13 @@
 /**
  * Log basic request and response information
  *
+ * @param {import("koa")} app
  * @param {{ disableRootEvent?: boolean }} options
  */
-export function logMiddleware(options: {
-  disableRootEvent?: boolean;
-}): (ctx: any, next: any) => Promise<void>;
+export function logMiddleware(
+  app: import("koa"),
+  options: {
+    disableRootEvent?: boolean;
+  },
+): (ctx: any, next: any) => Promise<void>;
 //# sourceMappingURL=log.d.ts.map


### PR DESCRIPTION
These are emitted if for example the socket is hang up from the browser.
It tries to use the request logger but else uses a 'http-error' context type logger.