### PR TITLE
feat(code-gen): generate openAPI spec based on compas structure 

### DIFF
--- a/gen/testing.js
+++ b/gen/testing.js
@@ -140,6 +140,44 @@ export function applyTestingServerStructure(app) {
   const T = new TypeCreator("server");
   const R = T.router("/");
 
+  // Group test
+  const testR = R.group("group", "/group");
+  app.add(
+    T.object("item").keys({
+      A: T.string(),
+      B: T.number(),
+      C: T.number().float(),
+      D: T.bool(),
+      E: T.date(),
+    }),
+
+    T.number("input").convert().docs("WITH DOCS"),
+
+    testR
+      .post("/file", "upload")
+      .files({
+        input1: T.file(),
+      })
+      .response(T.file()),
+
+    testR
+      .delete("/:id", "refRoute")
+      .query({ ref: T.string(), ref2: T.string() })
+      .params({ id: T.reference("server", "input") })
+      .response(T.reference("bench", "nested")),
+
+    testR
+      .put("/:full/:color/route", "fullRoute")
+      .params({ full: T.string(), color: T.number().convert() })
+      .body({
+        foo: T.anyOf().values(T.string()),
+        bar: T.reference("server", "options"),
+      })
+      .response({
+        items: [{ foo: T.string(), bar: T.reference("server", "item") }],
+      }),
+  );
+
   // Reference (validate TS output)
   app.add(
     T.string("options").oneOf("A", "B", "C"),

--- a/packages/code-gen/src/App.d.ts
+++ b/packages/code-gen/src/App.d.ts
@@ -73,6 +73,13 @@ export class App {
    */
   extendWithOpenApi(defaultGroup: string, data: Record<string, any>): this;
   /**
+   * @param {import("./generator/openAPI").GenerateOpenApiOpts} options
+   * @returns {Promise<void>}
+   */
+  generateOpenApi(
+    options: import("./generator/openAPI").GenerateOpenApiOpts,
+  ): Promise<void>;
+  /**
    * @param {import("./generate-types").GenerateTypeOpts} options
    * @returns {Promise<void>}
    */

--- a/packages/code-gen/src/App.js
+++ b/packages/code-gen/src/App.js
@@ -19,6 +19,7 @@ import {
   validateCodeGenType,
 } from "./generated/codeGen/validators.js";
 import { generate } from "./generator/index.js";
+import { generateOpenApi } from "./generator/openAPI/index.js";
 import { getInternalRoutes } from "./generator/router/index.js";
 import { recursivelyRemoveInternalFields } from "./internal.js";
 import { loadFromOpenAPISpec } from "./loaders.js";
@@ -234,6 +235,32 @@ export class App {
    */
   extendWithOpenApi(defaultGroup, data) {
     return this.extendInternal(loadFromOpenAPISpec(defaultGroup, data), true);
+  }
+
+  /**
+   * @param {import("./generator/openAPI").GenerateOpenApiOpts} options
+   * @returns {Promise<void>}
+   */
+  async generateOpenApi(options) {
+    options.verbose = options.verbose ?? this.verbose;
+
+    if (isNil(options?.outputFile)) {
+      throw new Error("Need options.outputFile to write file to.");
+    }
+
+    if (isNil(options?.inputPath)) {
+      throw new Error("Need options.inputPath for compas structure");
+    }
+
+    const inputStructure = pathJoin(options.inputPath, "common/structure.js");
+    if (!existsSync(inputStructure)) {
+      throw new Error(
+        `Invalid inputPath '${options.inputPath}'. '${inputStructure}' does not exists. Is it correctly generated?`,
+      );
+    }
+    options.inputPath = inputStructure;
+
+    await generateOpenApi(this.logger, options);
   }
 
   /**

--- a/packages/code-gen/src/generate.d.ts
+++ b/packages/code-gen/src/generate.d.ts
@@ -1,4 +1,6 @@
 /**
+ * Provided that input is empty
+ *
  * @param {CodeGenStructure} input
  * @param {CodeGenStructure} structure
  * @param {string[]} groups

--- a/packages/code-gen/src/generate.js
+++ b/packages/code-gen/src/generate.js
@@ -5,6 +5,8 @@ import { isNamedTypeBuilderLike, TypeBuilder } from "./builders/index.js";
 import { upperCaseFirst } from "./utils.js";
 
 /**
+ * Provided that input is empty
+ *
  * @param {CodeGenStructure} input
  * @param {CodeGenStructure} structure
  * @param {string[]} groups

--- a/packages/code-gen/src/generator/errors.d.ts
+++ b/packages/code-gen/src/generator/errors.d.ts
@@ -1,2 +1,8 @@
-export function exitOnErrorsOrReturn(context: any): void;
+/**
+ * If errors are present, they are printed and the process is exited.
+ * Else this function will just return
+ *
+ * @param {CodeGenContext} context
+ */
+export function exitOnErrorsOrReturn(context: CodeGenContext): void;
 //# sourceMappingURL=errors.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/generator.d.ts
+++ b/packages/code-gen/src/generator/openAPI/generator.d.ts
@@ -1,0 +1,21 @@
+/**
+ * @typedef GenerateOpenApiFileOpts
+ * @property {import("./index.js").OpenApiOpts} openApiOptions
+ * @property {string[]} enabledGroups
+ * @property {boolean} verbose
+ */
+/**
+ * @param {CodeGenStructure} structure
+ * @param {GenerateOpenApiFileOpts} options
+ * @returns {string}
+ */
+export function generateOpenApiFile(
+  structure: CodeGenStructure,
+  options: GenerateOpenApiFileOpts,
+): string;
+export type GenerateOpenApiFileOpts = {
+  openApiOptions: import("./index.js").OpenApiOpts;
+  enabledGroups: string[];
+  verbose: boolean;
+};
+//# sourceMappingURL=generator.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/generator.js
+++ b/packages/code-gen/src/generator/openAPI/generator.js
@@ -1,0 +1,215 @@
+import { readFileSync } from "fs";
+import { pathJoin } from "@compas/stdlib";
+import {
+  transformBody,
+  transformComponents,
+  transformParams,
+  transformResponse,
+} from "./transform.js";
+
+/**
+ * @type {any}
+ */
+const OPENAPI_SPEC_TEMPLATE = {
+  openapi: "3.0.3",
+  paths: {},
+  tags: [],
+  components: {
+    schemas: {
+      AppError: {
+        type: "object",
+        description: "https://compasjs.com/api/stdlib.html#AppError",
+        properties: {
+          info: {
+            type: "object",
+          },
+          key: {
+            type: "string",
+          },
+          status: {
+            type: "number",
+          },
+        },
+      },
+    },
+  },
+  externalDocs: {
+    description: "Find more info here (Compas)",
+    url: "https://compasjs.com/",
+  },
+  // pass-through (settings)
+  servers: [],
+};
+
+/**
+ * @typedef GenerateOpenApiFileOpts
+ * @property {import("./index.js").OpenApiOpts} openApiOptions
+ * @property {string[]} enabledGroups
+ * @property {boolean} verbose
+ */
+
+/**
+ * @param {CodeGenStructure} structure
+ * @param {GenerateOpenApiFileOpts} options
+ * @returns {string}
+ */
+export function generateOpenApiFile(structure, options) {
+  const openApiSpec = Object.assign({}, OPENAPI_SPEC_TEMPLATE);
+
+  for (const group of Object.keys(structure)) {
+    const groupStructure = structure[group];
+
+    /**
+     * @type {CodeGenRouteType[]}
+     */
+    // @ts-ignore
+    const groupRoutes = Object.values(groupStructure).filter(
+      (it) => it.type === "route",
+    );
+
+    // ensure tag
+    if (groupRoutes.length > 0) {
+      openApiSpec.tags.push({
+        name: group,
+        description: "",
+      });
+    }
+
+    for (const route of groupRoutes) {
+      // define endpoint
+      const method = route.method.toLowerCase();
+      const path = transformRoutePath(route.path);
+      openApiSpec.paths[path] = {
+        [method]: {
+          tags: [route.group],
+          description: route.docString,
+          operationId: route.uniqueName,
+          // query, params
+          ...transformParams(structure, route),
+          // requestBody (with files, if any)
+          ...transformBody(structure, route),
+          responses: constructResponse(structure, route),
+        },
+      };
+    }
+
+    /**
+     * @type {import('./transform.js').TransformCodeGenType[]}
+     */
+    // @ts-ignore
+    const groupComponents = Object.values(groupStructure).filter(
+      (it) => it.type !== "route",
+    );
+
+    // transform components
+    const schemas = transformComponents(structure, groupComponents);
+    openApiSpec.components.schemas = {
+      ...openApiSpec.components.schemas,
+      ...schemas,
+    };
+  }
+
+  // determine compas version
+  const compasVersion = parseCompasVersionNumber();
+  openApiSpec[
+    "x-generator"
+  ] = `Compas (https://compasjs.com) v${compasVersion}`;
+
+  // set meta
+  openApiSpec.info = {
+    title: `${options.openApiOptions?.title ?? process.env.APP_NAME}`,
+    description: options.openApiOptions?.description ?? "",
+    version: options.openApiOptions?.version ?? "0.0.0",
+  };
+
+  // set servers, if any (pass-trough settings)
+  openApiSpec.servers = options.openApiOptions?.servers ?? [];
+
+  return openApiSpec;
+}
+
+/**
+ * Transform routes to responses but wrapped with possible compas
+ * error (http status codes) states (and explanation)
+ *
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenRouteType} route
+ */
+function constructResponse(structure, route) {
+  const contentAppError = {
+    "application/json": {
+      schema: {
+        $ref: "#/components/schemas/AppError",
+      },
+    },
+  };
+
+  // document all non 200 status codes, controlled by compas itself
+  const defaultResponses = {
+    400: {
+      description: "Validation Error",
+      content: contentAppError,
+    },
+    401: {
+      description: "Unauthorized Error",
+      content: contentAppError,
+    },
+    404: {
+      description: "Not Found Error",
+      content: contentAppError,
+    },
+    405: {
+      description: "Not Implemented Error",
+      content: contentAppError,
+    },
+    500: {
+      description: "Internal Server Error",
+      content: contentAppError,
+    },
+  };
+
+  // 200 behaviour
+  const response = transformResponse(structure, route);
+
+  return {
+    200: response,
+    ...defaultResponses,
+  };
+}
+
+/**
+ * Interpret package version number of compas code-gen package.
+ * Node_modules path is used for current "installed" version.
+ *
+ * @returns {string}
+ */
+function parseCompasVersionNumber() {
+  const { version } = JSON.parse(
+    readFileSync(
+      // take on of the packages for reference
+      pathJoin(process.cwd(), "./node_modules/@compas/code-gen/package.json"),
+      "utf-8",
+    ),
+  );
+
+  return version ?? "0.0.1";
+}
+
+/**
+ * Transform path params to {} notation and append leading slash
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+function transformRoutePath(path) {
+  return `/${path
+    .split("/")
+    .filter((it) => it.length > 0)
+    .map((it) => {
+      if (it.startsWith(":")) {
+        return `{${it.substring(1)}}`;
+      }
+      return it;
+    })
+    .join("/")}`;
+}

--- a/packages/code-gen/src/generator/openAPI/generator.test.js
+++ b/packages/code-gen/src/generator/openAPI/generator.test.js
@@ -1,0 +1,62 @@
+import { mainTestFn, test } from "@compas/cli";
+import { pathJoin } from "@compas/stdlib";
+import { convertOpenAPISpec } from "../../open-api-importer.js";
+import { generateOpenApiFile } from "./generator.js";
+
+mainTestFn(import.meta);
+
+test("code-gen/generator/openAPI", async (t) => {
+  // load structure
+  const { structure } = await import(
+    pathJoin(process.cwd(), "./generated/testing/server/common/structure.js")
+  );
+
+  t.test("generateOpenApiFile, ensure build and assert version", (t) => {
+    const spec = generateOpenApiFile(structure, {
+      enabledGroups: ["server"],
+      openApiOptions: {
+        version: "1.0.0",
+        title: "Lorem",
+        description: "Ipsum",
+      },
+    });
+
+    t.equal(spec?.openapi, "3.0.3");
+  });
+
+  t.test("generateOpenApiFile, ensure paths/routes are correct", (t) => {
+    const { paths } = generateOpenApiFile(structure, {
+      enabledGroups: ["server"],
+      openApiOptions: {
+        version: "1.0.0",
+        title: "Lorem",
+        description: "Ipsum",
+      },
+    });
+
+    for (const path of Object.keys(paths)) {
+      t.ok(!path.includes(":"), "path contains compas path identifier");
+    }
+  });
+
+  t.test(
+    "generateOpenApiFile, ensure created structure can be imported",
+    (t) => {
+      const openapiSpec = generateOpenApiFile(structure, {
+        enabledGroups: ["server"],
+      });
+
+      if (!openapiSpec) {
+        t.fail("api spec not generated");
+      }
+
+      try {
+        convertOpenAPISpec("server", openapiSpec);
+        t.pass("Should not throw");
+      } catch (e) {
+        t.fail("Should not throw");
+        t.log.error(e);
+      }
+    },
+  );
+});

--- a/packages/code-gen/src/generator/openAPI/index.d.ts
+++ b/packages/code-gen/src/generator/openAPI/index.d.ts
@@ -1,0 +1,38 @@
+/**
+ * @typedef {object} OpenApiOpts
+ * @property {string|undefined} [version]
+ * @property {string|undefined} [title]
+ * @property {string|undefined} [description]
+ * @property {any[]|undefined} [servers]
+ */
+/**
+ * @typedef {object} GenerateOpenApiOpts
+ * @property {string} inputPath
+ * @property {string} outputFile
+ * @property {OpenApiOpts} [openApiOptions]
+ * @property {string[]|undefined} [enabledGroups]
+ * @property {boolean|undefined} [verbose]
+ */
+/**
+ * @param {Logger} logger
+ * @param {GenerateOpenApiOpts} options
+ * @returns {Promise<void>}
+ */
+export function generateOpenApi(
+  logger: Logger,
+  options: GenerateOpenApiOpts,
+): Promise<void>;
+export type OpenApiOpts = {
+  version?: string | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+  servers?: any[] | undefined;
+};
+export type GenerateOpenApiOpts = {
+  inputPath: string;
+  outputFile: string;
+  openApiOptions?: OpenApiOpts | undefined;
+  enabledGroups?: string[] | undefined;
+  verbose?: boolean | undefined;
+};
+//# sourceMappingURL=index.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/index.js
+++ b/packages/code-gen/src/generator/openAPI/index.js
@@ -1,0 +1,81 @@
+import { mkdirSync, writeFileSync } from "fs";
+import { pathToFileURL } from "url";
+import { isPlainObject } from "@compas/stdlib";
+import { addGroupsToGeneratorInput } from "../../generate.js";
+import { generateOpenApiFile } from "./generator.js";
+
+/**
+ * @typedef {object} OpenApiOpts
+ * @property {string|undefined} [version]
+ * @property {string|undefined} [title]
+ * @property {string|undefined} [description]
+ * @property {any[]|undefined} [servers]
+ */
+
+/**
+ * @typedef {object} GenerateOpenApiOpts
+ * @property {string} inputPath
+ * @property {string} outputFile
+ * @property {OpenApiOpts} [openApiOptions]
+ * @property {string[]|undefined} [enabledGroups]
+ * @property {boolean|undefined} [verbose]
+ */
+
+/**
+ * @param {Logger} logger
+ * @param {GenerateOpenApiOpts} options
+ * @returns {Promise<void>}
+ */
+export async function generateOpenApi(logger, options) {
+  options.openApiOptions = options?.openApiOptions ?? {};
+
+  if (options.verbose) {
+    logger.info({
+      openApiGenerator: options,
+    });
+  }
+
+  // @ts-ignore
+  const { structure } = await import(pathToFileURL(options.inputPath));
+  if (!isPlainObject(structure)) {
+    throw new Error(
+      "Content of structure file is invalid. Is it correctly generated?",
+    );
+  }
+
+  // ensure enabledGroups are present in structure
+  const structureGroups = Object.keys(structure);
+  for (const group of options?.enabledGroups ?? []) {
+    if (!structureGroups.includes(group)) {
+      throw new Error(
+        `Enabled group (name: "${group}") on generator not found in structure. Found groups: "${structureGroups.join(
+          `","`,
+        )}"`,
+      );
+    }
+  }
+
+  // if no enabledGroups are provided, take all groups in structure (without compas group)
+  options.enabledGroups =
+    options?.enabledGroups ??
+    structureGroups.filter((group) => group !== "compas");
+
+  /**
+   * @type {CodeGenStructure}
+   */
+  const extendedStructure = {};
+  addGroupsToGeneratorInput(
+    extendedStructure,
+    structure,
+    options.enabledGroups,
+  );
+
+  // call generator and transform structure to json (openapi spec)
+  // @ts-ignore
+  const contents = generateOpenApiFile(extendedStructure, options);
+
+  // write file to absolute location
+  const directory = options.outputFile.split("/").slice(0, -1).join("/");
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(options.outputFile, JSON.stringify(contents, null, 2), "utf8");
+}

--- a/packages/code-gen/src/generator/openAPI/transform.d.ts
+++ b/packages/code-gen/src/generator/openAPI/transform.d.ts
@@ -1,0 +1,56 @@
+/**
+ * @typedef {CodeGenAnyType|CodeGenAnyOfType|CodeGenArrayType|CodeGenBooleanType|CodeGenDateType|CodeGenFileType|CodeGenGenericType|CodeGenNumberType|CodeGenReferenceType|CodeGenStringType|CodeGenUuidType|CodeGenObjectType|CodeGenRouteType} TransformCodeGenType
+ */
+/**
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenRouteType} route
+ * @returns {any}
+ */
+export function transformParams(
+  structure: CodeGenStructure,
+  route: CodeGenRouteType,
+): any;
+/**
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenRouteType} route
+ * @returns {any}
+ */
+export function transformBody(
+  structure: CodeGenStructure,
+  route: CodeGenRouteType,
+): any;
+/**
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenRouteType} route
+ * @returns {any}
+ */
+export function transformResponse(
+  structure: CodeGenStructure,
+  route: CodeGenRouteType,
+): any;
+/**
+ * @param {CodeGenStructure} structure
+ * @param {TransformCodeGenType[]} components
+ * @returns {Object<string, any>}
+ */
+export function transformComponents(
+  structure: CodeGenStructure,
+  components: TransformCodeGenType[],
+): {
+  [x: string]: any;
+};
+export type TransformCodeGenType =
+  | CodeGenAnyType
+  | CodeGenAnyOfType
+  | CodeGenArrayType
+  | CodeGenBooleanType
+  | CodeGenDateType
+  | CodeGenFileType
+  | CodeGenGenericType
+  | CodeGenNumberType
+  | CodeGenReferenceType
+  | CodeGenStringType
+  | CodeGenUuidType
+  | CodeGenObjectType
+  | CodeGenRouteType;
+//# sourceMappingURL=transform.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/transform.js
+++ b/packages/code-gen/src/generator/openAPI/transform.js
@@ -1,0 +1,292 @@
+/**
+ * @typedef {CodeGenAnyType|CodeGenAnyOfType|CodeGenArrayType|CodeGenBooleanType|CodeGenDateType|CodeGenFileType|CodeGenGenericType|CodeGenNumberType|CodeGenReferenceType|CodeGenStringType|CodeGenUuidType|CodeGenObjectType|CodeGenRouteType} TransformCodeGenType
+ */
+
+/**
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenRouteType} route
+ * @returns {any}
+ */
+export function transformParams(structure, route) {
+  if (!route?.params && !route?.query) {
+    return {};
+  }
+
+  const parameters = [];
+
+  // params
+  // @ts-ignore
+  const paramFields = route?.params?.reference?.keys ?? {};
+  for (const [key, param] of Object.entries(paramFields)) {
+    switch (param.type) {
+      case "reference":
+        parameters.push(transformGenType(key, param.reference, "path"));
+        break;
+      default:
+        parameters.push(transformGenType(key, param, "path"));
+    }
+  }
+
+  // query
+  // @ts-ignore
+  const queryFields = route?.query?.reference?.keys ?? {};
+  for (const [key, param] of Object.entries(queryFields)) {
+    parameters.push(transformGenType(key, param, "query"));
+  }
+
+  return { parameters };
+
+  /**
+   * @param {string} key
+   * @param {TransformCodeGenType} param
+   * @param {"path"|"query"} paramType
+   * @returns {any}
+   */
+  function transformGenType(key, param, paramType) {
+    const schema = {};
+    switch (param.type) {
+      case "string":
+        schema.type = "string";
+        schema.enum = param?.oneOf;
+        schema.minLength = param.validator?.min;
+        schema.maxLength = param.validator?.max;
+        break;
+
+      case "file":
+        schema.type = "string";
+        schema.format = "binary";
+        break;
+
+      case "uuid":
+        schema.type = "string";
+        schema.format = "uuid";
+        break;
+
+      case "date":
+        schema.type = "string";
+        schema.format = "date-time";
+        break;
+
+      case "number":
+        schema.type = param.validator.floatingPoint ? "number" : "integer";
+        schema.minimum = param.validator?.min;
+        schema.maximum = param.validator?.max;
+        break;
+
+      default:
+        schema.type = param.type;
+        break;
+    }
+
+    return {
+      name: key,
+      description: param.docString,
+      required: !param.isOptional,
+      in: paramType,
+      schema,
+    };
+  }
+}
+
+/**
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenRouteType} route
+ * @returns {any}
+ */
+export function transformBody(structure, route) {
+  const content = {};
+  const field = route?.body ?? route?.files;
+
+  if (!field) {
+    return {};
+  }
+
+  /**
+   * @type {TransformCodeGenType}
+   */
+  // @ts-ignore
+  const reference = field?.reference;
+  if (reference) {
+    content.schema = {
+      $ref: `#/components/schemas/${reference.uniqueName}`,
+    };
+  }
+
+  const contentType = route?.files ? "multipart/form-data" : "application/json";
+
+  return {
+    requestBody: {
+      // @ts-ignore
+      description: field.docString,
+      content: { [contentType]: content },
+      required: true,
+    },
+  };
+}
+
+/**
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenRouteType} route
+ * @returns {any}
+ */
+export function transformResponse(structure, route) {
+  // 200 behaviour
+  const response = {
+    // @ts-ignore
+    description: route.response?.docString ?? "",
+    content: {
+      "application/json": {
+        schema: {},
+      },
+    },
+  };
+
+  // @ts-ignore
+  if (route.response?.reference) {
+    response.content["application/json"].schema = {
+      // @ts-ignore
+      $ref: `#/components/schemas/${route.response.reference.uniqueName}`,
+    };
+  }
+
+  return response;
+}
+
+/**
+ * @param {CodeGenStructure} structure
+ * @param {TransformCodeGenType[]} components
+ * @returns {Object<string, any>}
+ */
+export function transformComponents(structure, components) {
+  const schemas = {};
+
+  for (const component of components) {
+    schemas[component.uniqueName] = transformTypes(component);
+  }
+
+  return schemas;
+
+  /**
+   * Docs: https://swagger.io/docs/specification/data-models/data-types/
+   *
+   * @param {TransformCodeGenType} component
+   * @returns {any}
+   */
+  function transformTypes(component) {
+    const property = {
+      description: component.docString,
+    };
+
+    switch (component.type) {
+      // primitive
+      case "string":
+        return {
+          type: "string",
+          minLength: component.validator?.min,
+          maxLength: component.validator?.max,
+          enum: component?.oneOf,
+          ...property,
+        };
+
+      case "file":
+        return {
+          type: "string",
+          format: "binary",
+          ...property,
+        };
+
+      case "uuid":
+        return {
+          type: "string",
+          format: "uuid",
+          ...property,
+        };
+
+      case "date":
+        return {
+          type: "string",
+          format: "date-time",
+          ...property,
+        };
+
+      case "boolean":
+        return {
+          type: "boolean",
+          ...property,
+        };
+
+      case "number":
+        return {
+          type: component.validator.floatingPoint ? "number" : "integer",
+          minimum: component.validator?.min,
+          maximum: component.validator?.max,
+          ...property,
+        };
+
+      case "object":
+        return {
+          type: "object",
+          description: component.docString,
+          properties: Object.entries(component.keys).reduce(
+            (curr, [key, property]) => {
+              // @ts-ignore
+              curr[key] = transformTypes(property);
+              return curr;
+            },
+            {},
+          ),
+          required: Object.entries(component.keys).reduce(
+            (curr, [key, property]) => {
+              if (!property?.isOptional) {
+                if (!curr) {
+                  // @ts-ignore
+                  curr = [];
+                }
+
+                // @ts-ignore
+                curr.push(key);
+              }
+              return curr;
+            },
+            undefined,
+          ),
+        };
+
+      case "generic":
+        return {
+          type: "object",
+          additionalProperties: true,
+          ...property,
+        };
+
+      case "array":
+        return {
+          type: "array",
+          // @ts-ignore
+          items: transformTypes(component.values),
+          ...property,
+        };
+
+      case "reference":
+        // @ts-ignore
+        return transformTypes(component.reference);
+
+      case "anyOf":
+        return {
+          type: "object",
+          anyOf: Object.entries(component.values).reduce(
+            (curr, [, property]) => {
+              // @ts-ignore
+              curr.push(transformTypes(property));
+              return curr;
+            },
+            [],
+          ),
+          ...property,
+        };
+
+      default:
+        return undefined;
+    }
+  }
+}

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -1,5 +1,5 @@
 node_modules/
 *.test.js
 __fixtures__/
-generate.js
+generator.js
 test/

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -5,6 +5,7 @@ import {
   generateStore,
   generateTestAndBench,
   generateTypes,
+  generateOpenApiSpec,
 } from "../src/generate.js";
 
 /** @type {CliWatchOptions} */
@@ -21,6 +22,7 @@ async function main(logger) {
   await generateRepo();
   await generateTestAndBench();
   await generateTypes();
+  await generateOpenApiSpec();
 
   logger.info("Transpiling typescript...");
 

--- a/src/generate.js
+++ b/src/generate.js
@@ -28,7 +28,7 @@ export const generateTestAndBenchSettings = {
   server: {
     outputDirectory: "./generated/testing/server",
     enabledGenerators: ["apiClient", "router", "validator"],
-    enabledGroups: ["server"],
+    enabledGroups: ["server", "group"],
     isNodeServer: true,
     dumpStructure: true,
   },
@@ -64,6 +64,24 @@ export async function generateTypes() {
       "./packages/store/src/generated",
     ],
     dumpCompasTypes: true,
+  });
+}
+
+export async function generateOpenApiSpec() {
+  const app = new App({
+    verbose: true,
+  });
+
+  await app.generateOpenApi({
+    inputPath: "./generated/testing/server",
+    outputFile: "./generated/testing/server/common/openapi.json",
+    enabledGroups: ["server", "group"],
+    openApiOptions: {
+      version: "0.0.99",
+      title: "Compas Test server OpenAPI Docs",
+      description: "Lorem ipsum",
+      servers: [{ url: "https://api.compasjs.com" }],
+    },
   });
 }
 

--- a/types/generated/common/types.d.ts
+++ b/types/generated/common/types.d.ts
@@ -7,10 +7,25 @@ import { Next } from "@compas/server";
 import { Middleware } from "@compas/server";
 import { QueryPart } from "@compas/store";
 declare global {
+  type BenchNested = { foo: true; bar: 5; nest: BenchSimple[] };
+  type BenchSimple = { foo: boolean; bar: number; baz: string };
   type CompasStructure = undefined | any;
   type CompasStructureResponse = any;
-  type ServerAnswers = { [K in ServerOptions]: string };
+  type GroupFullRoute = CompasStructure;
+  type GroupFullRouteBody = { foo: string; bar: ServerOptions };
   type ServerOptions = "A" | "B" | "C";
+  type GroupFullRouteParams = { full: string; color: number };
+  type GroupFullRouteResponse = { items: { foo: string; bar: ServerItem }[] };
+  type ServerItem = { A: string; B: number; C: number; D: boolean; E: Date };
+  type GroupRefRoute = CompasStructure;
+  type GroupRefRouteParams = { id: ServerInput };
+  type ServerInput = number;
+  type GroupRefRouteQuery = { ref: string; ref2: string };
+  type GroupRefRouteResponse = BenchNested;
+  type GroupUpload = CompasStructure;
+  type GroupUploadFiles = { input1: ReadableStream };
+  type GroupUploadResponse = ReadableStream;
+  type ServerAnswers = { [K in ServerOptions]: string };
   type ServerCreate = CompasStructure;
   type ServerCreateBody = { foo: boolean; string?: undefined | null | string };
   type ServerCreateQuery = { alwaysTrue?: undefined | boolean };
@@ -19,7 +34,7 @@ declare global {
   type ServerEmptyResponseQuery = { foo?: undefined | string };
   type ServerGetFile = CompasStructure;
   type ServerGetFileQuery = { throwError?: undefined | boolean };
-  type ServerGetFileResponse = ReadableStream;
+  type ServerGetFileResponse = GroupUploadResponse;
   type ServerGetId = CompasStructure;
   type ServerGetIdParams = { id: number };
   type ServerGetIdResponse = ServerGetIdParams;
@@ -51,6 +66,47 @@ declare global {
   >;
   type CompasStructureFn = (
     ctx: CompasStructureCtx,
+    next: Next,
+  ) => void | Promise<void>;
+  type GroupFullRouteCtx = Context<
+    {},
+    {
+      event: InsightEvent;
+      log: Logger;
+      validatedParams: GroupFullRouteParams;
+      validatedBody: GroupFullRouteBody;
+    },
+    GroupFullRouteResponse
+  >;
+  type GroupFullRouteFn = (
+    ctx: GroupFullRouteCtx,
+    next: Next,
+  ) => void | Promise<void>;
+  type GroupRefRouteCtx = Context<
+    {},
+    {
+      event: InsightEvent;
+      log: Logger;
+      validatedQuery: GroupRefRouteQuery;
+      validatedParams: GroupRefRouteParams;
+    },
+    GroupRefRouteResponse
+  >;
+  type GroupRefRouteFn = (
+    ctx: GroupRefRouteCtx,
+    next: Next,
+  ) => void | Promise<void>;
+  type GroupUploadCtx = Context<
+    {},
+    {
+      event: InsightEvent;
+      log: Logger;
+      validatedFiles: GroupUploadFiles;
+    },
+    GroupUploadResponse
+  >;
+  type GroupUploadFn = (
+    ctx: GroupUploadCtx,
     next: Next,
   ) => void | Promise<void>;
   type ServerCreateCtx = Context<
@@ -196,9 +252,37 @@ declare global {
   ) => void | Promise<void>;
   type GroupMiddleware = {
     compas: Middleware | Middleware[];
+    group: Middleware | Middleware[];
     server: Middleware | Middleware[];
   };
   type CompasStructureResponseApiResponse = CompasStructureResponse;
+  type GroupFullRouteParamsInput = { full: string; color: number | string };
+  type GroupFullRouteBodyInput = { foo: string; bar: ServerOptionsInput };
+  type ServerOptionsInput = ServerOptions;
+  type GroupFullRouteResponseApiResponse = {
+    items: { foo: string; bar: ServerItemApiResponse }[];
+  };
+  type ServerItemApiResponse = {
+    A: string;
+    B: number;
+    C: number;
+    D: boolean;
+    E: string;
+  };
+  type GroupRefRouteParamsInput = { id: ServerInputInput };
+  type ServerInputInput = number | string;
+  type GroupRefRouteQueryInput = GroupRefRouteQuery;
+  type GroupRefRouteResponseApiResponse = BenchNestedApiResponse;
+  type BenchNestedApiResponse = {
+    foo: true;
+    bar: 5;
+    nest: BenchSimpleApiResponse[];
+  };
+  type BenchSimpleApiResponse = BenchSimple;
+  type GroupUploadFilesInput = {
+    input1: { name?: string; data: ReadableStream };
+  };
+  type GroupUploadResponseApiResponse = GroupUploadResponse;
   type ServerCreateQueryInput = ServerCreateQuery;
   type ServerCreateBodyInput = ServerCreateBody;
   type ServerCreateResponseApiResponse = ServerCreateResponse;
@@ -206,7 +290,7 @@ declare global {
   type ServerGetFileQueryInput = {
     throwError?: undefined | boolean | "true" | "false";
   };
-  type ServerGetFileResponseApiResponse = ServerGetFileResponse;
+  type ServerGetFileResponseApiResponse = GroupUploadResponse;
   type ServerGetIdParamsInput = { id: number | string };
   type ServerGetIdResponseApiResponse = ServerGetIdParams;
   type ServerInvalidResponseResponseApiResponse = ServerInvalidResponseResponse;
@@ -1217,10 +1301,10 @@ declare global {
   type ValidatorNamedLevelOne = { levelOne: ValidatorNamedLevelTwo };
   type ValidatorNamedLevelTwo = { two: ValidatorNamedLevelThree };
   type ValidatorNamedLevelThree = { foo?: undefined | ValidatorNamedLevelOne };
-  type ValidatorNumber = number;
-  type ValidatorNumberConvert = ValidatorNumber;
-  type ValidatorNumberFloat = ValidatorNumber;
-  type ValidatorNumberMinMax = ValidatorNumber;
+  type ValidatorNumber = ServerInput;
+  type ValidatorNumberConvert = ServerInput;
+  type ValidatorNumberFloat = ServerInput;
+  type ValidatorNumberMinMax = ServerInput;
   type ValidatorNumberOneOf = 1 | 3 | 5;
   type ValidatorObject = { bool: boolean; string: string };
   type ValidatorObjectLoose = ValidatorObject;


### PR DESCRIPTION
Closes #574

Contents:
 - [X] Generate openAPI in json format for compas (project) structure
   - [x] Input
     - [X] Query
     - [X] Paths
     - [X] Body
     - [x] Files
   - [x] Response
     - [X] Compas default types (with validator props and enumerations)
     - [X] Objects
     - [X] Arrays / collections
     - [X] Refrence types
     - [X] Files
     - [x] Generics
     - [x] anyOf 
   - [X] Group support
   - [X] Custom fields: version, title, description  
   - [X] Compas generator tags and version numbers
 - [x] Unit tests  
   - [x] Various invalid inputs (invalid groups and file locations)
   - [x] Ensure generator output can be imported trough `convertOpenAPISpec`
 - [x] Fix string format properties in `open-api-importer.js`
 - [x] Use unique for `operationId` because of conflicting names over groups
 - [x] Extends string parameters with various formatting types
 - [x] Implement servers in generator options
 - [x] Split various functions in unit (with more unit tests)
 - [ ] ~Investigate and resolve call stack error in `addGroupsToGeneratorInput`~ See issue: https://github.com/compasjs/compas/issues/1324

Wish list:
 - [ ] Support for group/top level route description (docString) support. Currently, this is not supported by the compas structure

Example (generator call):
```node
const app = new App({
  verbose: true,
});

await app.generateOpenApi({
  inputPath: "./generated/testing/server",
  outputFile: "./generated/testing/server/common/openapi.json",
  enabledGroups: ["server", "group"],
  openApiOptions: {
    version: "0.0.99",
    title: "Compas Test server OpenAPI Docs",
    description: "Lorem ipsum",
    servers: ["https://api.compasjs.com"]
  },
});
  ```
