### PR TITLE
feat(store): add session transports

### DIFF
--- a/packages/stdlib/src/error.d.ts
+++ b/packages/stdlib/src/error.d.ts
@@ -53,7 +53,7 @@ export class AppError extends Error {
   /**
    * Format any error skipping the stack automatically for nested errors
    *
-   * @param {AppError|Error|undefined|null|{}|string|number|boolean|function} [e]
+   * @param {AppError|Error|undefined|null|{}|string|number|boolean|function|unknown} [e]
    * @returns {Record<string, any>}
    */
   static format(
@@ -66,7 +66,8 @@ export class AppError extends Error {
       | string
       | number
       | boolean
-      | Function,
+      | Function
+      | unknown,
   ): Record<string, any>;
   /**
    * @param {string} key

--- a/packages/stdlib/src/error.js
+++ b/packages/stdlib/src/error.js
@@ -93,7 +93,7 @@ export class AppError extends Error {
   /**
    * Format any error skipping the stack automatically for nested errors
    *
-   * @param {AppError|Error|undefined|null|{}|string|number|boolean|function} [e]
+   * @param {AppError|Error|undefined|null|{}|string|number|boolean|function|unknown} [e]
    * @returns {Record<string, any>}
    */
   static format(e) {

--- a/packages/store/index.d.ts
+++ b/packages/store/index.d.ts
@@ -14,6 +14,8 @@ export type GetStreamFn = import("./src/send-transformed-image").GetStreamFn;
 export type SessionStore = import("./src/sessions.js").SessionStore;
 export type SessionStoreSettings =
   import("./src/session-store.js").SessionStoreSettings;
+export type SessionTransportSettings =
+  import("./src/session-transport.js").SessionTransportSettings;
 export {
   newMinioClient,
   minio,
@@ -61,6 +63,10 @@ export {
   sessionStoreRefreshTokens,
   sessionStoreCleanupExpiredSessions,
 } from "./src/session-store.js";
+export {
+  sessionTransportLoadFromContext,
+  sessionTransportAddAsCookiesToContext,
+} from "./src/session-transport.js";
 export {
   query,
   isQueryPart,

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -27,6 +27,10 @@
  * @typedef {import("./src/session-store.js").SessionStoreSettings} SessionStoreSettings
  */
 
+/**
+ * @typedef {import("./src/session-transport.js").SessionTransportSettings} SessionTransportSettings
+ */
+
 export { structure as storeStructure } from "./src/generated/common/structure.js";
 export { queries as storeQueries } from "./src/generated/database/index.js";
 
@@ -90,6 +94,11 @@ export {
   sessionStoreRefreshTokens,
   sessionStoreCleanupExpiredSessions,
 } from "./src/session-store.js";
+
+export {
+  sessionTransportLoadFromContext,
+  sessionTransportAddAsCookiesToContext,
+} from "./src/session-transport.js";
 
 export { newSessionStore } from "./src/sessions.js";
 

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@compas/stdlib": "0.0.175",
+    "@types/koa": "2.13.4",
     "@types/minio": "7.0.11",
     "crc": "3.8.0",
     "is-animated": "2.0.1",

--- a/packages/store/src/session-store.js
+++ b/packages/store/src/session-store.js
@@ -655,6 +655,14 @@ export async function sessionStoreVerifyAndDecodeJWT(
 ) {
   eventStart(event, "sessionStore.verifyAndDecodeJWT");
 
+  if (isNil(tokenString) || tokenString.length === 0) {
+    eventStop(event);
+
+    return {
+      error: AppError.validationError(`${event.name}.missingToken`),
+    };
+  }
+
   const { value, error } = await new Promise((resolve) => {
     createVerify({
       signature: tokenString,

--- a/packages/store/src/session-transport.d.ts
+++ b/packages/store/src/session-transport.d.ts
@@ -1,0 +1,179 @@
+/**
+ * @typedef {import("./session-store").SessionStoreSettings} SessionStoreSettings
+ */
+/**
+ * @template T
+ * @typedef {import("@compas/stdlib").Either<T, AppError>} Either
+ */
+/**
+ * @typedef {import("@compas/stdlib").InsightEvent} InsightEvent
+ */
+/**
+ * @typedef {import("../types/advanced-types").Postgres} Postgres
+ */
+/**
+ * @typedef {object} SessionTransportCookieSettings
+ * @property {"origin"|"own"|string} domain The domain to use.
+ *   'Origin' resolves to the request origin, and 'own' resolves to setting no domain,
+ *   which means only for the domain that was used for the request.
+ * @property {"strict"|"lax"} [sameSite] Set the
+ *   `sameSite` behaviour for this specific cookie. Defaults to `cookieOptions.sameSite`.
+ * @property {boolean} [secure] Set the
+ *   'Secure' behaviour for this specific cookie. Defaults to
+ *   `cookieOptions.secure`.
+ */
+/**
+ * @typedef {object} SessionTransportSettings
+ * @property {SessionStoreSettings} sessionStoreSettings JWT generation settings
+ *
+ * @property {boolean} [enableHeaderTransport] Defaults to true, can be used to disable
+ *   reading the `Authorization` header
+ * @property {boolean} [enableCookieTransport] Defaults to true, can be used to disable
+ *   reading and writing cookies.
+ *
+ * @property {boolean} [autoRefreshCookies] When `enableCookieSupport === true` and only
+ *   a 'refreshToken' is found, it will refresh the tokens and set new cookies.
+ *
+ * @property {object} [headerOptions] Object containing options to configure reading from
+ *   the 'Authorization' header.
+ *
+ * @property {object} [cookieOptions] Object containing options to configure reading and
+ *   writing the cookies
+ * @property {string} [cookieOptions.cookiePrefix] Can be used to add custom prefixes to
+ *   the set cookies. Defaults to `{environment.APP_NAME}.` or an empty string.
+ * @property {"strict"|"lax"} [cookieOptions.sameSite] Set the default `sameSite`
+ *   behaviour for all set cookies. Defaults to 'lax'.
+ * @property {boolean} [cookieOptions.secure] Set the default 'Secure' behaviour for all
+ *   set cookies. Defaults to `isProduction()`.
+ * @property {SessionTransportCookieSettings[]} [cookieOptions.cookies] A specification
+ *   of the cookies you want to set. Defaults to '[{ domain: "own" }, { domain: "origin"
+ *   }]'.
+ */
+/**
+ * Load either the Authorization header or cookies.
+ * If Cookies and autoRefresh is set, automatically refresh with the found refresh
+ * token. This way the accessToken cookie can expiry, and will be set again.
+ *
+ * @param {InsightEvent} event
+ * @param {Postgres} sql
+ * @param {import("koa").Context} ctx
+ * @param {SessionTransportSettings} opts
+ * @returns {Promise<Either<{session: QueryResultStoreSessionStore}>>}
+ */
+export function sessionTransportLoadFromContext(
+  event: InsightEvent,
+  sql: Postgres,
+  ctx: import("koa").Context,
+  opts: SessionTransportSettings,
+): Promise<
+  import("@compas/stdlib").Either<
+    {
+      session: QueryResultStoreSessionStore;
+    },
+    AppError
+  >
+>;
+/**
+ * Add the tokens as cookies.
+ * Set them both on 'Origin', and without domain (ie the api domain). This way we don't
+ * have to hardcode any domain as parameter.
+ * Pass undefined as token pair to remove all cookies.
+ *
+ * @param {import("@compas/stdlib").InsightEvent} event
+ * @param {import("koa").Context} ctx
+ * @param {{ accessToken: string, refreshToken: string }} [tokenPair]
+ * @param {SessionTransportSettings} options
+ * @returns <Promise<void>}
+ */
+export function sessionTransportAddAsCookiesToContext(
+  event: import("@compas/stdlib").InsightEvent,
+  ctx: import("koa").Context,
+  tokenPair?:
+    | {
+        accessToken: string;
+        refreshToken: string;
+      }
+    | undefined,
+  options: SessionTransportSettings,
+): Promise<void>;
+export type SessionStoreSettings =
+  import("./session-store").SessionStoreSettings;
+export type Either<T> = import("@compas/stdlib").Either<T, AppError>;
+export type InsightEvent = import("@compas/stdlib").InsightEvent;
+export type Postgres = import("../types/advanced-types").Postgres;
+export type SessionTransportCookieSettings = {
+  /**
+   * The domain to use.
+   * 'Origin' resolves to the request origin, and 'own' resolves to setting no domain,
+   * which means only for the domain that was used for the request.
+   */
+  domain: "origin" | "own" | string;
+  /**
+   * Set the
+   * `sameSite` behaviour for this specific cookie. Defaults to `cookieOptions.sameSite`.
+   */
+  sameSite?: "strict" | "lax" | undefined;
+  /**
+   * Set the
+   * 'Secure' behaviour for this specific cookie. Defaults to
+   * `cookieOptions.secure`.
+   */
+  secure?: boolean | undefined;
+};
+export type SessionTransportSettings = {
+  /**
+   * JWT generation settings
+   */
+  sessionStoreSettings: SessionStoreSettings;
+  /**
+   * Defaults to true, can be used to disable
+   * reading the `Authorization` header
+   */
+  enableHeaderTransport?: boolean | undefined;
+  /**
+   * Defaults to true, can be used to disable
+   * reading and writing cookies.
+   */
+  enableCookieTransport?: boolean | undefined;
+  /**
+   * When `enableCookieSupport === true` and only
+   * a 'refreshToken' is found, it will refresh the tokens and set new cookies.
+   */
+  autoRefreshCookies?: boolean | undefined;
+  /**
+   * Object containing options to configure reading from
+   * the 'Authorization' header.
+   */
+  headerOptions?: object;
+  /**
+   * Object containing options to configure reading and
+   * writing the cookies
+   */
+  cookieOptions?:
+    | {
+        /**
+         * Can be used to add custom prefixes to
+         * the set cookies. Defaults to `{environment.APP_NAME}.` or an empty string.
+         */
+        cookiePrefix?: string | undefined;
+        /**
+         * Set the default `sameSite`
+         * behaviour for all set cookies. Defaults to 'lax'.
+         */
+        sameSite?: "strict" | "lax" | undefined;
+        /**
+         * Set the default 'Secure' behaviour for all
+         * set cookies. Defaults to `isProduction()`.
+         */
+        secure?: boolean | undefined;
+        /**
+         * A specification
+         * of the cookies you want to set. Defaults to '[{ domain: "own" }, { domain: "origin"
+         * }]'.
+         */
+        cookies?: SessionTransportCookieSettings[] | undefined;
+      }
+    | undefined;
+};
+import { AppError } from "@compas/stdlib";
+//# sourceMappingURL=session-transport.d.ts.map

--- a/packages/store/src/session-transport.d.ts
+++ b/packages/store/src/session-transport.d.ts
@@ -81,14 +81,14 @@ export function sessionTransportLoadFromContext(
  *
  * @param {import("@compas/stdlib").InsightEvent} event
  * @param {import("koa").Context} ctx
- * @param {{ accessToken: string, refreshToken: string }} [tokenPair]
+ * @param {{ accessToken: string, refreshToken: string }|undefined} tokenPair
  * @param {SessionTransportSettings} options
  * @returns <Promise<void>}
  */
 export function sessionTransportAddAsCookiesToContext(
   event: import("@compas/stdlib").InsightEvent,
   ctx: import("koa").Context,
-  tokenPair?:
+  tokenPair:
     | {
         accessToken: string;
         refreshToken: string;

--- a/packages/store/src/session-transport.js
+++ b/packages/store/src/session-transport.js
@@ -1,0 +1,354 @@
+import {
+  AppError,
+  environment,
+  eventStart,
+  eventStop,
+  isNil,
+  isProduction,
+  newEventFromEvent,
+} from "@compas/stdlib";
+import {
+  sessionStoreGet,
+  sessionStoreRefreshTokens,
+  sessionStoreVerifyAndDecodeJWT,
+} from "./session-store.js";
+
+/**
+ * @typedef {import("./session-store").SessionStoreSettings} SessionStoreSettings
+ */
+
+/**
+ * @template T
+ * @typedef {import("@compas/stdlib").Either<T, AppError>} Either
+ */
+
+/**
+ * @typedef {import("@compas/stdlib").InsightEvent} InsightEvent
+ */
+
+/**
+ * @typedef {import("../types/advanced-types").Postgres} Postgres
+ */
+
+/**
+ * @typedef {object} SessionTransportCookieSettings
+ * @property {"origin"|"own"|string} domain The domain to use.
+ *   'Origin' resolves to the request origin, and 'own' resolves to setting no domain,
+ *   which means only for the domain that was used for the request.
+ * @property {"strict"|"lax"} [sameSite] Set the
+ *   `sameSite` behaviour for this specific cookie. Defaults to `cookieOptions.sameSite`.
+ * @property {boolean} [secure] Set the
+ *   'Secure' behaviour for this specific cookie. Defaults to
+ *   `cookieOptions.secure`.
+ */
+
+/**
+ * @typedef {object} SessionTransportSettings
+ * @property {SessionStoreSettings} sessionStoreSettings JWT generation settings
+ *
+ * @property {boolean} [enableHeaderTransport] Defaults to true, can be used to disable
+ *   reading the `Authorization` header
+ * @property {boolean} [enableCookieTransport] Defaults to true, can be used to disable
+ *   reading and writing cookies.
+ *
+ * @property {boolean} [autoRefreshCookies] When `enableCookieSupport === true` and only
+ *   a 'refreshToken' is found, it will refresh the tokens and set new cookies.
+ *
+ * @property {object} [headerOptions] Object containing options to configure reading from
+ *   the 'Authorization' header.
+ *
+ * @property {object} [cookieOptions] Object containing options to configure reading and
+ *   writing the cookies
+ * @property {string} [cookieOptions.cookiePrefix] Can be used to add custom prefixes to
+ *   the set cookies. Defaults to `{environment.APP_NAME}.` or an empty string.
+ * @property {"strict"|"lax"} [cookieOptions.sameSite] Set the default `sameSite`
+ *   behaviour for all set cookies. Defaults to 'lax'.
+ * @property {boolean} [cookieOptions.secure] Set the default 'Secure' behaviour for all
+ *   set cookies. Defaults to `isProduction()`.
+ * @property {SessionTransportCookieSettings[]} [cookieOptions.cookies] A specification
+ *   of the cookies you want to set. Defaults to '[{ domain: "own" }, { domain: "origin"
+ *   }]'.
+ */
+
+/**
+ * Load either the Authorization header or cookies.
+ * If Cookies and autoRefresh is set, automatically refresh with the found refresh
+ * token. This way the accessToken cookie can expiry, and will be set again.
+ *
+ * @param {InsightEvent} event
+ * @param {Postgres} sql
+ * @param {import("koa").Context} ctx
+ * @param {SessionTransportSettings} opts
+ * @returns {Promise<Either<{session: QueryResultStoreSessionStore}>>}
+ */
+export async function sessionTransportLoadFromContext(event, sql, ctx, opts) {
+  eventStart(event, "sessionTransport.loadFromContext");
+
+  const options = validateSessionTransportSettings(opts);
+
+  let accessToken;
+  if (options.enableHeaderTransport) {
+    accessToken = sessionTransportLoadAuthorizationHeader(ctx);
+  }
+
+  if (!accessToken && options.enableCookieTransport) {
+    accessToken = await sessionTransportLoadCookies(
+      newEventFromEvent(event),
+      sql,
+      ctx,
+      options,
+    );
+  }
+
+  const session = await sessionStoreGet(
+    newEventFromEvent(event),
+    sql,
+    options.sessionStoreSettings,
+    accessToken,
+  );
+
+  eventStop(event);
+
+  // We need to return the same `Either<X,Y>` as `sessionStoreGet`.
+  return session;
+}
+
+/**
+ * Add the tokens as cookies.
+ * Set them both on 'Origin', and without domain (ie the api domain). This way we don't
+ * have to hardcode any domain as parameter.
+ * Pass undefined as token pair to remove all cookies.
+ *
+ * @param {import("@compas/stdlib").InsightEvent} event
+ * @param {import("koa").Context} ctx
+ * @param {{ accessToken: string, refreshToken: string }} [tokenPair]
+ * @param {SessionTransportSettings} options
+ * @returns <Promise<void>}
+ */
+export async function sessionTransportAddAsCookiesToContext(
+  event,
+  ctx,
+  tokenPair,
+  options,
+) {
+  eventStart(event, "sessionTransport.addAsCookiesToContext");
+
+  if (!options.enableCookieTransport) {
+    throw AppError.serverError({
+      message: "Can't set cookies if the cookie transport is disabled.",
+    });
+  }
+
+  const accessToken = tokenPair?.accessToken
+    ? await sessionStoreVerifyAndDecodeJWT(
+        newEventFromEvent(event),
+        options.sessionStoreSettings,
+        tokenPair.accessToken,
+      )
+    : undefined;
+  const refreshToken = tokenPair?.refreshToken
+    ? await sessionStoreVerifyAndDecodeJWT(
+        newEventFromEvent(event),
+        options.sessionStoreSettings,
+        tokenPair.refreshToken,
+      )
+    : undefined;
+
+  for (const cookie of options.cookieOptions.cookies) {
+    const domain = getResolvedDomain(ctx, cookie.domain);
+
+    ctx.cookies.set(
+      getCookieName(options, "accessToken"),
+      tokenPair?.accessToken,
+      {
+        expires: new Date((accessToken?.value?.payload?.exp ?? 0) * 1000),
+        domain,
+        secure: cookie.secure,
+        httpOnly: true,
+        sameSite: cookie.sameSite,
+      },
+    );
+    ctx.cookies.set(
+      getCookieName(options, "refreshToken"),
+      tokenPair?.refreshToken,
+      {
+        expires: new Date((refreshToken?.value?.payload?.exp ?? 0) * 1000),
+        domain,
+        secure: cookie.secure,
+        httpOnly: true,
+        sameSite: cookie.sameSite,
+      },
+    );
+
+    // Maintain a JS readable public cookie so the frontend can do logic without
+    // executing requests.
+    ctx.cookies.set(
+      getCookieName(options, "public"),
+      tokenPair?.refreshToken ? "truthy" : undefined,
+      {
+        expires: new Date((refreshToken?.value?.payload?.exp ?? 0) * 1000),
+        domain,
+        secure: cookie.secure,
+        httpOnly: false,
+        sameSite: cookie.sameSite,
+      },
+    );
+  }
+
+  eventStop(event);
+}
+
+/**
+ *
+ * @param {SessionTransportSettings} opts
+ * @returns {SessionTransportSettings}
+ */
+function validateSessionTransportSettings(opts) {
+  opts.enableHeaderTransport = opts.enableHeaderTransport ?? true;
+  opts.enableCookieTransport = opts.enableCookieTransport ?? true;
+  opts.headerOptions = opts.headerOptions ?? {};
+  opts.cookieOptions = opts.cookieOptions ?? {};
+  opts.autoRefreshCookies = opts.autoRefreshCookies ?? true;
+
+  opts.cookieOptions.cookiePrefix =
+    opts.cookieOptions.cookiePrefix ?? environment.APP_NAME ?? "";
+  opts.cookieOptions.sameSite = opts.cookieOptions.sameSite ?? "lax";
+  opts.cookieOptions.secure = opts.cookieOptions.secure ?? isProduction();
+
+  opts.cookieOptions.cookies = opts.cookieOptions.cookies ?? [
+    { domain: "own" },
+    { domain: "origin" },
+  ];
+
+  if (!opts.enableHeaderTransport && !opts.enableCookieTransport) {
+    throw AppError.serverError({
+      message:
+        "Invalid session transport settings. Either needs `enableHeaderTransport` or `enabledCookieTransport` set.",
+    });
+  }
+
+  if (
+    opts.cookieOptions.cookiePrefix.length > 0 &&
+    !opts.cookieOptions.cookiePrefix.endsWith(".")
+  ) {
+    opts.cookieOptions.cookiePrefix += ".";
+  }
+
+  for (const cookieOpt of opts.cookieOptions.cookies) {
+    cookieOpt.cookiePrefix =
+      cookieOpt.cookiePrefix ?? opts.cookieOptions.cookiePrefix;
+    cookieOpt.sameSite = cookieOpt.sameSite ?? opts.cookieOptions.sameSite;
+    cookieOpt.secure = cookieOpt.secure ?? opts.cookieOptions.secure;
+  }
+
+  return opts;
+}
+
+/**
+ * Read the authorization header from the Koa context
+ *
+ * @param {import("koa").Context} ctx
+ * @return {string|undefined}
+ */
+function sessionTransportLoadAuthorizationHeader(ctx) {
+  const header = ctx.headers?.["authorization"] ?? "";
+
+  if (!header.startsWith("Bearer ") || header.substring(7).length === 0) {
+    return undefined;
+  }
+
+  return header.substring(7);
+}
+
+/**
+ * Load the access token from cookies, refreshing the tokens when a only a refresh token
+ * is found. Returns
+ *
+ * @param {InsightEvent} event
+ * @param {Postgres} sql
+ * @param {import("koa").Context} ctx
+ * @param {SessionTransportSettings} options
+ * @returns {string|undefined}
+ */
+async function sessionTransportLoadCookies(event, sql, ctx, options) {
+  eventStart(event, "sessionTransport.loadCookies");
+
+  let accessToken = ctx.cookies.get(getCookieName(options, "accessToken"));
+  const refreshToken = ctx.cookies.get(getCookieName(options, "refreshToken"));
+
+  if (
+    options.autoRefreshCookies &&
+    !isNil(accessToken) &&
+    accessToken.length === 0 &&
+    !isNil(refreshToken) &&
+    refreshToken.length > 0
+  ) {
+    const tokenPair = await sessionStoreRefreshTokens(
+      newEventFromEvent(event),
+      sql,
+      options.sessionStoreSettings,
+      refreshToken,
+    );
+
+    if (tokenPair.error) {
+      // We can ignore these errors and remove the left over tokens, since they are
+      // invalid.
+      await sessionTransportAddAsCookiesToContext(
+        newEventFromEvent(event),
+        ctx,
+        undefined,
+        options,
+      );
+      eventStop(event);
+
+      return accessToken;
+    }
+
+    await sessionTransportAddAsCookiesToContext(
+      newEventFromEvent(event),
+      ctx,
+      tokenPair.value,
+      options,
+    );
+
+    accessToken = tokenPair.value.accessToken;
+  }
+
+  eventStop(event);
+
+  return accessToken;
+}
+
+/**
+ * Determine the cookie name based on cookie options
+ *
+ * @param {SessionTransportSettings} options
+ * @param {string} suffix
+ * @returns {string}
+ */
+function getCookieName(options, suffix) {
+  return options.cookieOptions.cookiePrefix + suffix;
+}
+
+/**
+ * Resolve the domain setting
+ *
+ * @param {import("koa").Context} ctx
+ * @param {"own"|"origin"|string} domain
+ * @return {undefined|string}
+ */
+function getResolvedDomain(ctx, domain) {
+  if (domain === "own") {
+    return undefined;
+  } else if (domain === "origin") {
+    const originHeader = ctx.get("origin");
+
+    if (originHeader) {
+      return new URL(originHeader).hostname;
+    }
+
+    return undefined;
+  }
+
+  return domain;
+}

--- a/packages/store/src/session-transport.test.js
+++ b/packages/store/src/session-transport.test.js
@@ -1,0 +1,405 @@
+import { mainTestFn, newTestEvent, test } from "@compas/cli";
+import { closeTestApp, createTestAppAndClient, getApp } from "@compas/server";
+import {
+  AppError,
+  isPlainObject,
+  newEventFromEvent,
+  uuid,
+} from "@compas/stdlib";
+import Axios from "axios";
+import { sql } from "../../../src/testing.js";
+import { querySessionStore } from "./generated/database/sessionStore.js";
+import {
+  sessionStoreCreate,
+  sessionStoreVerifyAndDecodeJWT,
+} from "./session-store.js";
+import {
+  sessionTransportAddAsCookiesToContext,
+  sessionTransportLoadFromContext,
+  validateSessionTransportSettings,
+} from "./session-transport.js";
+
+mainTestFn(import.meta);
+
+test("store/session-store", (t) => {
+  const sessionStoreSettings = {
+    accessTokenMaxAgeInSeconds: 5,
+    refreshTokenMaxAgeInSeconds: 10,
+    signingKey: uuid(),
+  };
+
+  /**
+   *
+   * @param {import("koa").Middleware} middleware
+   * @return {Promise<{axiosInstance: AxiosInstance, session:
+   *   QueryResultStoreSessionStore, tokens: {accessToken: string, refreshToken: string},
+   *   closeApp: (function(): Promise<void>)}>}
+   */
+  const createAppWithSession = async (middleware) => {
+    const app = getApp();
+    app.use(middleware);
+
+    const axiosInstance = Axios.create();
+    await createTestAppAndClient(app, axiosInstance);
+
+    const tokenResult = await sessionStoreCreate(
+      newTestEvent(t),
+      sql,
+      sessionStoreSettings,
+      {},
+    );
+
+    if (tokenResult.error) {
+      throw tokenResult.error;
+    }
+
+    const accessTokenResult = await sessionStoreVerifyAndDecodeJWT(
+      newTestEvent(t),
+      sessionStoreSettings,
+      tokenResult.value.accessToken,
+    );
+
+    if (accessTokenResult.error) {
+      throw accessTokenResult.error;
+    }
+
+    const [session] = await querySessionStore({
+      viaAccessTokens: {
+        where: {
+          id: accessTokenResult.value.payload.compasSessionAccessToken,
+        },
+      },
+      accessTokens: {
+        where: {
+          refreshTokenIsNotNull: true,
+        },
+        refreshToken: {},
+      },
+    }).exec(sql);
+
+    return {
+      closeApp: () => closeTestApp(app),
+      axiosInstance,
+      session,
+      tokens: tokenResult.value,
+    };
+  };
+
+  t.test("validateSessionTransportSettings", (t) => {
+    t.test("defaults", (t) => {
+      const options = validateSessionTransportSettings({
+        sessionStoreSettings,
+      });
+
+      t.equal(options.enableHeaderTransport, true);
+      t.equal(options.enableCookieTransport, true);
+      t.equal(options.autoRefreshCookies, true);
+
+      t.equal(options.sessionStoreSettings, sessionStoreSettings);
+
+      t.ok(isPlainObject(options.headerOptions));
+      t.ok(isPlainObject(options.cookieOptions));
+
+      t.equal(options.cookieOptions.cookiePrefix, "compas.");
+      t.equal(options.cookieOptions.sameSite, "lax");
+      t.equal(options.cookieOptions.secure, false);
+
+      t.ok(options.cookieOptions.cookies.find((it) => it.domain === "own"));
+      t.ok(options.cookieOptions.cookies.find((it) => it.domain === "origin"));
+    });
+
+    t.test("cookieOptions as default for cookies", (t) => {
+      const options = validateSessionTransportSettings({
+        sessionStoreSettings,
+        cookieOptions: {
+          secure: true,
+          sameSite: "strict",
+          cookies: [
+            {
+              domain: "own",
+              sameSite: "lax",
+            },
+            {
+              domain: "origin",
+              secure: false,
+            },
+          ],
+        },
+      });
+
+      t.equal(options.cookieOptions.cookies[0].sameSite, "lax");
+      t.equal(options.cookieOptions.cookies[0].secure, true);
+
+      t.equal(options.cookieOptions.cookies[1].sameSite, "strict");
+      t.equal(options.cookieOptions.cookies[1].secure, false);
+    });
+
+    t.test("single transport required", (t) => {
+      try {
+        validateSessionTransportSettings({
+          sessionStoreSettings,
+          enableHeaderTransport: false,
+          enableCookieTransport: false,
+        });
+      } catch (e) {
+        t.ok(AppError.instanceOf(e));
+      }
+    });
+
+    t.test("single cookieOptions.cookies required if override", (t) => {
+      try {
+        validateSessionTransportSettings({
+          sessionStoreSettings,
+          cookieOptions: {
+            cookies: [],
+          },
+        });
+      } catch (e) {
+        t.ok(AppError.instanceOf(e));
+      }
+    });
+
+    t.test("cookiePrefix is ignored if empty", (t) => {
+      const options = validateSessionTransportSettings({
+        sessionStoreSettings,
+        cookieOptions: {
+          cookiePrefix: "",
+        },
+      });
+
+      t.equal(options.cookieOptions.cookiePrefix, "");
+    });
+
+    t.test("cookiePrefix is suffixed with a dot", (t) => {
+      const options1 = validateSessionTransportSettings({
+        sessionStoreSettings,
+        cookieOptions: {
+          cookiePrefix: "foo",
+        },
+      });
+
+      t.equal(options1.cookieOptions.cookiePrefix, "foo.");
+
+      const options2 = validateSessionTransportSettings({
+        sessionStoreSettings,
+        cookieOptions: {
+          cookiePrefix: "foo.",
+        },
+      });
+
+      t.equal(options2.cookieOptions.cookiePrefix, "foo.");
+    });
+
+    t.test("domain is required in cookies array", (t) => {
+      try {
+        validateSessionTransportSettings({
+          sessionStoreSettings,
+          cookieOptions: {
+            cookies: [{}],
+          },
+        });
+      } catch (e) {
+        t.ok(AppError.instanceOf(e));
+      }
+    });
+  });
+
+  t.test("sessionTransportLoadFromContext", (t) => {
+    t.test("headerTransport", async (t) => {
+      const { closeApp, axiosInstance, session, tokens } =
+        await createAppWithSession(async (ctx, next) => {
+          const { error, value } = await sessionTransportLoadFromContext(
+            newEventFromEvent(ctx.event),
+            sql,
+            ctx,
+            {
+              sessionStoreSettings,
+            },
+          );
+
+          ctx.body = {
+            error: AppError.format(error),
+            value,
+          };
+
+          return next();
+        });
+
+      t.test("invalid header", async (t) => {
+        const response = await axiosInstance.request({
+          method: "GET",
+          url: "/",
+          headers: {
+            Authorization: "Bearer",
+          },
+        });
+
+        t.equal(
+          response.data.error.key,
+          `sessionStore.verifyAndDecodeJWT.missingToken`,
+        );
+      });
+
+      t.test("valid header", async (t) => {
+        const response = await axiosInstance.request({
+          method: "GET",
+          url: "/",
+          headers: {
+            Authorization: `Bearer ${tokens.accessToken}`,
+          },
+        });
+
+        t.equal(response.data.value.session.id, session.id);
+      });
+
+      t.test("teardown", async (t) => {
+        await closeApp();
+
+        t.pass();
+      });
+    });
+
+    t.test("cookieTransport", async (t) => {
+      const { closeApp, axiosInstance, session, tokens } =
+        await createAppWithSession(async (ctx, next) => {
+          const { error, value } = await sessionTransportLoadFromContext(
+            newEventFromEvent(ctx.event),
+            sql,
+            ctx,
+            {
+              sessionStoreSettings,
+              enableHeaderTransport: false,
+            },
+          );
+
+          ctx.body = {
+            error: AppError.format(error),
+            value,
+          };
+
+          return next();
+        });
+
+      t.test("invalid cookie", async (t) => {
+        const response = await axiosInstance.request({
+          method: "GET",
+          url: "/",
+          headers: {
+            Cookie: `accessToken=${tokens.accessToken}`,
+          },
+        });
+
+        t.equal(
+          response.data.error.key,
+          `sessionStore.verifyAndDecodeJWT.missingToken`,
+        );
+      });
+
+      t.test("invalid refresh cookie", async (t) => {
+        const response = await axiosInstance.request({
+          method: "GET",
+          url: "/",
+          headers: {
+            Cookie: `refreshToken=${tokens.accessToken}`,
+          },
+        });
+
+        t.equal(
+          response.data.error.key,
+          `sessionStore.verifyAndDecodeJWT.missingToken`,
+        );
+      });
+
+      t.test("valid access token", async (t) => {
+        const response = await axiosInstance.request({
+          method: "GET",
+          url: "/",
+          headers: {
+            Cookie: `compas.accessToken=${tokens.accessToken}`,
+          },
+        });
+
+        t.equal(response.data.value.session.id, session.id);
+      });
+
+      t.test("valid refresh token", async (t) => {
+        const response = await axiosInstance.request({
+          method: "GET",
+          url: "/",
+          headers: {
+            Cookie: `compas.refreshToken=${tokens.refreshToken}`,
+          },
+        });
+
+        t.equal(response.data.value.session.id, session.id);
+
+        const setCookies = response.headers["set-cookie"];
+
+        t.equal(setCookies.length, 3);
+        const [accessToken, refreshToken, publicCookie] = setCookies;
+
+        t.ok(accessToken.includes("httponly"));
+        t.ok(accessToken.includes("compas.accessToken=ey"));
+
+        t.ok(refreshToken.includes("httponly"));
+        t.ok(refreshToken.includes("compas.refreshToken=ey"));
+
+        t.ok(!publicCookie.includes("httponly"));
+        t.ok(publicCookie.includes("compas.public=truthy"));
+      });
+
+      t.test("teardown", async (t) => {
+        await closeApp();
+
+        t.pass();
+      });
+    });
+  });
+
+  t.test("sessionTransportAddAsCookiesToContext", async (t) => {
+    const { closeApp, axiosInstance } = await createAppWithSession(
+      async (ctx, next) => {
+        await sessionTransportAddAsCookiesToContext(
+          newEventFromEvent(ctx.event),
+          ctx,
+          undefined,
+          {
+            sessionStoreSettings,
+          },
+        );
+
+        ctx.body = {};
+
+        return next();
+      },
+    );
+
+    t.test("set empty cookies", async (t) => {
+      const response = await axiosInstance.request({
+        method: "GET",
+        url: "/",
+      });
+
+      const setCookies = response.headers["set-cookie"];
+
+      t.equal(setCookies.length, 3);
+
+      const [accessToken, refreshToken, publicCookie] = setCookies;
+
+      t.ok(accessToken.includes("httponly"));
+      t.ok(accessToken.includes("compas.accessToken=;"));
+
+      t.ok(refreshToken.includes("httponly"));
+      t.ok(refreshToken.includes("compas.refreshToken=;"));
+
+      t.ok(!publicCookie.includes("httponly"));
+      t.ok(publicCookie.includes("compas.public=;"));
+    });
+
+    t.test("teardown", async (t) => {
+      await closeApp();
+
+      t.pass();
+    });
+  });
+});


### PR DESCRIPTION
Support reading access from Authorization headers. And support reading and writing tokens from and to cookies.

TODO:
- [x] Fixup `compas types`
- [x] Add tests

Testing this is going to be a bit of a pain, since there is no easy way to mock `ctx.cookies.get()` and `.set()` that are worth to write since we still need to test the full integration.