### PR TITLE
fix(code-gen): add React import to reactQuery template

### DIFF
--- a/packages/code-gen/src/generator/common.js
+++ b/packages/code-gen/src/generator/common.js
@@ -89,7 +89,7 @@ function generateCommonApiClientFile(context) {
 function generateCommonReactQueryFile() {
   return `
 import { AxiosError, AxiosInstance } from "axios";
-import { createContext, PropsWithChildren, useContext } from "react";
+import React, { createContext, PropsWithChildren, useContext } from "react";
 
 const ApiContext = createContext<AxiosInstance | undefined>(undefined);
 


### PR DESCRIPTION
This fixes an issue with React Native which requires React imports at the top of every file that includes JSX.

When missing, React Native will throw `Can't find variable: React` even when React is not directly used, however, it is still required to translate JSX.