### PR TITLE
feat(code-gen): make date validator more flexible

### DIFF
--- a/packages/code-gen/src/generated/common/anonymous-validators.d.ts
+++ b/packages/code-gen/src/generated/common/anonymous-validators.d.ts
@@ -308,15 +308,6 @@ export function anonymousValidator1573852460(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<undefined|string>}
- */
-export function anonymousValidator852571656(
-  value: any,
-  propertyPath: string,
-): EitherN<undefined | string>;
-/**
- * @param {*} value
- * @param {string} propertyPath
  * @returns {EitherN<undefined|Date>}
  */
 export function anonymousValidator1988053796(

--- a/packages/code-gen/src/generated/common/anonymous-validators.js
+++ b/packages/code-gen/src/generated/common/anonymous-validators.js
@@ -1220,76 +1220,6 @@ export function anonymousValidator1573852460(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<undefined|string>}
- */
-export function anonymousValidator852571656(value, propertyPath) {
-  if (isNil(value)) {
-    return { value: undefined };
-  }
-  if (typeof value !== "string") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (value.length === 0) {
-    return {
-      value: undefined,
-    };
-  }
-  if (value.length < 24) {
-    const min = 24;
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.min",
-          info: { min },
-        },
-      ],
-    };
-  }
-  if (value.length > 29) {
-    const max = 29;
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.max",
-          info: { max },
-        },
-      ],
-    };
-  }
-  if (
-    !/^(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))$/gi.test(
-      value,
-    )
-  ) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.pattern",
-          info: {},
-        },
-      ],
-    };
-  }
-  return { value };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
  * @returns {EitherN<undefined|Date>}
  */
 export function anonymousValidator1988053796(value, propertyPath) {
@@ -1312,17 +1242,7 @@ export function anonymousValidator1988053796(value, propertyPath) {
       ],
     };
   }
