### PR TITLE
feat(code-gen): remove 'via' traversers from the query builders

### DIFF
--- a/packages/code-gen/test/sql.test.js
+++ b/packages/code-gen/test/sql.test.js
@@ -183,10 +183,14 @@ test("code-gen/e2e/sql", (t) => {
 
   t.test("get posts for user", async (t) => {
     const result = await queryPost({
-      viaWriter: {
-        viaPosts: {
+      where: {
+        viaWriter: {
           where: {
-            id: post.id,
+            viaPosts: {
+              where: {
+                id: post.id,
+              },
+            },
           },
         },
       },
@@ -198,35 +202,6 @@ test("code-gen/e2e/sql", (t) => {
     t.equal(typeof result[0].createdAt, "object");
     t.equal(typeof result[0].updatedAt, "object");
     t.notEqual(result[0].deletedAt, null, "deletedAt is undefined");
-  });
-
-  t.test("queryBuilder via = where via", async (t) => {
-    t.deepEqual(
-      [
-        ...(await queryPost({
-          viaWriter: {
-            viaPosts: {
-              where: {
-                id: post.id,
-              },
-            },
-          },
-        }).exec(sql)),
-      ],
-      [
-        ...(await queryPost({
-          where: {
-            viaWriter: {
-              where: {
-                viaPosts: {
-                  where: { id: post.id },
-                },
-              },
-            },
-          },
-        }).exec(sql)),
-      ],
-    );
   });
 
   t.test("update user nick name", async (t) => {
@@ -494,13 +469,27 @@ test("code-gen/e2e/sql", (t) => {
           },
         },
       },
-      viaCategories: {
-        viaCategory: {
-          viaPosts: {
-            viaPost: {
-              viaWriter: {
+      where: {
+        viaCategories: {
+          where: {
+            viaCategory: {
+              where: {
                 viaPosts: {
-                  viaPostages: {},
+                  where: {
+                    viaPost: {
+                      where: {
+                        viaWriter: {
+                          where: {
+                            viaPosts: {
+                              where: {
+                                viaPostages: {},
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -514,9 +503,11 @@ test("code-gen/e2e/sql", (t) => {
 
   t.test("traverse via queryUser", async (t) => {
     const [dbUser] = await queryUser({
-      viaPosts: {
-        where: {
-          id: post.id,
+      where: {
+        viaPosts: {
+          where: {
+            id: post.id,
+          },
         },
       },
     }).exec(sql);
@@ -528,10 +519,10 @@ test("code-gen/e2e/sql", (t) => {
     const [dbUser] = await queryUser({
       where: {
         idIn: [post.writer],
-      },
-      viaPosts: {
-        where: {
-          id: post.id,
+        viaPosts: {
+          where: {
+            id: post.id,
+          },
         },
       },
     }).exec(sql);
@@ -543,10 +534,10 @@ test("code-gen/e2e/sql", (t) => {
     const [dbUser] = await queryUser({
       where: {
         idIn: [post.writer, uuid()],
-      },
-      viaPosts: {
-        where: {
-          id: post.id,
+        viaPosts: {
+          where: {
+            id: post.id,
+          },
         },
       },
     }).exec(sql);
@@ -556,18 +547,30 @@ test("code-gen/e2e/sql", (t) => {
 
   t.test("traverse via queryCategory", async (t) => {
     const builder = {
-      viaPosts: {
-        viaPost: {
-          viaWriter: {
-            where: {
-              id: user.id,
-            },
-            viaPosts: {
-              viaCategories: {
-                viaCategory: {
-                  viaMeta: {
-                    where: {
-                      isHighlighted: false,
+      where: {
+        viaPosts: {
+          where: {
+            viaPost: {
+              where: {
+                viaWriter: {
+                  where: {
+                    id: user.id,
+                    viaPosts: {
+                      where: {
+                        viaCategories: {
+                          where: {
+                            viaCategory: {
+                              where: {
+                                viaMeta: {
+                                  where: {
+                                    isHighlighted: false,
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
                     },
                   },
                 },

--- a/packages/store/src/file-group.test.js
+++ b/packages/store/src/file-group.test.js
@@ -215,8 +215,12 @@ test("store/file-group", async (t) => {
 
   t.test("get parents of all files", async (t) => {
     const result = await queryFileGroup({
-      viaChildren: {
-        viaFile: {},
+      where: {
+        viaChildren: {
+          where: {
+            viaFile: {},
+          },
+        },
       },
     }).exec(sql);
 

--- a/packages/store/src/generated/common/anonymous-validators.d.ts
+++ b/packages/store/src/generated/common/anonymous-validators.d.ts
@@ -1329,55 +1329,7 @@ export function anonymousValidator2119152283(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileGroupWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaFile"?: undefined|StoreFileQueryTraverser, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }>}
- */
-export function anonymousValidator1274599578(
-  value: any,
-  propertyPath: string,
-): EitherN<{
-  where?: undefined | StoreFileGroupWhere;
-  limit?: undefined | number;
-  offset?: undefined | number;
-  viaFile?: undefined | StoreFileQueryTraverser;
-  viaParent?: undefined | StoreFileGroupQueryTraverser;
-  viaChildren?: undefined | StoreFileGroupQueryTraverser;
-}>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreFileGroupQueryTraverser>}
- */
-export function anonymousValidator514437691(
-  value: any,
-  propertyPath: string,
-): EitherN<undefined | StoreFileGroupQueryTraverser>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, }>}
- */
-export function anonymousValidator1069465749(
-  value: any,
-  propertyPath: string,
-): EitherN<{
-  where?: undefined | StoreFileWhere;
-  limit?: undefined | number;
-  offset?: undefined | number;
-  viaGroup?: undefined | StoreFileGroupQueryTraverser;
-}>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreFileQueryTraverser>}
- */
-export function anonymousValidator1978760330(
-  value: any,
-  propertyPath: string,
-): EitherN<undefined | StoreFileQueryTraverser>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileGroupWhere, "orderBy"?: undefined|StoreFileGroupOrderBy, "orderBySpec"?: undefined|StoreFileGroupOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "viaFile"?: undefined|StoreFileQueryTraverser, "parent"?: undefined|StoreFileGroupQueryBuilder, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "children"?: undefined|StoreFileGroupQueryBuilder, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreFileGroupWhere, "orderBy"?: undefined|StoreFileGroupOrderBy, "orderBySpec"?: undefined|StoreFileGroupOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "parent"?: undefined|StoreFileGroupQueryBuilder, "children"?: undefined|StoreFileGroupQueryBuilder, }>}
  */
 export function anonymousValidator1862233461(
   value: any,
@@ -1390,11 +1342,8 @@ export function anonymousValidator1862233461(
   limit?: undefined | number;
   offset?: undefined | number;
   file?: undefined | StoreFileQueryBuilder;
-  viaFile?: undefined | StoreFileQueryTraverser;
   parent?: undefined | StoreFileGroupQueryBuilder;
-  viaParent?: undefined | StoreFileGroupQueryTraverser;
   children?: undefined | StoreFileGroupQueryBuilder;
-  viaChildren?: undefined | StoreFileGroupQueryTraverser;
 }>;
 /**
  * @param {*} value
@@ -1408,7 +1357,7 @@ export function anonymousValidator1996607136(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "group"?: undefined|StoreFileGroupQueryBuilder, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "group"?: undefined|StoreFileGroupQueryBuilder, }>}
  */
 export function anonymousValidator310044624(
   value: any,
@@ -1421,7 +1370,6 @@ export function anonymousValidator310044624(
   limit?: undefined | number;
   offset?: undefined | number;
   group?: undefined | StoreFileGroupQueryBuilder;
-  viaGroup?: undefined | StoreFileGroupQueryTraverser;
 }>;
 /**
  * @param {*} value
@@ -1469,19 +1417,6 @@ export function anonymousValidator343387919(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "limit"?: undefined|number, "offset"?: undefined|number, }>}
- */
-export function anonymousValidator1952914356(
-  value: any,
-  propertyPath: string,
-): EitherN<{
-  where?: undefined | StoreJobWhere;
-  limit?: undefined | number;
-  offset?: undefined | number;
-}>;
-/**
- * @param {*} value
- * @param {string} propertyPath
  * @returns {EitherN<undefined|StoreSessionWhere>}
  */
 export function anonymousValidator196488441(
@@ -1519,19 +1454,6 @@ export function anonymousValidator647856360(
   orderBy?: undefined | StoreSessionOrderBy;
   orderBySpec?: undefined | StoreSessionOrderBySpec;
   as?: undefined | string;
-  limit?: undefined | number;
-  offset?: undefined | number;
-}>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionWhere, "limit"?: undefined|number, "offset"?: undefined|number, }>}
- */
-export function anonymousValidator1805657267(
-  value: any,
-  propertyPath: string,
-): EitherN<{
-  where?: undefined | StoreSessionWhere;
   limit?: undefined | number;
   offset?: undefined | number;
 }>;
@@ -1583,55 +1505,7 @@ export function anonymousValidator1827379372(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaSession"?: undefined|StoreSessionStoreQueryTraverser, "viaRefreshToken"?: undefined|StoreSessionStoreTokenQueryTraverser, "viaAccessToken"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
- */
-export function anonymousValidator770376901(
-  value: any,
-  propertyPath: string,
-): EitherN<{
-  where?: undefined | StoreSessionStoreTokenWhere;
-  limit?: undefined | number;
-  offset?: undefined | number;
-  viaSession?: undefined | StoreSessionStoreQueryTraverser;
-  viaRefreshToken?: undefined | StoreSessionStoreTokenQueryTraverser;
-  viaAccessToken?: undefined | StoreSessionStoreTokenQueryTraverser;
-}>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreSessionStoreTokenQueryTraverser>}
- */
-export function anonymousValidator1149378288(
-  value: any,
-  propertyPath: string,
-): EitherN<undefined | StoreSessionStoreTokenQueryTraverser>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaAccessTokens"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
- */
-export function anonymousValidator135209020(
-  value: any,
-  propertyPath: string,
-): EitherN<{
-  where?: undefined | StoreSessionStoreWhere;
-  limit?: undefined | number;
-  offset?: undefined | number;
-  viaAccessTokens?: undefined | StoreSessionStoreTokenQueryTraverser;
-}>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreSessionStoreQueryTraverser>}
- */
-export function anonymousValidator1095313735(
-  value: any,
-  propertyPath: string,
-): EitherN<undefined | StoreSessionStoreQueryTraverser>;
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "session"?: undefined|StoreSessionStoreQueryBuilder, "viaSession"?: undefined|StoreSessionStoreQueryTraverser, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "viaRefreshToken"?: undefined|StoreSessionStoreTokenQueryTraverser, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "viaAccessToken"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator1856722848(
   value: any,
@@ -1644,11 +1518,8 @@ export function anonymousValidator1856722848(
   limit?: undefined | number;
   offset?: undefined | number;
   session?: undefined | StoreSessionStoreQueryBuilder;
-  viaSession?: undefined | StoreSessionStoreQueryTraverser;
   refreshToken?: undefined | StoreSessionStoreTokenQueryBuilder;
-  viaRefreshToken?: undefined | StoreSessionStoreTokenQueryTraverser;
   accessToken?: undefined | StoreSessionStoreTokenQueryBuilder;
-  viaAccessToken?: undefined | StoreSessionStoreTokenQueryTraverser;
 }>;
 /**
  * @param {*} value
@@ -1662,7 +1533,7 @@ export function anonymousValidator145903947(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, "viaAccessTokens"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator2093168415(
   value: any,
@@ -1675,7 +1546,6 @@ export function anonymousValidator2093168415(
   limit?: undefined | number;
   offset?: undefined | number;
   accessTokens?: undefined | StoreSessionStoreTokenQueryBuilder;
-  viaAccessTokens?: undefined | StoreSessionStoreTokenQueryTraverser;
 }>;
 export type InternalError = {
   propertyPath: string;

--- a/packages/store/src/generated/common/anonymous-validators.js
+++ b/packages/store/src/generated/common/anonymous-validators.js
@@ -366,7 +366,6 @@ const objectKeys310044624 = new Set([
   "limit",
   "offset",
   "group",
-  "viaGroup",
 ]);
 const objectKeys1862233461 = new Set([
   "where",
@@ -376,20 +375,8 @@ const objectKeys1862233461 = new Set([
   "limit",
   "offset",
   "file",
-  "viaFile",
   "parent",
-  "viaParent",
   "children",
-  "viaChildren",
-]);
-const objectKeys1069465749 = new Set(["where", "limit", "offset", "viaGroup"]);
-const objectKeys1274599578 = new Set([
-  "where",
-  "limit",
-  "offset",
-  "viaFile",
-  "viaParent",
-  "viaChildren",
 ]);
 const objectKeys343387919 = new Set([
   "where",
@@ -399,7 +386,6 @@ const objectKeys343387919 = new Set([
   "limit",
   "offset",
 ]);
-const objectKeys1952914356 = new Set(["where", "limit", "offset"]);
 const objectKeys647856360 = new Set([
   "where",
   "orderBy",
@@ -408,7 +394,6 @@ const objectKeys647856360 = new Set([
   "limit",
   "offset",
 ]);
-const objectKeys1805657267 = new Set(["where", "limit", "offset"]);
 const objectKeys2093168415 = new Set([
   "where",
   "orderBy",
@@ -417,7 +402,6 @@ const objectKeys2093168415 = new Set([
   "limit",
   "offset",
   "accessTokens",
-  "viaAccessTokens",
 ]);
 const objectKeys1856722848 = new Set([
   "where",
@@ -427,25 +411,8 @@ const objectKeys1856722848 = new Set([
   "limit",
   "offset",
   "session",
-  "viaSession",
   "refreshToken",
-  "viaRefreshToken",
   "accessToken",
-  "viaAccessToken",
-]);
-const objectKeys135209020 = new Set([
-  "where",
-  "limit",
-  "offset",
-  "viaAccessTokens",
-]);
-const objectKeys770376901 = new Set([
-  "where",
-  "limit",
-  "offset",
-  "viaSession",
-  "viaRefreshToken",
-  "viaAccessToken",
 ]);
 /**
  * @param {*} value
@@ -5211,167 +5178,7 @@ export function anonymousValidator2119152283(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileGroupWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaFile"?: undefined|StoreFileQueryTraverser, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }>}
- */
-export function anonymousValidator1274599578(value, propertyPath) {
-  if (isNil(value)) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.undefined",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (typeof value !== "object") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  const result = Object.create(null);
-  const errors = [];
-  for (const key of Object.keys(value)) {
-    if (!objectKeys1274599578.has(key)) {
-      /** @type {{ errors: InternalError[] }} */
-      return {
-        errors: [
-          {
-            propertyPath,
-            key: "validator.object.strict",
-            info: { extraKey: key },
-          },
-        ],
-      };
-    }
-  }
-  /**
-   * @type {[string, (value: *, propertyPath: string) => EitherN<*>][]}
-   */
-  const validatorPairs = [
-    ["where", anonymousValidator481156646],
-    ["limit", anonymousValidator963028965],
-    ["offset", anonymousValidator963028965],
-    ["viaFile", anonymousValidator1978760330],
-    ["viaParent", anonymousValidator514437691],
-    ["viaChildren", anonymousValidator514437691],
-  ];
-  for (const [key, validator] of validatorPairs) {
-    const validatorResult = validator(value[key], `${propertyPath}.${key}`);
-    if (validatorResult.errors) {
-      errors.push(...validatorResult.errors);
-    } else {
-      result[key] = validatorResult.value;
-    }
-  }
-  if (errors.length > 0) {
-    return { errors };
-  }
-  return { value: result };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreFileGroupQueryTraverser>}
- */
-export function anonymousValidator514437691(value, propertyPath) {
-  if (isNil(value)) {
-    return { value: undefined };
-  }
-  return anonymousValidator1274599578(value, propertyPath);
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, }>}
- */
-export function anonymousValidator1069465749(value, propertyPath) {
-  if (isNil(value)) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.undefined",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (typeof value !== "object") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  const result = Object.create(null);
-  const errors = [];
-  for (const key of Object.keys(value)) {
-    if (!objectKeys1069465749.has(key)) {
-      /** @type {{ errors: InternalError[] }} */
-      return {
-        errors: [
-          {
-            propertyPath,
-            key: "validator.object.strict",
-            info: { extraKey: key },
-          },
-        ],
-      };
-    }
-  }
-  /**
-   * @type {[string, (value: *, propertyPath: string) => EitherN<*>][]}
-   */
-  const validatorPairs = [
-    ["where", anonymousValidator65842827],
-    ["limit", anonymousValidator963028965],
-    ["offset", anonymousValidator963028965],
-    ["viaGroup", anonymousValidator514437691],
-  ];
-  for (const [key, validator] of validatorPairs) {
-    const validatorResult = validator(value[key], `${propertyPath}.${key}`);
-    if (validatorResult.errors) {
-      errors.push(...validatorResult.errors);
-    } else {
-      result[key] = validatorResult.value;
-    }
-  }
-  if (errors.length > 0) {
-    return { errors };
-  }
-  return { value: result };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreFileQueryTraverser>}
- */
-export function anonymousValidator1978760330(value, propertyPath) {
-  if (isNil(value)) {
-    return { value: undefined };
-  }
-  return anonymousValidator1069465749(value, propertyPath);
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileGroupWhere, "orderBy"?: undefined|StoreFileGroupOrderBy, "orderBySpec"?: undefined|StoreFileGroupOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "viaFile"?: undefined|StoreFileQueryTraverser, "parent"?: undefined|StoreFileGroupQueryBuilder, "viaParent"?: undefined|StoreFileGroupQueryTraverser, "children"?: undefined|StoreFileGroupQueryBuilder, "viaChildren"?: undefined|StoreFileGroupQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreFileGroupWhere, "orderBy"?: undefined|StoreFileGroupOrderBy, "orderBySpec"?: undefined|StoreFileGroupOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "file"?: undefined|StoreFileQueryBuilder, "parent"?: undefined|StoreFileGroupQueryBuilder, "children"?: undefined|StoreFileGroupQueryBuilder, }>}
  */
 export function anonymousValidator1862233461(value, propertyPath) {
   if (isNil(value)) {
@@ -5425,11 +5232,8 @@ export function anonymousValidator1862233461(value, propertyPath) {
     ["limit", anonymousValidator963028965],
     ["offset", anonymousValidator963028965],
     ["file", anonymousValidator2119152283],
-    ["viaFile", anonymousValidator1978760330],
     ["parent", anonymousValidator1996607136],
-    ["viaParent", anonymousValidator514437691],
     ["children", anonymousValidator1996607136],
-    ["viaChildren", anonymousValidator514437691],
   ];
   for (const [key, validator] of validatorPairs) {
     const validatorResult = validator(value[key], `${propertyPath}.${key}`);
@@ -5458,7 +5262,7 @@ export function anonymousValidator1996607136(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "group"?: undefined|StoreFileGroupQueryBuilder, "viaGroup"?: undefined|StoreFileGroupQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "group"?: undefined|StoreFileGroupQueryBuilder, }>}
  */
 export function anonymousValidator310044624(value, propertyPath) {
   if (isNil(value)) {
@@ -5512,7 +5316,6 @@ export function anonymousValidator310044624(value, propertyPath) {
     ["limit", anonymousValidator963028965],
     ["offset", anonymousValidator963028965],
     ["group", anonymousValidator1996607136],
-    ["viaGroup", anonymousValidator514437691],
   ];
   for (const [key, validator] of validatorPairs) {
     const validatorResult = validator(value[key], `${propertyPath}.${key}`);
@@ -5614,73 +5417,6 @@ export function anonymousValidator343387919(value, propertyPath) {
     ["orderBy", anonymousValidator1683806814],
     ["orderBySpec", anonymousValidator608966855],
     ["as", anonymousValidator1443576836],
-    ["limit", anonymousValidator963028965],
-    ["offset", anonymousValidator963028965],
-  ];
-  for (const [key, validator] of validatorPairs) {
-    const validatorResult = validator(value[key], `${propertyPath}.${key}`);
-    if (validatorResult.errors) {
-      errors.push(...validatorResult.errors);
-    } else {
-      result[key] = validatorResult.value;
-    }
-  }
-  if (errors.length > 0) {
-    return { errors };
-  }
-  return { value: result };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "limit"?: undefined|number, "offset"?: undefined|number, }>}
- */
-export function anonymousValidator1952914356(value, propertyPath) {
-  if (isNil(value)) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.undefined",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (typeof value !== "object") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  const result = Object.create(null);
-  const errors = [];
-  for (const key of Object.keys(value)) {
-    if (!objectKeys1952914356.has(key)) {
-      /** @type {{ errors: InternalError[] }} */
-      return {
-        errors: [
-          {
-            propertyPath,
-            key: "validator.object.strict",
-            info: { extraKey: key },
-          },
-        ],
-      };
-    }
-  }
-  /**
-   * @type {[string, (value: *, propertyPath: string) => EitherN<*>][]}
-   */
-  const validatorPairs = [
-    ["where", anonymousValidator634541376],
     ["limit", anonymousValidator963028965],
     ["offset", anonymousValidator963028965],
   ];
@@ -5803,73 +5539,6 @@ export function anonymousValidator647856360(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionWhere, "limit"?: undefined|number, "offset"?: undefined|number, }>}
- */
-export function anonymousValidator1805657267(value, propertyPath) {
-  if (isNil(value)) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.undefined",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (typeof value !== "object") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  const result = Object.create(null);
-  const errors = [];
-  for (const key of Object.keys(value)) {
-    if (!objectKeys1805657267.has(key)) {
-      /** @type {{ errors: InternalError[] }} */
-      return {
-        errors: [
-          {
-            propertyPath,
-            key: "validator.object.strict",
-            info: { extraKey: key },
-          },
-        ],
-      };
-    }
-  }
-  /**
-   * @type {[string, (value: *, propertyPath: string) => EitherN<*>][]}
-   */
-  const validatorPairs = [
-    ["where", anonymousValidator196488441],
-    ["limit", anonymousValidator963028965],
-    ["offset", anonymousValidator963028965],
-  ];
-  for (const [key, validator] of validatorPairs) {
-    const validatorResult = validator(value[key], `${propertyPath}.${key}`);
-    if (validatorResult.errors) {
-      errors.push(...validatorResult.errors);
-    } else {
-      result[key] = validatorResult.value;
-    }
-  }
-  if (errors.length > 0) {
-    return { errors };
-  }
-  return { value: result };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
  * @returns {EitherN<undefined|StoreSessionStoreOrderBy>}
  */
 export function anonymousValidator1221642756(value, propertyPath) {
@@ -5925,167 +5594,7 @@ export function anonymousValidator1827379372(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaSession"?: undefined|StoreSessionStoreQueryTraverser, "viaRefreshToken"?: undefined|StoreSessionStoreTokenQueryTraverser, "viaAccessToken"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
- */
-export function anonymousValidator770376901(value, propertyPath) {
-  if (isNil(value)) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.undefined",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (typeof value !== "object") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  const result = Object.create(null);
-  const errors = [];
-  for (const key of Object.keys(value)) {
-    if (!objectKeys770376901.has(key)) {
-      /** @type {{ errors: InternalError[] }} */
-      return {
-        errors: [
-          {
-            propertyPath,
-            key: "validator.object.strict",
-            info: { extraKey: key },
-          },
-        ],
-      };
-    }
-  }
-  /**
-   * @type {[string, (value: *, propertyPath: string) => EitherN<*>][]}
-   */
-  const validatorPairs = [
-    ["where", anonymousValidator2065515599],
-    ["limit", anonymousValidator963028965],
-    ["offset", anonymousValidator963028965],
-    ["viaSession", anonymousValidator1095313735],
-    ["viaRefreshToken", anonymousValidator1149378288],
-    ["viaAccessToken", anonymousValidator1149378288],
-  ];
-  for (const [key, validator] of validatorPairs) {
-    const validatorResult = validator(value[key], `${propertyPath}.${key}`);
-    if (validatorResult.errors) {
-      errors.push(...validatorResult.errors);
-    } else {
-      result[key] = validatorResult.value;
-    }
-  }
-  if (errors.length > 0) {
-    return { errors };
-  }
-  return { value: result };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreSessionStoreTokenQueryTraverser>}
- */
-export function anonymousValidator1149378288(value, propertyPath) {
-  if (isNil(value)) {
-    return { value: undefined };
-  }
-  return anonymousValidator770376901(value, propertyPath);
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "limit"?: undefined|number, "offset"?: undefined|number, "viaAccessTokens"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
- */
-export function anonymousValidator135209020(value, propertyPath) {
-  if (isNil(value)) {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.undefined",
-          info: {},
-        },
-      ],
-    };
-  }
-  if (typeof value !== "object") {
-    /** @type {{ errors: InternalError[] }} */
-    return {
-      errors: [
-        {
-          propertyPath,
-          key: "validator.object.type",
-          info: {},
-        },
-      ],
-    };
-  }
-  const result = Object.create(null);
-  const errors = [];
-  for (const key of Object.keys(value)) {
-    if (!objectKeys135209020.has(key)) {
-      /** @type {{ errors: InternalError[] }} */
-      return {
-        errors: [
-          {
-            propertyPath,
-            key: "validator.object.strict",
-            info: { extraKey: key },
-          },
-        ],
-      };
-    }
-  }
-  /**
-   * @type {[string, (value: *, propertyPath: string) => EitherN<*>][]}
-   */
-  const validatorPairs = [
-    ["where", anonymousValidator1582696858],
-    ["limit", anonymousValidator963028965],
-    ["offset", anonymousValidator963028965],
-    ["viaAccessTokens", anonymousValidator1149378288],
-  ];
-  for (const [key, validator] of validatorPairs) {
-    const validatorResult = validator(value[key], `${propertyPath}.${key}`);
-    if (validatorResult.errors) {
-      errors.push(...validatorResult.errors);
-    } else {
-      result[key] = validatorResult.value;
-    }
-  }
-  if (errors.length > 0) {
-    return { errors };
-  }
-  return { value: result };
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<undefined|StoreSessionStoreQueryTraverser>}
- */
-export function anonymousValidator1095313735(value, propertyPath) {
-  if (isNil(value)) {
-    return { value: undefined };
-  }
-  return anonymousValidator135209020(value, propertyPath);
-}
-/**
- * @param {*} value
- * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "session"?: undefined|StoreSessionStoreQueryBuilder, "viaSession"?: undefined|StoreSessionStoreQueryTraverser, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "viaRefreshToken"?: undefined|StoreSessionStoreTokenQueryTraverser, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "viaAccessToken"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator1856722848(value, propertyPath) {
   if (isNil(value)) {
@@ -6139,11 +5648,8 @@ export function anonymousValidator1856722848(value, propertyPath) {
     ["limit", anonymousValidator963028965],
     ["offset", anonymousValidator963028965],
     ["session", anonymousValidator1827379372],
-    ["viaSession", anonymousValidator1095313735],
     ["refreshToken", anonymousValidator145903947],
-    ["viaRefreshToken", anonymousValidator1149378288],
     ["accessToken", anonymousValidator145903947],
-    ["viaAccessToken", anonymousValidator1149378288],
   ];
   for (const [key, validator] of validatorPairs) {
     const validatorResult = validator(value[key], `${propertyPath}.${key}`);
@@ -6172,7 +5678,7 @@ export function anonymousValidator145903947(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, "viaAccessTokens"?: undefined|StoreSessionStoreTokenQueryTraverser, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator2093168415(value, propertyPath) {
   if (isNil(value)) {
@@ -6226,7 +5732,6 @@ export function anonymousValidator2093168415(value, propertyPath) {
     ["limit", anonymousValidator963028965],
     ["offset", anonymousValidator963028965],
     ["accessTokens", anonymousValidator145903947],
-    ["viaAccessTokens", anonymousValidator1149378288],
   ];
   for (const [key, validator] of validatorPairs) {
     const validatorResult = validator(value[key], `${propertyPath}.${key}`);

--- a/packages/store/src/generated/database/file.d.ts
+++ b/packages/store/src/generated/database/file.d.ts
@@ -72,12 +72,12 @@ export function fileInsertValues(
  */
 export function fileUpdateSet(update: StoreFileUpdatePartial): QueryPart;
 /**
- * @param {StoreFileQueryBuilder & StoreFileQueryTraverser} builder
+ * @param {StoreFileQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQueryFile(
-  builder: StoreFileQueryBuilder & StoreFileQueryTraverser,
+  builder: StoreFileQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -458,48 +458,12 @@ export const fileQueries = {
   fileDeletePermanent,
 };
 /**
- * @param {StoreFileQueryBuilder & StoreFileQueryTraverser} builder
+ * @param {StoreFileQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQueryFile(builder, wherePartial) {
   const joinQb = query``;
-  if (builder.viaGroup) {
-    builder.where = builder.where ?? {};
-    // Prepare idIn
-    if (isQueryPart(builder.where.idIn)) {
-      builder.where.idIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.idIn) &&
-      builder.where.idIn.length > 0
-    ) {
-      builder.where.idIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.idIn,
-      );
-    } else {
-      builder.where.idIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaGroup.offset)
-      ? query`OFFSET ${builder.viaGroup.offset}`
-      : query``;
-    if (!isNil(builder.viaGroup.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaGroup.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.idIn.append(query`
-SELECT DISTINCT fg."file"
-${internalQueryFileGroup(builder.viaGroup ?? {})}
-${offsetLimitQb}
-`);
-  }
   if (builder.group) {
     const joinedKeys = [];
     const offsetLimitQb = !isNil(builder.group.offset)

--- a/packages/store/src/generated/database/fileGroup.d.ts
+++ b/packages/store/src/generated/database/fileGroup.d.ts
@@ -74,21 +74,21 @@ export function fileGroupUpdateSet(
   update: StoreFileGroupUpdatePartial,
 ): QueryPart;
 /**
- * @param {StoreFileGroupQueryBuilder & StoreFileGroupQueryTraverser} builder
+ * @param {StoreFileGroupQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQueryFileGroup2(
-  builder: StoreFileGroupQueryBuilder & StoreFileGroupQueryTraverser,
+  builder: StoreFileGroupQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**
- * @param {StoreFileGroupQueryBuilder & StoreFileGroupQueryTraverser} builder
+ * @param {StoreFileGroupQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQueryFileGroup(
-  builder: StoreFileGroupQueryBuilder & StoreFileGroupQueryTraverser,
+  builder: StoreFileGroupQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -507,120 +507,12 @@ export const fileGroupQueries = {
   fileGroupDeletePermanent,
 };
 /**
- * @param {StoreFileGroupQueryBuilder & StoreFileGroupQueryTraverser} builder
+ * @param {StoreFileGroupQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQueryFileGroup2(builder, wherePartial) {
   const joinQb = query``;
-  if (builder.viaFile) {
-    builder.where = builder.where ?? {};
-    // Prepare fileIn
-    if (isQueryPart(builder.where.fileIn)) {
-      builder.where.fileIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.fileIn) &&
-      builder.where.fileIn.length > 0
-    ) {
-      builder.where.fileIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.fileIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.fileIn,
-      );
-    } else {
-      builder.where.fileIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaFile.offset)
-      ? query`OFFSET ${builder.viaFile.offset}`
-      : query``;
-    if (!isNil(builder.viaFile.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaFile.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.fileIn.append(query`
-SELECT DISTINCT f."id"
-${internalQueryFile(builder.viaFile ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaParent) {
-    builder.where = builder.where ?? {};
-    // Prepare parentIn
-    if (isQueryPart(builder.where.parentIn)) {
-      builder.where.parentIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.parentIn) &&
-      builder.where.parentIn.length > 0
-    ) {
-      builder.where.parentIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.parentIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.parentIn,
-      );
-    } else {
-      builder.where.parentIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaParent.offset)
-      ? query`OFFSET ${builder.viaParent.offset}`
-      : query``;
-    if (!isNil(builder.viaParent.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaParent.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.parentIn.append(query`
-SELECT DISTINCT fg."id"
-${internalQueryFileGroup(builder.viaParent ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaChildren) {
-    builder.where = builder.where ?? {};
-    // Prepare idIn
-    if (isQueryPart(builder.where.idIn)) {
-      builder.where.idIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.idIn) &&
-      builder.where.idIn.length > 0
-    ) {
-      builder.where.idIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.idIn,
-      );
-    } else {
-      builder.where.idIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaChildren.offset)
-      ? query`OFFSET ${builder.viaChildren.offset}`
-      : query``;
-    if (!isNil(builder.viaChildren.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaChildren.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.idIn.append(query`
-SELECT DISTINCT fg."parent"
-${internalQueryFileGroup(builder.viaChildren ?? {})}
-${offsetLimitQb}
-`);
-  }
   if (builder.file) {
     const joinedKeys = [];
     const offsetLimitQb = !isNil(builder.file.offset)
@@ -739,120 +631,12 @@ WHERE ${fileGroupWhere(builder.where, "fg2.", {
 `;
 }
 /**
- * @param {StoreFileGroupQueryBuilder & StoreFileGroupQueryTraverser} builder
+ * @param {StoreFileGroupQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQueryFileGroup(builder, wherePartial) {
   const joinQb = query``;
-  if (builder.viaFile) {
-    builder.where = builder.where ?? {};
-    // Prepare fileIn
-    if (isQueryPart(builder.where.fileIn)) {
-      builder.where.fileIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.fileIn) &&
-      builder.where.fileIn.length > 0
-    ) {
-      builder.where.fileIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.fileIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.fileIn,
-      );
-    } else {
-      builder.where.fileIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaFile.offset)
-      ? query`OFFSET ${builder.viaFile.offset}`
-      : query``;
-    if (!isNil(builder.viaFile.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaFile.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.fileIn.append(query`
-SELECT DISTINCT f."id"
-${internalQueryFile(builder.viaFile ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaParent) {
-    builder.where = builder.where ?? {};
-    // Prepare parentIn
-    if (isQueryPart(builder.where.parentIn)) {
-      builder.where.parentIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.parentIn) &&
-      builder.where.parentIn.length > 0
-    ) {
-      builder.where.parentIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.parentIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.parentIn,
-      );
-    } else {
-      builder.where.parentIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaParent.offset)
-      ? query`OFFSET ${builder.viaParent.offset}`
-      : query``;
-    if (!isNil(builder.viaParent.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaParent.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.parentIn.append(query`
-SELECT DISTINCT fg2."id"
-${internalQueryFileGroup2(builder.viaParent ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaChildren) {
-    builder.where = builder.where ?? {};
-    // Prepare idIn
-    if (isQueryPart(builder.where.idIn)) {
-      builder.where.idIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.idIn) &&
-      builder.where.idIn.length > 0
-    ) {
-      builder.where.idIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.idIn,
-      );
-    } else {
-      builder.where.idIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaChildren.offset)
-      ? query`OFFSET ${builder.viaChildren.offset}`
-      : query``;
-    if (!isNil(builder.viaChildren.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaChildren.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.idIn.append(query`
-SELECT DISTINCT fg2."parent"
-${internalQueryFileGroup2(builder.viaChildren ?? {})}
-${offsetLimitQb}
-`);
-  }
   if (builder.file) {
     const joinedKeys = [];
     const offsetLimitQb = !isNil(builder.file.offset)

--- a/packages/store/src/generated/database/job.d.ts
+++ b/packages/store/src/generated/database/job.d.ts
@@ -72,12 +72,12 @@ export function jobInsertValues(
  */
 export function jobUpdateSet(update: StoreJobUpdatePartial): QueryPart;
 /**
- * @param {StoreJobQueryBuilder & StoreJobQueryTraverser} builder
+ * @param {StoreJobQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQueryJob(
-  builder: StoreJobQueryBuilder & StoreJobQueryTraverser,
+  builder: StoreJobQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**

--- a/packages/store/src/generated/database/job.js
+++ b/packages/store/src/generated/database/job.js
@@ -415,7 +415,7 @@ export const jobQueries = {
   jobUpdate,
 };
 /**
- * @param {StoreJobQueryBuilder & StoreJobQueryTraverser} builder
+ * @param {StoreJobQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */

--- a/packages/store/src/generated/database/session.d.ts
+++ b/packages/store/src/generated/database/session.d.ts
@@ -72,12 +72,12 @@ export function sessionInsertValues(
  */
 export function sessionUpdateSet(update: StoreSessionUpdatePartial): QueryPart;
 /**
- * @param {StoreSessionQueryBuilder & StoreSessionQueryTraverser} builder
+ * @param {StoreSessionQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQuerySession(
-  builder: StoreSessionQueryBuilder & StoreSessionQueryTraverser,
+  builder: StoreSessionQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**

--- a/packages/store/src/generated/database/session.js
+++ b/packages/store/src/generated/database/session.js
@@ -356,7 +356,7 @@ export const sessionQueries = {
   sessionUpdate,
 };
 /**
- * @param {StoreSessionQueryBuilder & StoreSessionQueryTraverser} builder
+ * @param {StoreSessionQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */

--- a/packages/store/src/generated/database/sessionStore.d.ts
+++ b/packages/store/src/generated/database/sessionStore.d.ts
@@ -74,12 +74,12 @@ export function sessionStoreUpdateSet(
   update: StoreSessionStoreUpdatePartial,
 ): QueryPart;
 /**
- * @param {StoreSessionStoreQueryBuilder & StoreSessionStoreQueryTraverser} builder
+ * @param {StoreSessionStoreQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQuerySessionStore(
-  builder: StoreSessionStoreQueryBuilder & StoreSessionStoreQueryTraverser,
+  builder: StoreSessionStoreQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**

--- a/packages/store/src/generated/database/sessionStore.js
+++ b/packages/store/src/generated/database/sessionStore.js
@@ -393,48 +393,12 @@ export const sessionStoreQueries = {
   sessionStoreUpdate,
 };
 /**
- * @param {StoreSessionStoreQueryBuilder & StoreSessionStoreQueryTraverser} builder
+ * @param {StoreSessionStoreQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQuerySessionStore(builder, wherePartial) {
   const joinQb = query``;
-  if (builder.viaAccessTokens) {
-    builder.where = builder.where ?? {};
-    // Prepare idIn
-    if (isQueryPart(builder.where.idIn)) {
-      builder.where.idIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.idIn) &&
-      builder.where.idIn.length > 0
-    ) {
-      builder.where.idIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.idIn,
-      );
-    } else {
-      builder.where.idIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaAccessTokens.offset)
-      ? query`OFFSET ${builder.viaAccessTokens.offset}`
-      : query``;
-    if (!isNil(builder.viaAccessTokens.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaAccessTokens.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.idIn.append(query`
-SELECT DISTINCT sst."session"
-${internalQuerySessionStoreToken(builder.viaAccessTokens ?? {})}
-${offsetLimitQb}
-`);
-  }
   if (builder.accessTokens) {
     const joinedKeys = [];
     const offsetLimitQb = !isNil(builder.accessTokens.offset)

--- a/packages/store/src/generated/database/sessionStoreToken.d.ts
+++ b/packages/store/src/generated/database/sessionStoreToken.d.ts
@@ -76,23 +76,21 @@ export function sessionStoreTokenUpdateSet(
   update: StoreSessionStoreTokenUpdatePartial,
 ): QueryPart;
 /**
- * @param {StoreSessionStoreTokenQueryBuilder & StoreSessionStoreTokenQueryTraverser} builder
+ * @param {StoreSessionStoreTokenQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQuerySessionStoreToken2(
-  builder: StoreSessionStoreTokenQueryBuilder &
-    StoreSessionStoreTokenQueryTraverser,
+  builder: StoreSessionStoreTokenQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**
- * @param {StoreSessionStoreTokenQueryBuilder & StoreSessionStoreTokenQueryTraverser} builder
+ * @param {StoreSessionStoreTokenQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQuerySessionStoreToken(
-  builder: StoreSessionStoreTokenQueryBuilder &
-    StoreSessionStoreTokenQueryTraverser,
+  builder: StoreSessionStoreTokenQueryBuilder,
   wherePartial?: QueryPart | undefined,
 ): QueryPart;
 /**

--- a/packages/store/src/generated/database/sessionStoreToken.js
+++ b/packages/store/src/generated/database/sessionStoreToken.js
@@ -455,120 +455,12 @@ export const sessionStoreTokenQueries = {
   sessionStoreTokenUpdate,
 };
 /**
- * @param {StoreSessionStoreTokenQueryBuilder & StoreSessionStoreTokenQueryTraverser} builder
+ * @param {StoreSessionStoreTokenQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQuerySessionStoreToken2(builder, wherePartial) {
   const joinQb = query``;
-  if (builder.viaSession) {
-    builder.where = builder.where ?? {};
-    // Prepare sessionIn
-    if (isQueryPart(builder.where.sessionIn)) {
-      builder.where.sessionIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.sessionIn) &&
-      builder.where.sessionIn.length > 0
-    ) {
-      builder.where.sessionIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.sessionIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.sessionIn,
-      );
-    } else {
-      builder.where.sessionIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaSession.offset)
-      ? query`OFFSET ${builder.viaSession.offset}`
-      : query``;
-    if (!isNil(builder.viaSession.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaSession.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.sessionIn.append(query`
-SELECT DISTINCT ss."id"
-${internalQuerySessionStore(builder.viaSession ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaRefreshToken) {
-    builder.where = builder.where ?? {};
-    // Prepare refreshTokenIn
-    if (isQueryPart(builder.where.refreshTokenIn)) {
-      builder.where.refreshTokenIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.refreshTokenIn) &&
-      builder.where.refreshTokenIn.length > 0
-    ) {
-      builder.where.refreshTokenIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({
-            length: builder.where.refreshTokenIn.length - 1,
-          }).map(() => "), ("),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.refreshTokenIn,
-      );
-    } else {
-      builder.where.refreshTokenIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaRefreshToken.offset)
-      ? query`OFFSET ${builder.viaRefreshToken.offset}`
-      : query``;
-    if (!isNil(builder.viaRefreshToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaRefreshToken.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.refreshTokenIn.append(query`
-SELECT DISTINCT sst."id"
-${internalQuerySessionStoreToken(builder.viaRefreshToken ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaAccessToken) {
-    builder.where = builder.where ?? {};
-    // Prepare idIn
-    if (isQueryPart(builder.where.idIn)) {
-      builder.where.idIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.idIn) &&
-      builder.where.idIn.length > 0
-    ) {
-      builder.where.idIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.idIn,
-      );
-    } else {
-      builder.where.idIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaAccessToken.offset)
-      ? query`OFFSET ${builder.viaAccessToken.offset}`
-      : query``;
-    if (!isNil(builder.viaAccessToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaAccessToken.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.idIn.append(query`
-SELECT DISTINCT sst."refreshToken"
-${internalQuerySessionStoreToken(builder.viaAccessToken ?? {})}
-${offsetLimitQb}
-`);
-  }
   if (builder.session) {
     const joinedKeys = [];
     const offsetLimitQb = !isNil(builder.session.offset)
@@ -698,120 +590,12 @@ WHERE ${sessionStoreTokenWhere(builder.where, "sst2.", {
 `;
 }
 /**
- * @param {StoreSessionStoreTokenQueryBuilder & StoreSessionStoreTokenQueryTraverser} builder
+ * @param {StoreSessionStoreTokenQueryBuilder} builder
  * @param {QueryPart|undefined} [wherePartial]
  * @returns {QueryPart}
  */
 export function internalQuerySessionStoreToken(builder, wherePartial) {
   const joinQb = query``;
-  if (builder.viaSession) {
-    builder.where = builder.where ?? {};
-    // Prepare sessionIn
-    if (isQueryPart(builder.where.sessionIn)) {
-      builder.where.sessionIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.sessionIn) &&
-      builder.where.sessionIn.length > 0
-    ) {
-      builder.where.sessionIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.sessionIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.sessionIn,
-      );
-    } else {
-      builder.where.sessionIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaSession.offset)
-      ? query`OFFSET ${builder.viaSession.offset}`
-      : query``;
-    if (!isNil(builder.viaSession.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaSession.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.sessionIn.append(query`
-SELECT DISTINCT ss."id"
-${internalQuerySessionStore(builder.viaSession ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaRefreshToken) {
-    builder.where = builder.where ?? {};
-    // Prepare refreshTokenIn
-    if (isQueryPart(builder.where.refreshTokenIn)) {
-      builder.where.refreshTokenIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.refreshTokenIn) &&
-      builder.where.refreshTokenIn.length > 0
-    ) {
-      builder.where.refreshTokenIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({
-            length: builder.where.refreshTokenIn.length - 1,
-          }).map(() => "), ("),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.refreshTokenIn,
-      );
-    } else {
-      builder.where.refreshTokenIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaRefreshToken.offset)
-      ? query`OFFSET ${builder.viaRefreshToken.offset}`
-      : query``;
-    if (!isNil(builder.viaRefreshToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaRefreshToken.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.refreshTokenIn.append(query`
-SELECT DISTINCT sst2."id"
-${internalQuerySessionStoreToken2(builder.viaRefreshToken ?? {})}
-${offsetLimitQb}
-`);
-  }
-  if (builder.viaAccessToken) {
-    builder.where = builder.where ?? {};
-    // Prepare idIn
-    if (isQueryPart(builder.where.idIn)) {
-      builder.where.idIn.append(query` INTERSECT `);
-    } else if (
-      Array.isArray(builder.where.idIn) &&
-      builder.where.idIn.length > 0
-    ) {
-      builder.where.idIn = query(
-        [
-          "(SELECT value::uuid FROM(values (",
-          ...Array.from({ length: builder.where.idIn.length - 1 }).map(
-            () => "), (",
-          ),
-          ")) as ids(value)) INTERSECT ",
-        ],
-        ...builder.where.idIn,
-      );
-    } else {
-      builder.where.idIn = query``;
-    }
-    const offsetLimitQb = !isNil(builder.viaAccessToken.offset)
-      ? query`OFFSET ${builder.viaAccessToken.offset}`
-      : query``;
-    if (!isNil(builder.viaAccessToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.viaAccessToken.limit} ROWS ONLY`,
-      );
-    }
-    builder.where.idIn.append(query`
-SELECT DISTINCT sst2."refreshToken"
-${internalQuerySessionStoreToken2(builder.viaAccessToken ?? {})}
-${offsetLimitQb}
-`);
-  }
   if (builder.session) {
     const joinedKeys = [];
     const offsetLimitQb = !isNil(builder.session.offset)

--- a/packages/store/src/generated/store/validators.d.ts
+++ b/packages/store/src/generated/store/validators.d.ts
@@ -270,30 +270,12 @@ export function validateStoreFileQueryBuilder(
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreFileQueryTraverser>}
- */
-export function validateStoreFileQueryTraverser(
-  value: undefined | any,
-  propertyPath?: string | undefined,
-): Either<StoreFileQueryTraverser>;
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreFileGroupQueryBuilder>}
  */
 export function validateStoreFileGroupQueryBuilder(
   value: undefined | any,
   propertyPath?: string | undefined,
 ): Either<StoreFileGroupQueryBuilder>;
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreFileGroupQueryTraverser>}
- */
-export function validateStoreFileGroupQueryTraverser(
-  value: undefined | any,
-  propertyPath?: string | undefined,
-): Either<StoreFileGroupQueryTraverser>;
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
@@ -306,30 +288,12 @@ export function validateStoreJobQueryBuilder(
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreJobQueryTraverser>}
- */
-export function validateStoreJobQueryTraverser(
-  value: undefined | any,
-  propertyPath?: string | undefined,
-): Either<StoreJobQueryTraverser>;
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreSessionQueryBuilder>}
  */
 export function validateStoreSessionQueryBuilder(
   value: undefined | any,
   propertyPath?: string | undefined,
 ): Either<StoreSessionQueryBuilder>;
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreSessionQueryTraverser>}
- */
-export function validateStoreSessionQueryTraverser(
-  value: undefined | any,
-  propertyPath?: string | undefined,
-): Either<StoreSessionQueryTraverser>;
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
@@ -342,30 +306,12 @@ export function validateStoreSessionStoreQueryBuilder(
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreSessionStoreQueryTraverser>}
- */
-export function validateStoreSessionStoreQueryTraverser(
-  value: undefined | any,
-  propertyPath?: string | undefined,
-): Either<StoreSessionStoreQueryTraverser>;
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreSessionStoreTokenQueryBuilder>}
  */
 export function validateStoreSessionStoreTokenQueryBuilder(
   value: undefined | any,
   propertyPath?: string | undefined,
 ): Either<StoreSessionStoreTokenQueryBuilder>;
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreSessionStoreTokenQueryTraverser>}
- */
-export function validateStoreSessionStoreTokenQueryTraverser(
-  value: undefined | any,
-  propertyPath?: string | undefined,
-): Either<StoreSessionStoreTokenQueryTraverser>;
 export type Either<T> = import("@compas/stdlib").Either<T, AppError>;
 import { AppError } from "@compas/stdlib";
 //# sourceMappingURL=validators.d.ts.map

--- a/packages/store/src/generated/store/validators.js
+++ b/packages/store/src/generated/store/validators.js
@@ -3,25 +3,20 @@
 
 import { AppError, isNil } from "@compas/stdlib";
 import {
-  anonymousValidator1069465749,
   anonymousValidator1108679019,
   anonymousValidator1196685479,
   anonymousValidator1257773835,
-  anonymousValidator1274599578,
   anonymousValidator1334934277,
   anonymousValidator1337490931,
-  anonymousValidator135209020,
   anonymousValidator1430489818,
   anonymousValidator144635851,
   anonymousValidator153017499,
   anonymousValidator163358845,
   anonymousValidator1781782332,
   anonymousValidator1795948632,
-  anonymousValidator1805657267,
   anonymousValidator1856722848,
   anonymousValidator1862233461,
   anonymousValidator1864958291,
-  anonymousValidator1952914356,
   anonymousValidator2038758416,
   anonymousValidator2060025506,
   anonymousValidator2074494218,
@@ -42,7 +37,6 @@ import {
   anonymousValidator647856360,
   anonymousValidator685221527,
   anonymousValidator753972035,
-  anonymousValidator770376901,
 } from "../common/anonymous-validators.js";
 /**
  * @template T
@@ -818,32 +812,6 @@ export function validateStoreFileQueryBuilder(value, propertyPath = "$") {
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreFileQueryTraverser>}
- */
-export function validateStoreFileQueryTraverser(value, propertyPath = "$") {
-  const result = anonymousValidator1069465749(value, propertyPath);
-  if (result.errors) {
-    const info = {};
-    for (const err of result.errors) {
-      if (isNil(info[err.propertyPath])) {
-        info[err.propertyPath] = err;
-      } else if (Array.isArray(info[err.propertyPath])) {
-        info[err.propertyPath].push(err);
-      } else {
-        info[err.propertyPath] = [info[err.propertyPath], err];
-      }
-    }
-    /** @type {{ error: AppError }} */
-    return {
-      error: AppError.validationError("validator.error", info),
-    };
-  }
-  /** @type {{ value: StoreFileQueryTraverser}} */
-  return { value: result.value };
-}
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreFileGroupQueryBuilder>}
  */
 export function validateStoreFileGroupQueryBuilder(value, propertyPath = "$") {
@@ -865,35 +833,6 @@ export function validateStoreFileGroupQueryBuilder(value, propertyPath = "$") {
     };
   }
   /** @type {{ value: StoreFileGroupQueryBuilder}} */
-  return { value: result.value };
-}
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreFileGroupQueryTraverser>}
- */
-export function validateStoreFileGroupQueryTraverser(
-  value,
-  propertyPath = "$",
-) {
-  const result = anonymousValidator1274599578(value, propertyPath);
-  if (result.errors) {
-    const info = {};
-    for (const err of result.errors) {
-      if (isNil(info[err.propertyPath])) {
-        info[err.propertyPath] = err;
-      } else if (Array.isArray(info[err.propertyPath])) {
-        info[err.propertyPath].push(err);
-      } else {
-        info[err.propertyPath] = [info[err.propertyPath], err];
-      }
-    }
-    /** @type {{ error: AppError }} */
-    return {
-      error: AppError.validationError("validator.error", info),
-    };
-  }
-  /** @type {{ value: StoreFileGroupQueryTraverser}} */
   return { value: result.value };
 }
 /**
@@ -925,32 +864,6 @@ export function validateStoreJobQueryBuilder(value, propertyPath = "$") {
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreJobQueryTraverser>}
- */
-export function validateStoreJobQueryTraverser(value, propertyPath = "$") {
-  const result = anonymousValidator1952914356(value, propertyPath);
-  if (result.errors) {
-    const info = {};
-    for (const err of result.errors) {
-      if (isNil(info[err.propertyPath])) {
-        info[err.propertyPath] = err;
-      } else if (Array.isArray(info[err.propertyPath])) {
-        info[err.propertyPath].push(err);
-      } else {
-        info[err.propertyPath] = [info[err.propertyPath], err];
-      }
-    }
-    /** @type {{ error: AppError }} */
-    return {
-      error: AppError.validationError("validator.error", info),
-    };
-  }
-  /** @type {{ value: StoreJobQueryTraverser}} */
-  return { value: result.value };
-}
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreSessionQueryBuilder>}
  */
 export function validateStoreSessionQueryBuilder(value, propertyPath = "$") {
@@ -972,32 +885,6 @@ export function validateStoreSessionQueryBuilder(value, propertyPath = "$") {
     };
   }
   /** @type {{ value: StoreSessionQueryBuilder}} */
-  return { value: result.value };
-}
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreSessionQueryTraverser>}
- */
-export function validateStoreSessionQueryTraverser(value, propertyPath = "$") {
-  const result = anonymousValidator1805657267(value, propertyPath);
-  if (result.errors) {
-    const info = {};
-    for (const err of result.errors) {
-      if (isNil(info[err.propertyPath])) {
-        info[err.propertyPath] = err;
-      } else if (Array.isArray(info[err.propertyPath])) {
-        info[err.propertyPath].push(err);
-      } else {
-        info[err.propertyPath] = [info[err.propertyPath], err];
-      }
-    }
-    /** @type {{ error: AppError }} */
-    return {
-      error: AppError.validationError("validator.error", info),
-    };
-  }
-  /** @type {{ value: StoreSessionQueryTraverser}} */
   return { value: result.value };
 }
 /**
@@ -1032,35 +919,6 @@ export function validateStoreSessionStoreQueryBuilder(
 /**
  * @param {undefined|any} value
  * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreSessionStoreQueryTraverser>}
- */
-export function validateStoreSessionStoreQueryTraverser(
-  value,
-  propertyPath = "$",
-) {
-  const result = anonymousValidator135209020(value, propertyPath);
-  if (result.errors) {
-    const info = {};
-    for (const err of result.errors) {
-      if (isNil(info[err.propertyPath])) {
-        info[err.propertyPath] = err;
-      } else if (Array.isArray(info[err.propertyPath])) {
-        info[err.propertyPath].push(err);
-      } else {
-        info[err.propertyPath] = [info[err.propertyPath], err];
-      }
-    }
-    /** @type {{ error: AppError }} */
-    return {
-      error: AppError.validationError("validator.error", info),
-    };
-  }
-  /** @type {{ value: StoreSessionStoreQueryTraverser}} */
-  return { value: result.value };
-}
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreSessionStoreTokenQueryBuilder>}
  */
 export function validateStoreSessionStoreTokenQueryBuilder(
@@ -1085,34 +943,5 @@ export function validateStoreSessionStoreTokenQueryBuilder(
     };
   }
   /** @type {{ value: StoreSessionStoreTokenQueryBuilder}} */
-  return { value: result.value };
-}
-/**
- * @param {undefined|any} value
- * @param {string|undefined} [propertyPath]
- * @returns {Either<StoreSessionStoreTokenQueryTraverser>}
- */
-export function validateStoreSessionStoreTokenQueryTraverser(
-  value,
-  propertyPath = "$",
-) {
-  const result = anonymousValidator770376901(value, propertyPath);
-  if (result.errors) {
-    const info = {};
-    for (const err of result.errors) {
-      if (isNil(info[err.propertyPath])) {
-        info[err.propertyPath] = err;
-      } else if (Array.isArray(info[err.propertyPath])) {
-        info[err.propertyPath].push(err);
-      } else {
-        info[err.propertyPath] = [info[err.propertyPath], err];
-      }
-    }
-    /** @type {{ error: AppError }} */
-    return {
-      error: AppError.validationError("validator.error", info),
-    };
-  }
-  /** @type {{ value: StoreSessionStoreTokenQueryTraverser}} */
   return { value: result.value };
 }

--- a/packages/store/src/session-store.test.js
+++ b/packages/store/src/session-store.test.js
@@ -48,9 +48,11 @@ test("store/session-store", (t) => {
     }
 
     const [session] = await querySessionStore({
-      viaAccessTokens: {
-        where: {
-          id: accessTokenResult.value.payload.compasSessionAccessToken,
+      where: {
+        viaAccessTokens: {
+          where: {
+            id: accessTokenResult.value.payload.compasSessionAccessToken,
+          },
         },
       },
       accessTokens: {
@@ -113,9 +115,11 @@ test("store/session-store", (t) => {
       t.ok(isNil(accessTokenPayload.error));
 
       const [session] = await querySessionStore({
-        viaAccessTokens: {
-          where: {
-            id: accessTokenPayload.value.payload.compasSessionAccessToken,
+        where: {
+          viaAccessTokens: {
+            where: {
+              id: accessTokenPayload.value.payload.compasSessionAccessToken,
+            },
           },
         },
         accessTokens: {
@@ -603,9 +607,11 @@ test("store/session-store", (t) => {
       t.ok(isNil(accessTokenPayload.error));
 
       const [session] = await querySessionStore({
-        viaAccessTokens: {
-          where: {
-            id: accessTokenPayload.value.payload.compasSessionAccessToken,
+        where: {
+          viaAccessTokens: {
+            where: {
+              id: accessTokenPayload.value.payload.compasSessionAccessToken,
+            },
           },
         },
         accessTokens: {

--- a/packages/store/src/session-transport.test.js
+++ b/packages/store/src/session-transport.test.js
@@ -21,7 +21,7 @@ import {
 
 mainTestFn(import.meta);
 
-test("store/session-store", (t) => {
+test("store/session-transport", (t) => {
   const sessionStoreSettings = {
     accessTokenMaxAgeInSeconds: 5,
     refreshTokenMaxAgeInSeconds: 10,
@@ -64,9 +64,11 @@ test("store/session-store", (t) => {
     }
 
     const [session] = await querySessionStore({
-      viaAccessTokens: {
-        where: {
-          id: accessTokenResult.value.payload.compasSessionAccessToken,
+      where: {
+        viaAccessTokens: {
+          where: {
+            id: accessTokenResult.value.payload.compasSessionAccessToken,
+          },
         },
       },
       accessTokens: {

--- a/types/generated/common/types.d.ts
+++ b/types/generated/common/types.d.ts
@@ -1207,9 +1207,7 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     posts?: undefined | SqlPostCategoryQueryBuilder;
-    viaPosts?: undefined | SqlPostCategoryQueryTraverser;
     meta?: undefined | SqlCategoryMetaQueryBuilder;
-    viaMeta?: undefined | SqlCategoryMetaQueryTraverser;
   };
   type SqlPostCategoryQueryBuilder = {
     where?: undefined | SqlPostCategoryWhere;
@@ -1219,9 +1217,7 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     post?: undefined | SqlPostQueryBuilder;
-    viaPost?: undefined | SqlPostQueryTraverser;
     category?: undefined | SqlCategoryQueryBuilder;
-    viaCategory?: undefined | SqlCategoryQueryTraverser;
   };
   type SqlPostQueryBuilder = {
     where?: undefined | SqlPostWhere;
@@ -1231,11 +1227,8 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     writer?: undefined | SqlUserQueryBuilder;
-    viaWriter?: undefined | SqlUserQueryTraverser;
     categories?: undefined | SqlPostCategoryQueryBuilder;
-    viaCategories?: undefined | SqlPostCategoryQueryTraverser;
     postages?: undefined | SqlPostageQueryBuilder;
-    viaPostages?: undefined | SqlPostageQueryTraverser;
   };
   type SqlUserQueryBuilder = {
     where?: undefined | SqlUserWhere;
@@ -1245,63 +1238,6 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     posts?: undefined | SqlPostQueryBuilder;
-    viaPosts?: undefined | SqlPostQueryTraverser;
-  };
-  type SqlPostQueryTraverser = {
-    where?: undefined | SqlPostWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaWriter?: undefined | SqlUserQueryTraverser;
-    viaCategories?: undefined | SqlPostCategoryQueryTraverser;
-    viaPostages?: undefined | SqlPostageQueryTraverser;
-  };
-  type SqlUserQueryTraverser = {
-    where?: undefined | SqlUserWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaPosts?: undefined | SqlPostQueryTraverser;
-  };
-  type SqlPostCategoryQueryTraverser = {
-    where?: undefined | SqlPostCategoryWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaPost?: undefined | SqlPostQueryTraverser;
-    viaCategory?: undefined | SqlCategoryQueryTraverser;
-  };
-  type SqlCategoryQueryTraverser = {
-    where?: undefined | SqlCategoryWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaPosts?: undefined | SqlPostCategoryQueryTraverser;
-    viaMeta?: undefined | SqlCategoryMetaQueryTraverser;
-  };
-  type SqlCategoryMetaQueryTraverser = {
-    where?: undefined | SqlCategoryMetaWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaCategory?: undefined | SqlCategoryQueryTraverser;
-  };
-  type SqlPostageQueryTraverser = {
-    where?: undefined | SqlPostageWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaPost?: undefined | SqlPostQueryTraverser;
-    viaImages?: undefined | StoreFileGroupQueryTraverser;
-  };
-  type StoreFileGroupQueryTraverser = {
-    where?: undefined | StoreFileGroupWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaFile?: undefined | StoreFileQueryTraverser;
-    viaParent?: undefined | StoreFileGroupQueryTraverser;
-    viaChildren?: undefined | StoreFileGroupQueryTraverser;
-    viaPostageImages?: undefined | SqlPostageQueryTraverser;
-  };
-  type StoreFileQueryTraverser = {
-    where?: undefined | StoreFileWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaGroup?: undefined | StoreFileGroupQueryTraverser;
   };
   type SqlPostageQueryBuilder = {
     where?: undefined | SqlPostageWhere;
@@ -1311,9 +1247,7 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     post?: undefined | SqlPostQueryBuilder;
-    viaPost?: undefined | SqlPostQueryTraverser;
     images?: undefined | StoreFileGroupQueryBuilder;
-    viaImages?: undefined | StoreFileGroupQueryTraverser;
   };
   type StoreFileGroupQueryBuilder = {
     where?: undefined | StoreFileGroupWhere;
@@ -1323,13 +1257,9 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     file?: undefined | StoreFileQueryBuilder;
-    viaFile?: undefined | StoreFileQueryTraverser;
     parent?: undefined | StoreFileGroupQueryBuilder;
-    viaParent?: undefined | StoreFileGroupQueryTraverser;
     children?: undefined | StoreFileGroupQueryBuilder;
-    viaChildren?: undefined | StoreFileGroupQueryTraverser;
     postageImages?: undefined | SqlPostageQueryBuilder;
-    viaPostageImages?: undefined | SqlPostageQueryTraverser;
   };
   type StoreFileQueryBuilder = {
     where?: undefined | StoreFileWhere;
@@ -1339,7 +1269,6 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     group?: undefined | StoreFileGroupQueryBuilder;
-    viaGroup?: undefined | StoreFileGroupQueryTraverser;
   };
   type SqlCategoryMetaQueryBuilder = {
     where?: undefined | SqlCategoryMetaWhere;
@@ -1349,7 +1278,6 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     category?: undefined | SqlCategoryQueryBuilder;
-    viaCategory?: undefined | SqlCategoryQueryTraverser;
   };
   type SqlJobStatusAggregateQueryBuilder = {
     where?: undefined | SqlJobStatusAggregateWhere;
@@ -1359,7 +1287,6 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     job?: undefined | StoreJobQueryBuilder;
-    viaJob?: undefined | StoreJobQueryTraverser;
   };
   type StoreJobQueryBuilder = {
     where?: undefined | StoreJobWhere;
@@ -1369,19 +1296,6 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     status?: undefined | SqlJobStatusAggregateQueryBuilder;
-    viaStatus?: undefined | SqlJobStatusAggregateQueryTraverser;
-  };
-  type SqlJobStatusAggregateQueryTraverser = {
-    where?: undefined | SqlJobStatusAggregateWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaJob?: undefined | StoreJobQueryTraverser;
-  };
-  type StoreJobQueryTraverser = {
-    where?: undefined | StoreJobWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaStatus?: undefined | SqlJobStatusAggregateQueryTraverser;
   };
   type QueryResultSqlCategory = SqlCategory & {
     posts?: QueryResultSqlPostCategory[];
@@ -1736,11 +1650,6 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
   };
-  type StoreSessionQueryTraverser = {
-    where?: undefined | StoreSessionWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-  };
   type StoreSessionStoreQueryBuilder = {
     where?: undefined | StoreSessionStoreWhere;
     orderBy?: undefined | StoreSessionStoreOrderBy;
@@ -1749,7 +1658,6 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     accessTokens?: undefined | StoreSessionStoreTokenQueryBuilder;
-    viaAccessTokens?: undefined | StoreSessionStoreTokenQueryTraverser;
   };
   type StoreSessionStoreTokenQueryBuilder = {
     where?: undefined | StoreSessionStoreTokenWhere;
@@ -1759,25 +1667,8 @@ declare global {
     limit?: undefined | number;
     offset?: undefined | number;
     session?: undefined | StoreSessionStoreQueryBuilder;
-    viaSession?: undefined | StoreSessionStoreQueryTraverser;
     refreshToken?: undefined | StoreSessionStoreTokenQueryBuilder;
-    viaRefreshToken?: undefined | StoreSessionStoreTokenQueryTraverser;
     accessToken?: undefined | StoreSessionStoreTokenQueryBuilder;
-    viaAccessToken?: undefined | StoreSessionStoreTokenQueryTraverser;
-  };
-  type StoreSessionStoreQueryTraverser = {
-    where?: undefined | StoreSessionStoreWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaAccessTokens?: undefined | StoreSessionStoreTokenQueryTraverser;
-  };
-  type StoreSessionStoreTokenQueryTraverser = {
-    where?: undefined | StoreSessionStoreTokenWhere;
-    limit?: undefined | number;
-    offset?: undefined | number;
-    viaSession?: undefined | StoreSessionStoreQueryTraverser;
-    viaRefreshToken?: undefined | StoreSessionStoreTokenQueryTraverser;
-    viaAccessToken?: undefined | StoreSessionStoreTokenQueryTraverser;
   };
   type QueryResultStoreSession = StoreSession & {};
   type QueryResultStoreSessionStore = StoreSessionStore & {


### PR DESCRIPTION
Closes #1394

BREAKING CHANGE:
- This should be done in the new `where.viaXxx`. Giving more flexibility by combining it with `where.$or` and allowed usage in update and delete queries.
- Note that the query builder functions validate their inputs, so if you have decent test coverage, your tests should be able to catch most of your usages for you.