### PR TITLE
feat(code-gen,store): migrate query builder to generator helper

### DIFF
--- a/docs/releases/0.0.180.md
+++ b/docs/releases/0.0.180.md
@@ -70,6 +70,13 @@ some options to log the event name if available. Since all communications of
 routes are based on the route group and name, this should make it easier to find
 logs about that route.
 
+The generated query builder now uses a generator helper provided by
+@compas/store. This makes the generated output much cleaner, and improves the
+maintainability of the generator. It also migrated to use correlated sub-queries
+which should be as fast or even faster than the lateral joins used previously.
+This change is however breaking for if you used `execRaw`, so make sure to check
+the query output and update your code accordingly.
+
 ## In closing
 
 I am quite happy with the progress last year, and in the last weeks with the new

--- a/packages/code-gen/src/generator/sql/where-type.js
+++ b/packages/code-gen/src/generator/sql/where-type.js
@@ -282,9 +282,7 @@ export function getWherePartial(context, imports, type) {
            shortName: "${shortName}",
            entityKey: "${referencedKey}",
            referencedKey: "${ownKey}",
-           where: ${
-             isSelfReference ? `"self"` : `() => ${otherSide.name}WhereSpec`
-           },
+           where: () => ${otherSide.name}WhereSpec,
          },`;
       }
 

--- a/packages/store/index.d.ts
+++ b/packages/store/index.d.ts
@@ -1,7 +1,6 @@
 export { structure as storeStructure } from "./src/generated/common/structure.js";
 export { queries as storeQueries } from "./src/generated/database/index.js";
 export { setStoreQueries } from "./src/generated.js";
-export { generatedWhereBuilderHelper } from "./src/generator-helpers.js";
 export { FileCache } from "./src/file-cache.js";
 export { postgresTableSizes } from "./src/insight.js";
 export { sendTransformedImage } from "./src/send-transformed-image.js";
@@ -14,6 +13,10 @@ export type SessionStoreSettings =
   import("./src/session-store.js").SessionStoreSettings;
 export type SessionTransportSettings =
   import("./src/session-transport.js").SessionTransportSettings;
+export {
+  generatedWhereBuilderHelper,
+  generatedQueryBuilderHelper,
+} from "./src/generator-helpers.js";
 export {
   newMinioClient,
   minio,

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -32,7 +32,10 @@ export { queries as storeQueries } from "./src/generated/database/index.js";
 
 export { setStoreQueries } from "./src/generated.js";
 
-export { generatedWhereBuilderHelper } from "./src/generator-helpers.js";
+export {
+  generatedWhereBuilderHelper,
+  generatedQueryBuilderHelper,
+} from "./src/generator-helpers.js";
 
 export {
   newMinioClient,

--- a/packages/store/src/generated/database/file.d.ts
+++ b/packages/store/src/generated/database/file.d.ts
@@ -72,17 +72,7 @@ export function fileInsertValues(
  */
 export function fileUpdateSet(update: StoreFileUpdatePartial): QueryPart;
 /**
- * @param {StoreFileQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQueryFile(
-  builder: StoreFileQueryBuilder,
-  wherePartial?: QueryPart | undefined,
-): QueryPart;
-/**
  * Query Builder for file
- * Note that nested limit and offset don't work yet.
  *
  * @param {StoreFileQueryBuilder} [builder={}]
  * @returns {{
@@ -120,6 +110,20 @@ export namespace fileQueries {
   export { fileUpsertOnId };
   export { fileUpdate };
   export { fileDeletePermanent };
+}
+export namespace fileQueryBuilderSpec {
+  export const name: string;
+  export const shortName: string;
+  export { fileOrderBy as orderBy };
+  export { fileWhereSpec as where };
+  export const columns: string[];
+  export const relations: {
+    builderKey: string;
+    ownKey: string;
+    referencedKey: string;
+    returnsMany: boolean;
+    entityInformation: () => any;
+  }[];
 }
 /**
  * @param {Postgres} sql

--- a/packages/store/src/generated/database/fileGroup.d.ts
+++ b/packages/store/src/generated/database/fileGroup.d.ts
@@ -74,26 +74,7 @@ export function fileGroupUpdateSet(
   update: StoreFileGroupUpdatePartial,
 ): QueryPart;
 /**
- * @param {StoreFileGroupQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQueryFileGroup2(
-  builder: StoreFileGroupQueryBuilder,
-  wherePartial?: QueryPart | undefined,
-): QueryPart;
-/**
- * @param {StoreFileGroupQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQueryFileGroup(
-  builder: StoreFileGroupQueryBuilder,
-  wherePartial?: QueryPart | undefined,
-): QueryPart;
-/**
  * Query Builder for fileGroup
- * Note that nested limit and offset don't work yet.
  *
  * @param {StoreFileGroupQueryBuilder} [builder={}]
  * @returns {{
@@ -134,6 +115,7 @@ export namespace fileGroupQueries {
   export { fileGroupUpdate };
   export { fileGroupDeletePermanent };
 }
+export const fileGroupQueryBuilderSpec: any;
 /**
  * @param {Postgres} sql
  * @param {StoreFileGroupWhere} [where]

--- a/packages/store/src/generated/database/job.d.ts
+++ b/packages/store/src/generated/database/job.d.ts
@@ -72,17 +72,7 @@ export function jobInsertValues(
  */
 export function jobUpdateSet(update: StoreJobUpdatePartial): QueryPart;
 /**
- * @param {StoreJobQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQueryJob(
-  builder: StoreJobQueryBuilder,
-  wherePartial?: QueryPart | undefined,
-): QueryPart;
-/**
  * Query Builder for job
- * Note that nested limit and offset don't work yet.
  *
  * @param {StoreJobQueryBuilder} [builder={}]
  * @returns {{
@@ -119,6 +109,14 @@ export namespace jobQueries {
   export { jobInsert };
   export { jobUpsertOnId };
   export { jobUpdate };
+}
+export namespace jobQueryBuilderSpec {
+  export const name: string;
+  export const shortName: string;
+  export { jobOrderBy as orderBy };
+  export { jobWhereSpec as where };
+  export const columns: string[];
+  export const relations: never[];
 }
 /**
  * @param {Postgres} sql

--- a/packages/store/src/generated/database/sessionStore.d.ts
+++ b/packages/store/src/generated/database/sessionStore.d.ts
@@ -74,17 +74,7 @@ export function sessionStoreUpdateSet(
   update: StoreSessionStoreUpdatePartial,
 ): QueryPart;
 /**
- * @param {StoreSessionStoreQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQuerySessionStore(
-  builder: StoreSessionStoreQueryBuilder,
-  wherePartial?: QueryPart | undefined,
-): QueryPart;
-/**
  * Query Builder for sessionStore
- * Note that nested limit and offset don't work yet.
  *
  * @param {StoreSessionStoreQueryBuilder} [builder={}]
  * @returns {{
@@ -123,6 +113,20 @@ export namespace sessionStoreQueries {
   export { sessionStoreInsert };
   export { sessionStoreUpsertOnId };
   export { sessionStoreUpdate };
+}
+export namespace sessionStoreQueryBuilderSpec {
+  export const name: string;
+  export const shortName: string;
+  export { sessionStoreOrderBy as orderBy };
+  export { sessionStoreWhereSpec as where };
+  export const columns: string[];
+  export const relations: {
+    builderKey: string;
+    ownKey: string;
+    referencedKey: string;
+    returnsMany: boolean;
+    entityInformation: () => any;
+  }[];
 }
 /**
  * @param {Postgres} sql

--- a/packages/store/src/generated/database/sessionStoreToken.d.ts
+++ b/packages/store/src/generated/database/sessionStoreToken.d.ts
@@ -76,26 +76,7 @@ export function sessionStoreTokenUpdateSet(
   update: StoreSessionStoreTokenUpdatePartial,
 ): QueryPart;
 /**
- * @param {StoreSessionStoreTokenQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQuerySessionStoreToken2(
-  builder: StoreSessionStoreTokenQueryBuilder,
-  wherePartial?: QueryPart | undefined,
-): QueryPart;
-/**
- * @param {StoreSessionStoreTokenQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQuerySessionStoreToken(
-  builder: StoreSessionStoreTokenQueryBuilder,
-  wherePartial?: QueryPart | undefined,
-): QueryPart;
-/**
  * Query Builder for sessionStoreToken
- * Note that nested limit and offset don't work yet.
  *
  * @param {StoreSessionStoreTokenQueryBuilder} [builder={}]
  * @returns {{
@@ -135,6 +116,7 @@ export namespace sessionStoreTokenQueries {
   export { sessionStoreTokenUpsertOnId };
   export { sessionStoreTokenUpdate };
 }
+export const sessionStoreTokenQueryBuilderSpec: any;
 /**
  * @param {Postgres} sql
  * @param {StoreSessionStoreTokenWhere} [where]

--- a/packages/store/src/generated/database/sessionStoreToken.js
+++ b/packages/store/src/generated/database/sessionStoreToken.js
@@ -2,7 +2,12 @@
 /* eslint-disable no-unused-vars */
 
 import { AppError, isNil, isPlainObject, isStaging } from "@compas/stdlib";
-import { generatedWhereBuilderHelper, isQueryPart, query } from "@compas/store";
+import {
+  generatedQueryBuilderHelper,
+  generatedWhereBuilderHelper,
+  isQueryPart,
+  query,
+} from "@compas/store";
 import {
   validateStoreSessionStoreTokenOrderBy,
   validateStoreSessionStoreTokenOrderBySpec,
@@ -10,8 +15,7 @@ import {
   validateStoreSessionStoreTokenWhere,
 } from "../store/validators.js";
 import {
-  internalQuerySessionStore,
-  sessionStoreOrderBy,
+  sessionStoreQueryBuilderSpec,
   sessionStoreWhere,
   sessionStoreWhereSpec,
   transformSessionStore,
@@ -109,7 +113,7 @@ export const sessionStoreTokenWhereSpec = {
             shortName: "sst2",
             entityKey: "id",
             referencedKey: "refreshToken",
-            where: "self",
+            where: () => sessionStoreTokenWhereSpec,
           },
         },
       ],
@@ -140,7 +144,7 @@ export const sessionStoreTokenWhereSpec = {
             shortName: "sst2",
             entityKey: "refreshToken",
             referencedKey: "id",
-            where: "self",
+            where: () => sessionStoreTokenWhereSpec,
           },
         },
         {
@@ -151,7 +155,7 @@ export const sessionStoreTokenWhereSpec = {
             shortName: "sst2",
             entityKey: "refreshToken",
             referencedKey: "id",
-            where: "self",
+            where: () => sessionStoreTokenWhereSpec,
           },
         },
       ],
@@ -454,279 +458,45 @@ export const sessionStoreTokenQueries = {
   sessionStoreTokenUpsertOnId,
   sessionStoreTokenUpdate,
 };
-/**
- * @param {StoreSessionStoreTokenQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQuerySessionStoreToken2(builder, wherePartial) {
-  const joinQb = query``;
-  if (builder.session) {
-    const joinedKeys = [];
-    const offsetLimitQb = !isNil(builder.session.offset)
-      ? query`OFFSET ${builder.session.offset}`
-      : query``;
-    if (!isNil(builder.session.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.session.limit} ROWS ONLY`,
-      );
-    }
-    if (builder.session.accessTokens) {
-      joinedKeys.push(
-        `'${builder.session.accessTokens?.as ?? "accessTokens"}'`,
-        `coalesce("ss_sst_0"."result", '{}')`,
-      );
-    }
-    joinQb.append(query`LEFT JOIN LATERAL (
-SELECT to_jsonb(ss.*) || jsonb_build_object(${query([
-      joinedKeys.join(","),
-    ])}) as "result"
-${internalQuerySessionStore(
-  builder.session ?? {},
-  query`AND ss."id" = sst2."session"`,
-)}
-ORDER BY ${sessionStoreOrderBy(
-      builder.session.orderBy,
-      builder.session.orderBySpec,
-      "ss.",
-    )}
-${offsetLimitQb}
-) as "sst_ss_0" ON TRUE`);
-  }
-  if (builder.refreshToken) {
-    const joinedKeys = [];
-    const offsetLimitQb = !isNil(builder.refreshToken.offset)
-      ? query`OFFSET ${builder.refreshToken.offset}`
-      : query``;
-    if (!isNil(builder.refreshToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.refreshToken.limit} ROWS ONLY`,
-      );
-    }
-    if (builder.refreshToken.session) {
-      joinedKeys.push(
-        `'${builder.refreshToken.session?.as ?? "session"}'`,
-        `"sst_ss_0"."result"`,
-      );
-    }
-    if (builder.refreshToken.refreshToken) {
-      joinedKeys.push(
-        `'${builder.refreshToken.refreshToken?.as ?? "refreshToken"}'`,
-        `"sst_sst_0"."result"`,
-      );
-    }
-    if (builder.refreshToken.accessToken) {
-      joinedKeys.push(
-        `'${builder.refreshToken.accessToken?.as ?? "accessToken"}'`,
-        `"sst_sst_1"."result"`,
-      );
-    }
-    joinQb.append(query`LEFT JOIN LATERAL (
-SELECT to_jsonb(sst.*) || jsonb_build_object(${query([
-      joinedKeys.join(","),
-    ])}) as "result"
-${internalQuerySessionStoreToken(
-  builder.refreshToken ?? {},
-  query`AND sst."id" = sst2."refreshToken"`,
-)}
-ORDER BY ${sessionStoreTokenOrderBy(
-      builder.refreshToken.orderBy,
-      builder.refreshToken.orderBySpec,
-      "sst.",
-    )}
-${offsetLimitQb}
-) as "sst_sst_0" ON TRUE`);
-  }
-  if (builder.accessToken) {
-    const joinedKeys = [];
-    const offsetLimitQb = !isNil(builder.accessToken.offset)
-      ? query`OFFSET ${builder.accessToken.offset}`
-      : query``;
-    if (!isNil(builder.accessToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.accessToken.limit} ROWS ONLY`,
-      );
-    }
-    if (builder.accessToken.session) {
-      joinedKeys.push(
-        `'${builder.accessToken.session?.as ?? "session"}'`,
-        `"sst_ss_0"."result"`,
-      );
-    }
-    if (builder.accessToken.refreshToken) {
-      joinedKeys.push(
-        `'${builder.accessToken.refreshToken?.as ?? "refreshToken"}'`,
-        `"sst_sst_0"."result"`,
-      );
-    }
-    if (builder.accessToken.accessToken) {
-      joinedKeys.push(
-        `'${builder.accessToken.accessToken?.as ?? "accessToken"}'`,
-        `"sst_sst_1"."result"`,
-      );
-    }
-    joinQb.append(query`LEFT JOIN LATERAL (
-SELECT to_jsonb(sst.*) || jsonb_build_object(${query([
-      joinedKeys.join(","),
-    ])}) as "result"
-${internalQuerySessionStoreToken(
-  builder.accessToken ?? {},
-  query`AND sst."refreshToken" = sst2."id"`,
-)}
-ORDER BY ${sessionStoreTokenOrderBy(
-      builder.accessToken.orderBy,
-      builder.accessToken.orderBySpec,
-      "sst.",
-    )}
-${offsetLimitQb}
-) as "sst_sst_1" ON TRUE`);
-  }
-  return query`
-FROM "sessionStoreToken" sst2
-${joinQb}
-WHERE ${sessionStoreTokenWhere(builder.where, "sst2.", {
-    skipValidator: true,
-  })} ${wherePartial}
-`;
-}
-/**
- * @param {StoreSessionStoreTokenQueryBuilder} builder
- * @param {QueryPart|undefined} [wherePartial]
- * @returns {QueryPart}
- */
-export function internalQuerySessionStoreToken(builder, wherePartial) {
-  const joinQb = query``;
-  if (builder.session) {
-    const joinedKeys = [];
-    const offsetLimitQb = !isNil(builder.session.offset)
-      ? query`OFFSET ${builder.session.offset}`
-      : query``;
-    if (!isNil(builder.session.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.session.limit} ROWS ONLY`,
-      );
-    }
-    if (builder.session.accessTokens) {
-      joinedKeys.push(
-        `'${builder.session.accessTokens?.as ?? "accessTokens"}'`,
-        `coalesce("ss_sst_0"."result", '{}')`,
-      );
-    }
-    joinQb.append(query`LEFT JOIN LATERAL (
-SELECT to_jsonb(ss.*) || jsonb_build_object(${query([
-      joinedKeys.join(","),
-    ])}) as "result"
-${internalQuerySessionStore(
-  builder.session ?? {},
-  query`AND ss."id" = sst."session"`,
-)}
-ORDER BY ${sessionStoreOrderBy(
-      builder.session.orderBy,
-      builder.session.orderBySpec,
-      "ss.",
-    )}
-${offsetLimitQb}
-) as "sst_ss_0" ON TRUE`);
-  }
-  if (builder.refreshToken) {
-    const joinedKeys = [];
-    const offsetLimitQb = !isNil(builder.refreshToken.offset)
-      ? query`OFFSET ${builder.refreshToken.offset}`
-      : query``;
-    if (!isNil(builder.refreshToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.refreshToken.limit} ROWS ONLY`,
-      );
-    }
-    if (builder.refreshToken.session) {
-      joinedKeys.push(
-        `'${builder.refreshToken.session?.as ?? "session"}'`,
-        `"sst_ss_0"."result"`,
-      );
-    }
-    if (builder.refreshToken.refreshToken) {
-      joinedKeys.push(
-        `'${builder.refreshToken.refreshToken?.as ?? "refreshToken"}'`,
-        `"sst_sst_0"."result"`,
-      );
-    }
-    if (builder.refreshToken.accessToken) {
-      joinedKeys.push(
-        `'${builder.refreshToken.accessToken?.as ?? "accessToken"}'`,
-        `"sst_sst_1"."result"`,
-      );
-    }
-    joinQb.append(query`LEFT JOIN LATERAL (
-SELECT to_jsonb(sst2.*) || jsonb_build_object(${query([
-      joinedKeys.join(","),
-    ])}) as "result"
-${internalQuerySessionStoreToken2(
-  builder.refreshToken ?? {},
-  query`AND sst2."id" = sst."refreshToken"`,
-)}
-ORDER BY ${sessionStoreTokenOrderBy(
-      builder.refreshToken.orderBy,
-      builder.refreshToken.orderBySpec,
-      "sst2.",
-    )}
-${offsetLimitQb}
-) as "sst_sst_0" ON TRUE`);
-  }
-  if (builder.accessToken) {
-    const joinedKeys = [];
-    const offsetLimitQb = !isNil(builder.accessToken.offset)
-      ? query`OFFSET ${builder.accessToken.offset}`
-      : query``;
-    if (!isNil(builder.accessToken.limit)) {
-      offsetLimitQb.append(
-        query`FETCH NEXT ${builder.accessToken.limit} ROWS ONLY`,
-      );
-    }
-    if (builder.accessToken.session) {
-      joinedKeys.push(
-        `'${builder.accessToken.session?.as ?? "session"}'`,
-        `"sst_ss_0"."result"`,
-      );
-    }
-    if (builder.accessToken.refreshToken) {
-      joinedKeys.push(
-        `'${builder.accessToken.refreshToken?.as ?? "refreshToken"}'`,
-        `"sst_sst_0"."result"`,
-      );
-    }
-    if (builder.accessToken.accessToken) {
-      joinedKeys.push(
-        `'${builder.accessToken.accessToken?.as ?? "accessToken"}'`,
-        `"sst_sst_1"."result"`,
-      );
-    }
-    joinQb.append(query`LEFT JOIN LATERAL (
-SELECT to_jsonb(sst2.*) || jsonb_build_object(${query([
-      joinedKeys.join(","),
-    ])}) as "result"
-${internalQuerySessionStoreToken2(
-  builder.accessToken ?? {},
-  query`AND sst2."refreshToken" = sst."id"`,
-)}
-ORDER BY ${sessionStoreTokenOrderBy(
-      builder.accessToken.orderBy,
-      builder.accessToken.orderBySpec,
-      "sst2.",
-    )}
-${offsetLimitQb}
-) as "sst_sst_1" ON TRUE`);
-  }
-  return query`
-FROM "sessionStoreToken" sst
-${joinQb}
-WHERE ${sessionStoreTokenWhere(builder.where, "sst.", {
-    skipValidator: true,
-  })} ${wherePartial}
-`;
-}
+export const sessionStoreTokenQueryBuilderSpec = {
+  name: "sessionStoreToken",
+  shortName: "sst",
+  orderBy: sessionStoreTokenOrderBy,
+  where: sessionStoreTokenWhereSpec,
+  columns: [
+    "expiresAt",
+    "revokedAt",
+    "createdAt",
+    "id",
+    "session",
+    "refreshToken",
+  ],
+  relations: [
+    {
+      builderKey: "session",
+      ownKey: "session",
+      referencedKey: "id",
+      returnsMany: false,
+      entityInformation: () => sessionStoreQueryBuilderSpec,
+    },
+    {
+      builderKey: "refreshToken",
+      ownKey: "refreshToken",
+      referencedKey: "id",
+      returnsMany: false,
+      entityInformation: () => sessionStoreTokenQueryBuilderSpec,
+    },
+    {
+      builderKey: "accessToken",
+      ownKey: "id",
+      referencedKey: "refreshToken",
+      returnsMany: false,
+      entityInformation: () => sessionStoreTokenQueryBuilderSpec,
+    },
+  ],
+};
 /**
  * Query Builder for sessionStoreToken
- * Note that nested limit and offset don't work yet.
  *
  * @param {StoreSessionStoreTokenQueryBuilder} [builder={}]
  * @returns {{
@@ -737,7 +507,6 @@ WHERE ${sessionStoreTokenWhere(builder.where, "sst.", {
  * }}
  */
 export function querySessionStoreToken(builder = {}) {
-  const joinedKeys = [];
   const builderValidated = validateStoreSessionStoreTokenQueryBuilder(
     builder,
     "$.sessionStoreTokenBuilder",
@@ -746,37 +515,11 @@ export function querySessionStoreToken(builder = {}) {
     throw builderValidated.error;
   }
   builder = builderValidated.value;
-  if (builder.session) {
-    joinedKeys.push(
-      `'${builder.session?.as ?? "session"}'`,
-      `"sst_ss_0"."result"`,
-    );
-  }
-  if (builder.refreshToken) {
-    joinedKeys.push(
-      `'${builder.refreshToken?.as ?? "refreshToken"}'`,
-      `"sst_sst_0"."result"`,
-    );
-  }
-  if (builder.accessToken) {
-    joinedKeys.push(
-      `'${builder.accessToken?.as ?? "accessToken"}'`,
-      `"sst_sst_1"."result"`,
-    );
-  }
-  const qb = query`
-SELECT to_jsonb(sst.*) || jsonb_build_object(${query([
-    joinedKeys.join(","),
-  ])}) as "result"
-${internalQuerySessionStoreToken(builder ?? {})}
-ORDER BY ${sessionStoreTokenOrderBy(builder.orderBy, builder.orderBySpec)}
-`;
-  if (!isNil(builder.offset)) {
-    qb.append(query`OFFSET ${builder.offset}`);
-  }
-  if (!isNil(builder.limit)) {
-    qb.append(query`FETCH NEXT ${builder.limit} ROWS ONLY`);
-  }
+  const qb = generatedQueryBuilderHelper(
+    sessionStoreTokenQueryBuilderSpec,
+    builder,
+    {},
+  );
   return {
     then: () => {
       throw AppError.serverError({

--- a/packages/store/src/generator-helpers.d.ts
+++ b/packages/store/src/generator-helpers.d.ts
@@ -14,10 +14,29 @@
  *       shortName: string,
  *       entityKey: string,
  *       referencedKey: string,
- *       where: "self"|EntityWhere,
+ *       where: () => EntityWhere,
  *     },
  *   }[],
  * }[]} fieldSpecification
+ */
+/**
+ * @typedef {object} EntityQueryBuilder
+ * @property {string} name
+ * @property {string} shortName
+ * @property {string[]} columns
+ * @property {( orderBy?: any[],
+ *   orderBySpec?: *,
+ *   shortName?: string,
+ *   options?: { skipValidator?: boolean|undefined },
+ *   ) => import("../types/advanced-types").QueryPart} orderBy
+ * @property {EntityWhere} where
+ * @property {{
+ *   builderKey: string,
+ *   ownKey: string,
+ *   referencedKey: string,
+ *   returnsMany: boolean,
+ *   entityInformation: () => EntityQueryBuilder,
+ * }[]} relations
  */
 /**
  * Builds a where clause based on the generated 'where' information.
@@ -32,6 +51,34 @@ export function generatedWhereBuilderHelper(
   where: any,
   shortName: string,
 ): import("../types/advanced-types").QueryPart;
+/**
+ * Helper to generate the correct queries to be used with the query builder.
+ * Works with correlated sub queries to fetched nested result sets.
+ *
+ * Calls itself recursively with the entities that need to be included.
+ *
+ * @param {EntityQueryBuilder} entity
+ * @param {*} builder
+ * @param {{
+ *   shortName?: string,
+ *   wherePart?: string,
+ *   nestedIndex?: number,
+ * }} options
+ * @return {import("../types/advanced-types").QueryPart<any[]>}
+ */
+export function generatedQueryBuilderHelper(
+  entity: EntityQueryBuilder,
+  builder: any,
+  {
+    shortName,
+    wherePart,
+    nestedIndex,
+  }: {
+    shortName?: string;
+    wherePart?: string;
+    nestedIndex?: number;
+  },
+): import("../types/advanced-types").QueryPart<any[]>;
 export type EntityWhere = {
   fieldSpecification: {
     tableKey: string;
@@ -59,9 +106,32 @@ export type EntityWhere = {
         shortName: string;
         entityKey: string;
         referencedKey: string;
-        where: "self" | EntityWhere;
+        where: () => EntityWhere;
       };
     }[];
+  }[];
+};
+export type EntityQueryBuilder = {
+  name: string;
+  shortName: string;
+  columns: string[];
+  orderBy: (
+    orderBy?: any[] | undefined,
+    orderBySpec?: any,
+    shortName?: string | undefined,
+    options?:
+      | {
+          skipValidator?: boolean | undefined;
+        }
+      | undefined,
+  ) => import("../types/advanced-types").QueryPart;
+  where: EntityWhere;
+  relations: {
+    builderKey: string;
+    ownKey: string;
+    referencedKey: string;
+    returnsMany: boolean;
+    entityInformation: () => EntityQueryBuilder;
   }[];
 };
 //# sourceMappingURL=generator-helpers.d.ts.map

--- a/packages/store/src/session-store.test.js
+++ b/packages/store/src/session-store.test.js
@@ -127,6 +127,8 @@ test("store/session-store", (t) => {
         },
       }).exec(sql);
 
+      t.log.info(session);
+
       t.equal(session.accessTokens.length, 2);
       t.equal(session.data.foo, data.foo);
     });


### PR DESCRIPTION
Closes #1465

BREAKING CHANGE:
- `queryXxx().execRaw` has some output differences, verify your usages.