### PR TITLE
feat(store): add `unsafeIgnoreSorting` as a queue worker option

### DIFF
--- a/packages/store/src/queue.d.ts
+++ b/packages/store/src/queue.d.ts
@@ -171,6 +171,7 @@ export class JobQueueWorker {
   pollInterval: number;
   maxRetryCount: number;
   handlerTimeout: number;
+  unsafeIgnoreSorting: boolean;
   /** @type {StoreJobWhere} */
   where: StoreJobWhere;
   workers: any[];
@@ -286,5 +287,12 @@ export type JobQueueWorkerOptions = {
    * picks up all other jobs.
    */
   excludedNames?: string[] | undefined;
+  /**
+   * Improve job throughput by ignoring
+   * the 'priority' and 'scheduledAt' sort when picking up jobs. This still only picks up
+   * jobs that are eligible to be picked up, however it doesn't guarantee any order. This
+   * property is also not bound to any SemVer versioning of this package.
+   */
+  unsafeIgnoreSorting?: boolean | undefined;
 };
 //# sourceMappingURL=queue.d.ts.map

--- a/packages/store/src/queue.js
+++ b/packages/store/src/queue.js
@@ -74,7 +74,6 @@ const queueQueries = {
   // Should only run in a transaction
 
   /**
-   * @param {Postgres} sql
    * @param {StoreJobWhere} where
    * @returns {QueryPart}
    */
@@ -98,7 +97,6 @@ const queueQueries = {
   `,
 
   /**
-   * @param {Postgres} sql
    * @param {StoreJobWhere} where
    * @returns {QueryPart}
    */


### PR DESCRIPTION
References #1344

As the option implies this disables any sorting when picking up jobs. Which equals to ignoring the 'priority' and 'scheduledAt' properties of jobs. Resulting in a much faster way of picking up jobs, for example when generating bursts of a million jobs. Which often results in slow seq scans and in memory sorting by postgres.
A 'normal' workload consisting of transactional inserted jobs that are immediately picked up by Postgres should most likely use the existing indices and don't need this option.

Seeing improvements of 30 seconds to just a few milliseconds when picking up a job.