### PR TITLE
feat(code-gen): use abort signal in api clients

### DIFF
--- a/packages/code-gen/src/generate-types.js
+++ b/packages/code-gen/src/generate-types.js
@@ -149,6 +149,7 @@ export async function generateTypes(logger, options) {
           type BodyParserPair = server.BodyParserPair;
           type AxiosInstance = import("axios").AxiosInstance;
           type AxiosError = import("axios").AxiosError;
+          type AxiosRequestConfig = import("axios").AxiosRequestConfig;
           `;
       }
     }

--- a/packages/code-gen/src/generator/apiClient/templates/apiClientFile.tmpl
+++ b/packages/code-gen/src/generator/apiClient/templates/apiClientFile.tmpl
@@ -5,7 +5,7 @@ import { isPlainObject } from "@compas/stdlib";
 
 {{ if (options.useTypescript) { }}
 import * as T from "../common/types";
-import { CancelToken, AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 {{ } }}
 
 {{ if (options.isNodeServer) { }}

--- a/packages/code-gen/src/generator/apiClient/templates/apiClientFn.tmpl
+++ b/packages/code-gen/src/generator/apiClient/templates/apiClientFn.tmpl
@@ -19,9 +19,7 @@
     {{ if (item.files) { }}
      * @param { {{= getTypeNameForType(item.files.reference, typeSuffix.apiInput, { useDefaults: false, fileTypeIO: "input", }) }} } files
     {{ } }}
-    {{ if (options.isBrowser) { }}
-     * @param { { cancelToken?: CancelToken } } [options]
-    {{ } }}
+     * @param { { signal?: AbortSignal | undefined } } [requestConfig]
     {{ if (item.response) { }}
      * @returns {Promise<{{= getTypeNameForType(item.response.reference, typeSuffix.apiResponse, { isJSON: true, fileTypeIO: "outputClient", }) }}>}
     {{ } }}
@@ -42,6 +40,7 @@ export async function api{{= item.uniqueName }}(
     {{ if (item.files) { }}
     files: T.{{= getTypeNameForType(item.files.reference, typeSuffix.apiInput, { useDefaults: false, fileTypeIO: "input", }) }},
     {{ } }}
+    requestConfig: { signal?: AbortSignal|undefined } = {},
 {{ } else { }}
     instance,
     {{ if (item.params) { }}
@@ -56,11 +55,7 @@ export async function api{{= item.uniqueName }}(
     {{ if (item.files) { }}
     files,
     {{ } }}
-{{ } }}
-{{ if (options.isBrowser && options.useTypescript) { }}
-options: { cancelToken?: CancelToken } = {},
-{{ } else if (options.useBrowser) { }}
-options = {},
+    requestConfig = {},
 {{ } }}
 {{= options.useTypescript && item.response ? `): Promise<T.${getTypeNameForType(item.response.reference, typeSuffix.apiResponse, { isJSON: true, fileTypeIO: "outputClient", })}> {` : ") {" }}
     {{ if (item.files) { }}
@@ -106,9 +101,7 @@ options = {},
       {{ if (item.response?.reference?.type === "file") { }}
       responseType: "{{= options.isNode ? "stream" : "blob" }}",
       {{ } }}
-      {{ if (options.isBrowser) { }}
-      cancelToken: options?.cancelToken,
-      {{ } }}
+      ...requestConfig,
     });
 
     {{ if (!options.isNodeServer) { }}

--- a/packages/code-gen/src/generator/common.js
+++ b/packages/code-gen/src/generator/common.js
@@ -88,15 +88,8 @@ function generateCommonApiClientFile(context) {
  */
 function generateCommonReactQueryFile() {
   return `
-import { AxiosError, AxiosInstance, CancelTokenSource } from "axios";
+import { AxiosError, AxiosInstance } from "axios";
 import { createContext, PropsWithChildren, useContext } from "react";
-import {
-  UseQueryOptions as ReactUseQueryOptions,
-} from "react-query";
-
-export interface CancellablePromise<T> extends Promise<T> {
-  cancel?: () => void;
-}
 
 const ApiContext = createContext<AxiosInstance | undefined>(undefined);
 
@@ -130,7 +123,5 @@ export type AppErrorResponse = AxiosError<{
     [key: string]: any;
   }
 }>
-
-export type UseQueryOptions<Response, Error, TData = Response> = ReactUseQueryOptions<Response, Error, TData> & { cancelToken?: CancelTokenSource };
 `;
 }

--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFile.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFile.tmpl
@@ -1,8 +1,9 @@
-import { CancellablePromise, useApi, AppErrorResponse, UseQueryOptions } from "../common/reactQuery";
+import {  useApi, AppErrorResponse } from "../common/reactQuery";
 import {
   QueryKey,
   UseMutationOptions,
   UseMutationResult,
+  UseQueryOptions,
   UseQueryResult,
   useMutation,
   useQuery,

--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -89,20 +89,14 @@ options?: UseQueryOptions<{{= responseType }}, AppErrorResponse, TData> | undefi
     opts.body,
     {{ } }}
     ),
-    () => {
-      const promise: CancellablePromise<{{= responseType }}> = api{{= item.uniqueName }}(
+    ({ signal }) => {
+      return api{{= item.uniqueName }}(
         axiosInstance,
         {{= item.params ? "opts.params, " : ""}}
         {{= item.query ? "opts.query, " : "" }}
         {{= item.body ? "opts.body, " : "" }}
-        { cancelToken: options.cancelToken?.token },
+        { signal },
       );
-
-      if (options.cancelToken) {
-        promise.cancel = () => options.cancelToken?.cancel();
-      }
-
-      return promise;
     },
     options,
   );

--- a/packages/code-gen/test/e2e-server.test.js
+++ b/packages/code-gen/test/e2e-server.test.js
@@ -29,23 +29,21 @@ test("code-gen/e2e-server", async (t) => {
 
   t.test("client - request cancellation works", async (t) => {
     try {
-      const cancelToken = Axios.CancelToken.source();
+      const abortController = new AbortController();
 
       const requestPromise = clientApiClientImport.apiServerGetId(
         axiosInstance,
         { id: "5" },
-        { cancelToken: cancelToken.token },
+        { signal: abortController.signal },
       );
       await Promise.all([
         new Promise((r) => {
           setTimeout(r, 0);
-        }).then(() => cancelToken.cancel("foo")),
+        }).then(() => abortController.abort()),
         requestPromise,
       ]);
-      t.fail("Should throw cancel error");
     } catch (e) {
-      t.equal(e.__CANCEL__, true, "Cancel token throws");
-      t.equal(e.message, "foo");
+      t.equal(e.message, "canceled");
     }
   });
 

--- a/types/generated/common/compas.d.ts
+++ b/types/generated/common/compas.d.ts
@@ -27,6 +27,7 @@ declare global {
   type BodyParserPair = server.BodyParserPair;
   type AxiosInstance = import("axios").AxiosInstance;
   type AxiosError = import("axios").AxiosError;
+  type AxiosRequestConfig = import("axios").AxiosRequestConfig;
 
   type Logger = stdlib.Logger;
   type InsightEvent = stdlib.InsightEvent;


### PR DESCRIPTION
BREAKING CHANGE:
- Removed Axios.cancelToken support. Please use the `signal` option.
- Requires react-query 3.30.0 or higher