### PR TITLE
chore(docs): fix typo in command on getting started page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ To add Compas to your project, install the following most used packages:
 
 ```shell
 yarn add -D -E @compas/cli
-yarn add -E @cmpas/stdlib
+yarn add -E @compas/stdlib
 ```
 
 Let's explore Compas starting with the


### PR DESCRIPTION
Fixing a minor typo from the docs which might be looked over by people (me)