### PR TITLE
feat(code-gen): make reactQuery generator compatible with react-query@v4

### DIFF
--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -104,7 +104,7 @@ options?: UseQueryOptions<{{= responseType }}, AppErrorResponse, TData> | undefi
 /**
  * Base key used by {{= funcName }}.queryKey()
  */
-{{= funcName }}.baseKey = (): QueryKey => "{{= item.uniqueName }}";
+{{= funcName }}.baseKey = (): QueryKey => ["{{= item.group }}", "{{= item.name }}"];
 
 ((newline))
 /**
@@ -121,7 +121,7 @@ query: T.{{= getTypeNameForType(item.query.reference, typeSuffix.apiInput, { use
 body: T.{{= getTypeNameForType(item.body.reference, typeSuffix.apiInput, { useDefaults: false, useConvert: true, }) }},
 {{ } }}
 ): QueryKey => [
-  {{= funcName }}.baseKey(),
+  ...{{= funcName }}.baseKey(),
  {{ if (item.params) { }}
  params,
  {{ } }}


### PR DESCRIPTION
This also splits the query key to separate the `group` and `name`. This allows to invalidate a whole group of routes.

Closes #1422

BREAKING CHANGE:
- The `useFooBar.baseKey()` functions now returns an array, and is spread when used in `useFooBar.queryKey()`