### PR TITLE
feat(stdlib): use Pino as ndjson logger

### DIFF
--- a/docs/features/logger-and-events.md
+++ b/docs/features/logger-and-events.md
@@ -31,7 +31,10 @@ Parameters:
     to use. Automatically inferred from the env variables.
   - `stream` (Stream): The stream to write to, defaults to `process.stdout`.
     This is the intended use case. Although streams to files may work, this is
-    not supported.
+    not supported. This option is ignored if the printer is `ndjson`.
+  - `pinoOptions`: Specify a custom Pino transport or destination. See the
+    [Pino docs](https://getpino.io) for more information. This field is only
+    used if the printer is `ndjson`.
   - `ctx` (object): Any context to add to log lines. This value is copied
     immediately on logger creation, so changes made via a reference, will not be
     reflected.
@@ -69,8 +72,8 @@ line is structured as follows:
 {
   // The log level, either 'info' or 'error'
   level: "info",
-  // Current date and time formatted as ISO8601-string
-  timestamp: "2021-01-19T21:17:11.693Z",
+  // Milliseconds since the unix epoch
+  time: 1634375371114,
   // The `ctx` that is passed in `newLogger`
   // In this case the default by `mainFn` from `@compas/stdlib`
   context: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "fastest-validator": "1.11.1",
     "form-data": "4.0.0",
     "meriyah": "4.2.0",
-    "pino": "7.0.2",
     "react": "17.0.2",
     "react-query": "3.27.0",
     "typescript": "4.4.4",

--- a/packages/stdlib/package.json
+++ b/packages/stdlib/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@types/node": "16.11.1",
     "dotenv": "10.0.0",
-    "lodash.merge": "4.6.2"
+    "lodash.merge": "4.6.2",
+    "pino": "7.0.2"
   },
   "maintainers": [
     {

--- a/packages/stdlib/src/logger/logger.bench.js
+++ b/packages/stdlib/src/logger/logger.bench.js
@@ -4,34 +4,13 @@ import { newLogger } from "./logger.js";
 
 mainBenchFn(import.meta);
 
-const getCompasCompatiblePino = () => {
-  const pinoLogger = pino(
-    {
-      formatters: {
-        level: (label) => ({ level: label }),
-        bindings: () => ({}),
-      },
-      serializers: {},
-      base: {},
-      // We don't add time here, since it's much faster without
-      // timestamp: () => `, "timestamp": "${new Date().toISOString()}"`,
-    },
-    {
-      write() {},
-    },
-  ).child({ context: { application: "compas" } });
-
-  return {
-    info: (message) => pinoLogger.info({ message }),
-    error: (message) => pinoLogger.error({ message }),
-  };
-};
-
 bench("logger - strings", (b) => {
   const logger = newLogger({
     printer: "ndjson",
-    stream: {
-      write: () => {},
+    pinoOptions: {
+      destination: {
+        write: () => {},
+      },
     },
   });
 
@@ -52,19 +31,14 @@ bench("pino - default - strings", (b) => {
     logger.info("My simple string");
   }
 });
-bench("pino - compas compat - strings", (b) => {
-  const logger = getCompasCompatiblePino();
-
-  for (let i = 0; i < b.N; ++i) {
-    logger.info("My simple string");
-  }
-});
 
 bench("logger - objects", (b) => {
   const logger = newLogger({
     printer: "ndjson",
-    stream: {
-      write: () => {},
+    pinoOptions: {
+      destination: {
+        write: () => {},
+      },
     },
   });
 
@@ -94,23 +68,13 @@ bench("pino - default - objects", (b) => {
   }
 });
 
-bench("pino - compas compat - objects", (b) => {
-  const logger = getCompasCompatiblePino();
-
-  for (let i = 0; i < b.N; ++i) {
-    logger.info({
-      my: {
-        simple: "object",
-      },
-    });
-  }
-});
-
 bench("logger - deep objects", (b) => {
   const logger = newLogger({
     printer: "ndjson",
-    stream: {
-      write: () => {},
+    pinoOptions: {
+      destination: {
+        write: () => {},
+      },
     },
   });
 
@@ -139,27 +103,6 @@ bench("pino - default - deep objects", (b) => {
       write: () => {},
     },
   );
-
-  for (let i = 0; i < b.N; ++i) {
-    logger.info({
-      my: {
-        more: [
-          {
-            advanced: {
-              object: "with",
-              multiple: "keys",
-              foo: 5,
-            },
-          },
-        ],
-      },
-      bar: true,
-    });
-  }
-});
-
-bench("pino - compas compat - deep objects", (b) => {
-  const logger = getCompasCompatiblePino();
 
   for (let i = 0; i < b.N; ++i) {
     logger.info({

--- a/packages/stdlib/src/logger/logger.test.js
+++ b/packages/stdlib/src/logger/logger.test.js
@@ -1,0 +1,68 @@
+import { mainTestFn, test } from "@compas/cli";
+import { newLogger } from "./logger.js";
+
+mainTestFn(import.meta);
+
+test("stdlib/logger", (t) => {
+  const getLogInstanceWithMockedWrite = () => {
+    const logLines = [];
+
+    const logger = newLogger({
+      printer: "ndjson",
+      pinoOptions: {
+        destination: {
+          write(line) {
+            logLines.push(JSON.parse(line));
+          },
+        },
+      },
+    });
+
+    return { logger, logLines };
+  };
+
+  t.test("level", (t) => {
+    const { logger, logLines } = getLogInstanceWithMockedWrite();
+
+    logger.info("hi");
+    logger.error("hi");
+
+    t.equal(logLines.length, 2);
+    t.equal(logLines[0].level, "info");
+    t.equal(logLines[1].level, "error");
+  });
+
+  t.test("time", (t) => {
+    const { logger, logLines } = getLogInstanceWithMockedWrite();
+    logger.info("foo");
+
+    t.equal(logLines.length, 1);
+    t.ok(logLines[0].time);
+  });
+
+  t.test("with context", (t) => {
+    const { logger, logLines } = getLogInstanceWithMockedWrite();
+
+    logger.info({});
+    logger.error({});
+
+    t.equal(logLines.length, 2);
+    t.ok(logLines[0].context);
+    t.ok(logLines[1].context);
+  });
+
+  t.test("messages", (t) => {
+    const { logger, logLines } = getLogInstanceWithMockedWrite();
+
+    logger.info(true);
+    logger.info(5);
+    logger.info("foo");
+    logger.info({ foo: "bar" });
+
+    t.equal(logLines.length, 4);
+    t.equal(logLines[0].message, true);
+    t.equal(logLines[1].message, 5);
+    t.equal(logLines[2].message, "foo");
+    t.deepEqual(logLines[3].message, { foo: "bar" });
+  });
+});

--- a/packages/stdlib/src/logger/writer.d.ts
+++ b/packages/stdlib/src/logger/writer.d.ts
@@ -6,21 +6,6 @@
  * @param {*} message
  * @returns {void}
  */
-export function writeNDJSON(
-  stream: NodeJS.WritableStream,
-  level: string,
-  timestamp: Date,
-  context: string,
-  message: any,
-): void;
-/**
- * @param {NodeJS.WritableStream} stream
- * @param {string} level
- * @param {Date} timestamp
- * @param {string} context
- * @param {*} message
- * @returns {void}
- */
 export function writePretty(
   stream: NodeJS.WritableStream,
   level: string,

--- a/packages/stdlib/src/logger/writer.js
+++ b/packages/stdlib/src/logger/writer.js
@@ -10,22 +10,6 @@ import { inspect } from "util";
  * @param {*} message
  * @returns {void}
  */
-export function writeNDJSON(stream, level, timestamp, context, message) {
-  stream.write(
-    `{"level": "${level}", "timestamp": "${timestamp.toISOString()}", "context": ${context}, "message": ${JSON.stringify(
-      message,
-    )}}\n`,
-  );
-}
-
-/**
- * @param {NodeJS.WritableStream} stream
- * @param {string} level
- * @param {Date} timestamp
- * @param {string} context
- * @param {*} message
- * @returns {void}
- */
 export function writePretty(stream, level, timestamp, context, message) {
   stream.write(`${formatPretty(level, timestamp, context, message)}\n`);
 }

--- a/packages/stdlib/src/logger/writer.test.js
+++ b/packages/stdlib/src/logger/writer.test.js
@@ -1,9 +1,9 @@
 import { mainTestFn, test } from "@compas/cli";
-import { writeNDJSON, writePretty } from "./writer.js";
+import { writePretty } from "./writer.js";
 
 mainTestFn(import.meta);
 
-test("insight/writer", (t) => {
+test("stdlib/logger/writer", (t) => {
   t.test("writePretty", (t) => {
     const now = new Date();
     let result = [];
@@ -35,48 +35,5 @@ test("insight/writer", (t) => {
 
     t.equal(result.length, 1);
     t.ok(result[0].indexOf("foo") !== -1, "should print log type");
-  });
-
-  t.test("writeNDJSON", (t) => {
-    const now = new Date();
-    let result = [];
-    const mock = {
-      write: (arg) => {
-        result.push(arg);
-      },
-    };
-
-    writeNDJSON(mock, "info", now, "{}", {});
-
-    t.equal(result.length, 1);
-    t.equal(
-      JSON.parse(result[0]).level,
-      "info",
-      "log output can be parsed by json",
-    );
-
-    result = [];
-    writeNDJSON(
-      mock,
-      "info",
-      now,
-      JSON.stringify({
-        type: "foo",
-        application: "compas",
-      }),
-      { foo: { bar: { baz: "quix" } } },
-    );
-
-    t.equal(result.length, 1);
-    t.equal(
-      JSON.parse(result[0])?.context?.type,
-      "foo",
-      "should print log type",
-    );
-    t.equal(
-      JSON.parse(result[0])?.context?.application,
-      "compas",
-      "should print application type",
-    );
   });
 });

--- a/packages/stdlib/types/advanced-types.d.ts
+++ b/packages/stdlib/types/advanced-types.d.ts
@@ -1,4 +1,7 @@
 import { RandomUUIDOptions } from "crypto";
+import Pino from "pino";
+import { SonicBoom } from "sonic-boom";
+
 import { AppError } from "../src/error.js";
 
 export type Either<T, E = AppError> =
@@ -119,9 +122,28 @@ export interface LoggerOptions<T extends LoggerContext> {
   printer?: "pretty" | "ndjson" | "github-actions" | undefined;
 
   /**
-   * The stream to write the logs to
+   * The stream to write the logs to, is not used for the 'ndjson' printer
    */
   stream?: NodeJS.WriteStream;
+
+  /**
+   * Supported Pino options if the 'ndjson' logger is used
+   */
+  pinoOptions?:
+    | {
+        transport?:
+          | Pino.TransportSingleOptions
+          | Pino.TransportMultiOptions
+          | Pino.TransportPipelineOptions;
+        destination?:
+          | string
+          | number
+          | Pino.DestinationObjectOptions
+          | Pino.DestinationStream
+          | NodeJS.WritableStream
+          | SonicBoom;
+      }
+    | undefined;
 
   /**
    * Context that should be logged in all log lines. e.g


### PR DESCRIPTION
This improves the performance for production logs with around 200 nanoseconds per operation.
It also unlocks Pino's transport and destination options. For example to ship logs to Elastic search via worker-threads.

Closes #1271

BREAKING CHANGE:
- The production log writer is replaced.
- `ndjson` log lines contain a `time` field with milliseconds since epoch instead of a `timestamp` field with an ISO-8601 string.