### PR TITLE
feat(stdlib): support formatting Aggregate errors

### DIFF
--- a/packages/code-gen/test/e2e-server.test.js
+++ b/packages/code-gen/test/e2e-server.test.js
@@ -225,7 +225,7 @@ test("code-gen/e2e-server", async (t) => {
       t.ok(AppError.instanceOf(e));
       t.equal(e.key, "server.error");
       t.equal(e.status, 499);
-      t.equal(e.originalError.isAxiosError, true);
+      t.equal(e.cause.isAxiosError, true);
     }
   });
 

--- a/packages/server/src/app.d.ts
+++ b/packages/server/src/app.d.ts
@@ -22,7 +22,7 @@
  * @property {((ctx: Koa.Context, err: Error) => boolean)|undefined} [onError] Called
  *   before any logic, to let the user handle errors. If 'true' is returned, no other
  *   logic is applied.
- * @property {boolean|undefined} [leakError] Adds the stacktrace and originalError to the
+ * @property {boolean|undefined} [leakError] Adds the stacktrace and error cause to the
  *    response. Useful on development and staging environments.
  */
 /**
@@ -106,7 +106,7 @@ export type ErrorHandlerOptions = {
    */
   onError?: ((ctx: Koa.Context, err: Error) => boolean) | undefined;
   /**
-   * Adds the stacktrace and originalError to the
+   * Adds the stacktrace and error cause to the
    * response. Useful on development and staging environments.
    */
   leakError?: boolean | undefined;

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -34,7 +34,7 @@ import {
  * @property {((ctx: Koa.Context, err: Error) => boolean)|undefined} [onError] Called
  *   before any logic, to let the user handle errors. If 'true' is returned, no other
  *   logic is applied.
- * @property {boolean|undefined} [leakError] Adds the stacktrace and originalError to the
+ * @property {boolean|undefined} [leakError] Adds the stacktrace and error cause to the
  *    response. Useful on development and staging environments.
  */
 

--- a/packages/stdlib/src/error.d.ts
+++ b/packages/stdlib/src/error.d.ts
@@ -72,18 +72,18 @@ export class AppError extends Error {
    * @param {string} key
    * @param {number} status
    * @param {Record<string, any>} [info={}]
-   * @param {Error} [originalError]
+   * @param {Error} [cause]
    */
   constructor(
     key: string,
     status: number,
     info?: Record<string, any> | undefined,
-    originalError?: Error | undefined,
+    cause?: Error | undefined,
   );
   key: string;
   status: number;
   info: Record<string, any>;
-  originalError: Error | undefined;
+  cause: Error | undefined;
   /**
    * Use AppError#format when AppError is passed to JSON.stringify().
    * This is used in the compas insight logger in production mode.

--- a/packages/stdlib/src/error.js
+++ b/packages/stdlib/src/error.js
@@ -15,15 +15,15 @@ export class AppError extends Error {
    * @param {string} key
    * @param {number} status
    * @param {Record<string, any>} [info={}]
-   * @param {Error} [originalError]
+   * @param {Error} [cause]
    */
-  constructor(key, status, info, originalError) {
+  constructor(key, status, info, cause) {
     super();
 
     this.key = key;
     this.status = status;
     this.info = info || {};
-    this.originalError = originalError;
+    this.cause = cause;
 
     Object.setPrototypeOf(this, AppError.prototype);
 
@@ -143,9 +143,14 @@ export class AppError extends Error {
         status: e.status,
         info: e.info,
         stack,
-        originalError: e.originalError
-          ? AppError.format(e.originalError)
-          : undefined,
+        cause: e.cause ? AppError.format(e.cause) : undefined,
+      };
+    } else if (e.name === "AggregateError") {
+      return {
+        name: e.name,
+        message: e.message,
+        stack: stack,
+        cause: e.errors?.map((it) => AppError.format(it)),
       };
     } else if (e.name === "PostgresError") {
       return {

--- a/packages/stdlib/src/error.test.js
+++ b/packages/stdlib/src/error.test.js
@@ -13,7 +13,7 @@ test("stdlib/error", (t) => {
     t.equal(AppError.instanceOf(e), true);
     t.equal(e.key, "error.server.internal");
     t.equal(e.info.appErrorConstructParams.key, 500);
-    t.equal(e.originalError.key, 500);
+    t.equal(e.cause.key, 500);
   });
 
   t.test("throws on incorrect arguments: status", (t) => {
@@ -23,8 +23,8 @@ test("stdlib/error", (t) => {
     t.equal(e.key, "error.server.internal");
     t.equal(e.info.appErrorConstructParams.key, "test.error");
     t.equal(e.info.appErrorConstructParams.status, "500");
-    t.equal(e.originalError.key, "test.error");
-    t.equal(e.originalError.status, "500");
+    t.equal(e.cause.key, "test.error");
+    t.equal(e.cause.status, "500");
   });
 
   t.test("AppError#format with stack", (t) => {
@@ -51,9 +51,9 @@ test("stdlib/error", (t) => {
       t.ok(Array.isArray(formatted.stack));
       t.deepEqual(formatted.info, {});
 
-      t.equal(formatted.originalError.key, "error.server.internal");
-      t.equal(formatted.originalError.status, 500);
-      t.ok(Array.isArray(formatted.originalError.stack));
+      t.equal(formatted.cause.key, "error.server.internal");
+      t.equal(formatted.cause.status, 500);
+      t.ok(Array.isArray(formatted.cause.stack));
     }
   });
 
@@ -72,13 +72,13 @@ test("stdlib/error", (t) => {
       t.ok(Array.isArray(formatted.stack));
       t.deepEqual(formatted.info, {});
 
-      t.equal(formatted.originalError.message, "test message");
-      t.equal(formatted.originalError.name, "Error");
-      t.ok(Array.isArray(formatted.originalError.stack));
+      t.equal(formatted.cause.message, "test message");
+      t.equal(formatted.cause.name, "Error");
+      t.ok(Array.isArray(formatted.cause.stack));
     }
   });
 
-  t.test("AppError#format originalError with toJSON", (t) => {
+  t.test("AppError#format cause with toJSON", (t) => {
     try {
       throw AppError.validationError(
         "test.error",
@@ -100,9 +100,9 @@ test("stdlib/error", (t) => {
       t.ok(Array.isArray(formatted.stack));
       t.deepEqual(formatted.info, {});
 
-      t.equal(formatted.originalError.message, "JSON message");
-      t.equal(formatted.originalError.name, "JSONError");
-      t.ok(Array.isArray(formatted.originalError.stack));
+      t.equal(formatted.cause.message, "JSON message");
+      t.equal(formatted.cause.name, "JSONError");
+      t.ok(Array.isArray(formatted.cause.stack));
     }
   });
 
@@ -129,5 +129,20 @@ test("stdlib/error", (t) => {
     t.ok(symbol.warning);
     t.equal(fn.name, "sum");
     t.equal(fn.parameterLength, 2);
+  });
+
+  t.test("AppError#format Aggregate error", (t) => {
+    const err = AppError.format(
+      new AggregateError(
+        [new Error("foo"), AppError.serverError({})],
+        "message",
+      ),
+    );
+
+    t.equal(err.name, "AggregateError");
+    t.ok(err.stack);
+    t.ok(err.message);
+    t.ok(Array.isArray(err.cause));
+    t.equal(err.cause[1].key, "error.server.internal");
   });
 });

--- a/packages/store/src/session-store.d.ts
+++ b/packages/store/src/session-store.d.ts
@@ -200,10 +200,5 @@ export function sessionStoreVerifyAndDecodeJWT(
 export type Either<T> = import("@compas/stdlib").Either<T, AppError>;
 export type InsightEvent = import("@compas/stdlib").InsightEvent;
 export type Postgres = import("../types/advanced-types").Postgres;
-export type StoreSessionStoreSettings = {
-  accessTokenMaxAgeInSeconds: number;
-  refreshTokenMaxAgeInSeconds: number;
-  signingKey: string;
-};
 import { AppError } from "@compas/stdlib";
 //# sourceMappingURL=session-store.d.ts.map


### PR DESCRIPTION
Instead of 'errors' we use the 'cause' property here as well for consistency reasons with all other error formats

Closes #1205

BREAKING CHANGE:
- Renamed `AppError#originalError` to `AppError#cause`
- Format also uses `cause` as the key when formatting `AppError` instead of `originalError`