-  let date = new Date(value);
-  if (typeof value === "string") {
-    value = anonymousValidator852571656(value, propertyPath);
-    if (value.errors) {
-      return value;
-    }
-    if (!value.value) {
-      return { value: value.value };
-    }
-    date = new Date(value.value);
-  }
+  const date = new Date(value);
   if (isNaN(date.getTime())) {
     /** @type {{ errors: InternalError[] }} */
     return {

--- a/packages/code-gen/src/generator/validator.js
+++ b/packages/code-gen/src/generator/validator.js
@@ -585,19 +585,6 @@ function anonymousValidatorBoolean(context, imports, type) {
  * @param {CodeGenDateType} type
  */
 function anonymousValidatorDate(context, imports, type) {
-  const stringType = {
-    ...TypeBuilder.getBaseData(),
-    type: "string",
-    isOptional: type.isOptional,
-    validator: {
-      allowNull: type.validator.allowNull,
-      min: 24,
-      max: 29,
-      pattern:
-        "/^(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$/gi",
-    },
-  };
-
   return js`
     if (typeof value !== "string" && typeof value !== "number" &&
       !(value instanceof Date)) {
@@ -611,35 +598,7 @@ function anonymousValidatorDate(context, imports, type) {
       };
     }
     
-    let date = new Date(value);
-
-    if (typeof value === "string") {
-      ${generateAnonymousValidatorCall(
-        context,
-        imports,
-        stringType,
-        "value",
-        "propertyPath",
-        "value =",
-      )}
-      
-      if (value.errors) {
-        return value;
-      }
-
-      ${
-        type.isOptional && !isNil(type.defaultValue)
-          ? `if (!value.value) { return { value: ${type.defaultValue} }; }`
-          : ""
-      }
-      ${
-        type.isOptional
-          ? `if (!value.value) { return { value: value.value }; }`
-          : ""
-      }
-      
-      date = new Date(value.value);
-    }
+    const date = new Date(value);
 
     if (isNaN(date.getTime())) {
       /** @type {{ errors: InternalError[] }} */

--- a/packages/code-gen/test/validators.test.js
+++ b/packages/code-gen/test/validators.test.js
@@ -288,7 +288,6 @@ test("code-gen/validators", async (t) => {
   t.test("date", (t) => {
     const date = new Date();
     const str = date.toISOString();
-    const invalidFormat = "1221-10-13TAA:47:26.526Z";
     const time = date.getTime();
 
     assertAll(
@@ -309,12 +308,7 @@ test("code-gen/validators", async (t) => {
         {
           input: "foo",
           errorObjectKey: "$",
-          errorKey: "validator.string.min",
-        },
-        {
-          input: invalidFormat,
-          errorObjectKey: "$",
-          errorKey: "validator.string.pattern",
+          errorKey: "validator.date.invalid",
         },
       ],
       validators.validateValidatorDate,

--- a/packages/store/src/generated/common/anonymous-validators.d.ts
+++ b/packages/store/src/generated/common/anonymous-validators.d.ts
@@ -76,15 +76,6 @@ export function anonymousValidator56355924(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<undefined|string>}
- */
-export function anonymousValidator852571656(
-  value: any,
-  propertyPath: string,
-): EitherN<undefined | string>;
-/**
- * @param {*} value
- * @param {string} propertyPath
  * @returns {EitherN<Date>}
  */
 export function anonymousValidator1389014320(
@@ -294,15 +285,6 @@ export function anonymousValidator430889951(
   minutes?: undefined | number;
   seconds?: undefined | number;
 }>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<string>}
- */
-export function anonymousValidator1135331723(
-  value: any,
-  propertyPath: string,
-): EitherN<string>;
 /**
  * @param {*} value
  * @param {string} propertyPath

--- a/packages/store/src/generated/common/anonymous-validators.js
+++ b/packages/store/src/generated/common/anonymous-validators.js
@@ -661,76 +661,6 @@ export function anonymousValidator56355924(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<undefined|string>}
- */
-export function anonymousValidator852571656(value, propertyPath) {
-  if (isNil(value)) {
-    return { value: undefined };
-  }
-  if (typeof value !== "string") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (value.length === 0) {
-    return {
-      value: undefined,
-    };
-  }
-  if (value.length < 24) {
-    const min = 24;
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.min",
-          info: { min },
-        },
-      ],
-    };
-  }
-  if (value.length > 29) {
-    const max = 29;
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.max",
-          info: { max },
-        },
-      ],
-    };
-  }
-  if (
-    !/^(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))$/gi.test(
-      value,
-    )
-  ) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.pattern",
-          info: {},
-        },
-      ],
-    };
-  }
-  return { value };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
  * @returns {EitherN<Date>}
  */
 export function anonymousValidator1389014320(value, propertyPath) {
@@ -753,20 +683,7 @@ export function anonymousValidator1389014320(value, propertyPath) {
       ],
     };
   }
-  let date = new Date(value);
-  if (typeof value === "string") {
-    value = anonymousValidator852571656(value, propertyPath);
-    if (value.errors) {
-      return value;
-    }
-    if (!value.value) {
-      return { value: new Date() };
-    }
-    if (!value.value) {
-      return { value: value.value };
-    }
-    date = new Date(value.value);
-  }
+  const date = new Date(value);
   if (isNaN(date.getTime())) {
     /** @type {{ errors: InternalError[] }} */
     return {
@@ -806,17 +723,7 @@ export function anonymousValidator1988053796(value, propertyPath) {
       ],
     };
   }
-  let date = new Date(value);
-  if (typeof value === "string") {
-    value = anonymousValidator852571656(value, propertyPath);
-    if (value.errors) {
-      return value;
-    }
-    if (!value.value) {
-      return { value: value.value };
-    }
-    date = new Date(value.value);
-  }
+  const date = new Date(value);
   if (isNaN(date.getTime())) {
     /** @type {{ errors: InternalError[] }} */
     return {
@@ -1716,80 +1623,6 @@ export function anonymousValidator430889951(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<string>}
- */
-export function anonymousValidator1135331723(value, propertyPath) {
-  if (isNil(value)) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.undefined",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (typeof value !== "string") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (value.length < 24) {
-    const min = 24;
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.min",
-          info: { min },
-        },
-      ],
-    };
-  }
-  if (value.length > 29) {
-    const max = 29;
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.max",
-          info: { max },
-        },
-      ],
-    };
-  }
-  if (
-    !/^(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))$/gi.test(
-      value,
-    )
-  ) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.string.pattern",
-          info: {},
-        },
-      ],
-    };
-  }
-  return { value };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
  * @returns {EitherN<Date>}
  */
 export function anonymousValidator448481401(value, propertyPath) {
@@ -1821,14 +1654,7 @@ export function anonymousValidator448481401(value, propertyPath) {
       ],
     };
   }
-  let date = new Date(value);
-  if (typeof value === "string") {
-    value = anonymousValidator1135331723(value, propertyPath);
-    if (value.errors) {
-      return value;
-    }
-    date = new Date(value.value);
-  }
+  const date = new Date(value);
   if (isNaN(date.getTime())) {
     /** @type {{ errors: InternalError[] }} */
     return {


### PR DESCRIPTION
Now allows any valid number or string that is accepted by the date constructor, since for some cases the full timestamp may be too strict.

Closes #1229