### PR TITLE
feat(cli): use ESLint cache, default enable JSDoc rules for `compas lint`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 node_modules
 .eslintcache
+.cache
 
 # NPM / Yarn
 *-debug.log

--- a/docs/references/cli.md
+++ b/docs/references/cli.md
@@ -169,11 +169,13 @@ ESLint is used for all JavaScript files and Prettier runs on JavaScript, JSON,
 Markdown, and YAML files. The default configuration can be initialized via
 'compas init --lint-config'.
 
-| Option     | Description                                                                                    |
-| ---------- | ---------------------------------------------------------------------------------------------- |
-| --jsdoc    | Run ESLint with JSDoc rules enabled. This could degrade performance on big projects. (boolean) |
-| --timings  | Print information about CLI execution time. (boolean)                                          |
-| -h, --help | Display information about the current command. (boolean)                                       |
+| Option                  | Description                                                                |
+| ----------------------- | -------------------------------------------------------------------------- |
+| --skip-prettier         | Skip running Prettier. (boolean)                                           |
+| --skip-eslint           | Skip running ESLint. (boolean)                                             |
+| --eslint-cache-location | Location of ESLint cache directory. Defaults to '.cache/eslint/'. (string) |
+| --timings               | Print information about CLI execution time. (boolean)                      |
+| -h, --help              | Display information about the current command. (boolean)                   |
 
 ## `compas migrate`
 

--- a/packages/cli/src/cli/loader.d.ts
+++ b/packages/cli/src/cli/loader.d.ts
@@ -1,5 +1,6 @@
 /**
  * Load the specified directories and return a command array
+ *
  * @param {InsightEvent} event
  * @param {{inputs: { directory: string, validateOnLoad: boolean }[]}} options
  * @returns {Promise<import("../generated/common/types").CliCommandDefinitionInput[]>}

--- a/packages/cli/src/cli/loader.js
+++ b/packages/cli/src/cli/loader.js
@@ -12,6 +12,7 @@ import { validateCliCommandDefinition } from "../generated/cli/validators.js";
 
 /**
  * Load the specified directories and return a command array
+ *
  * @param {InsightEvent} event
  * @param {{inputs: { directory: string, validateOnLoad: boolean }[]}} options
  * @returns {Promise<import("../generated/common/types").CliCommandDefinitionInput[]>}

--- a/packages/cli/src/cli/utils.d.ts
+++ b/packages/cli/src/cli/utils.d.ts
@@ -7,6 +7,7 @@
 export function lowerCaseFirst(str?: string | undefined): string;
 /**
  * Converts 'code-mod', 'code_mod' to 'codeMod'
+ *
  * @param {string} str
  * @returns {string}
  */

--- a/packages/cli/src/cli/utils.js
+++ b/packages/cli/src/cli/utils.js
@@ -10,6 +10,7 @@ export function lowerCaseFirst(str = "") {
 
 /**
  * Converts 'code-mod', 'code_mod' to 'codeMod'
+ *
  * @param {string} str
  * @returns {string}
  */

--- a/packages/cli/src/compas/commands/check-env.js
+++ b/packages/cli/src/compas/commands/check-env.js
@@ -57,7 +57,7 @@ ${envLocalResult.message}
 /**
  * If a `.env.local` exists, it should be ignored
  *
- * @return {Promise<{ failed: boolean, message: string }>}
+ * @returns {Promise<{ failed: boolean, message: string }>}
  */
 async function isEnvLocalNotIgnored() {
   let result;
@@ -88,7 +88,7 @@ async function isEnvLocalNotIgnored() {
  * leads to weird behaviour. So warn if that is happening.
  *
  * @param {string} compasVersion
- * @return {Promise<{ failed: boolean, message: string }>}
+ * @returns {Promise<{ failed: boolean, message: string }>}
  */
 async function areOtherCompasVersionsInstalled(compasVersion) {
   const foundVersions = [];

--- a/packages/cli/src/compas/commands/docker.js
+++ b/packages/cli/src/compas/commands/docker.js
@@ -399,7 +399,7 @@ async function cleanContainers(logger, state, context) {
 }
 
 /**
-
+ 
  * @param postgresVersion
  * @returns {DockerContext}
  */

--- a/packages/code-gen/src/builders/DateType.d.ts
+++ b/packages/code-gen/src/builders/DateType.d.ts
@@ -6,7 +6,7 @@ export class DateType extends TypeBuilder {
    *
    * @public
    *
-   * @return {DateType}
+   * @returns {DateType}
    */
   public dateOnly(): DateType;
   /**
@@ -14,7 +14,7 @@ export class DateType extends TypeBuilder {
    *
    * @public
    *
-   * @return {DateType}
+   * @returns {DateType}
    */
   public timeOnly(): DateType;
   /**

--- a/packages/code-gen/src/builders/DateType.js
+++ b/packages/code-gen/src/builders/DateType.js
@@ -18,7 +18,7 @@ export class DateType extends TypeBuilder {
    *
    * @public
    *
-   * @return {DateType}
+   * @returns {DateType}
    */
   dateOnly() {
     this.data.specifier = "dateOnly";
@@ -42,7 +42,7 @@ export class DateType extends TypeBuilder {
    *
    * @public
    *
-   * @return {DateType}
+   * @returns {DateType}
    */
   timeOnly() {
     this.data.specifier = "timeOnly";

--- a/packages/lint-config/index.js
+++ b/packages/lint-config/index.js
@@ -6,12 +6,18 @@
 const settings = {
   root: true,
   globals: {},
+  plugins: ["jsdoc"],
   extends: [
     "eslint:recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
     "prettier",
   ],
+  settings: {
+    jsdoc: {
+      mode: "typescript",
+    },
+  },
   parser: "@babel/eslint-parser",
   parserOptions: {
     requireConfigFile: false,
@@ -54,18 +60,7 @@ const settings = {
         alphabetize: { order: "asc", caseInsensitive: true },
       },
     ],
-  },
-  env: {
-    node: true,
-    es2021: true,
-  },
-};
-/**
- * @type {Record<string, any>} Eslint settings
- */
-const jsdocSettings = {
-  plugins: ["jsdoc"],
-  rules: {
+
     // ESLint plugin jsdoc
     "jsdoc/check-alignment": "error",
     "jsdoc/check-examples": ["off", { padding: 2 }],
@@ -89,24 +84,13 @@ const jsdocSettings = {
     "jsdoc/require-returns-type": "off",
     "jsdoc/valid-types": "off",
   },
-  settings: {
-    jsdoc: {
-      mode: "typescript",
-    },
+  env: {
+    node: true,
+    es2021: true,
   },
 };
 
 /**
  * @type {Record<string, any>} Eslint settings
  */
-module.exports =
-  process.env.CI === "true" || process.env.LINT_JSDOC === "true"
-    ? {
-        ...settings,
-        ...jsdocSettings,
-        rules: {
-          ...settings.rules,
-          ...jsdocSettings.rules,
-        },
-      }
-    : settings;
+module.exports = settings;

--- a/packages/store/src/generator-helpers.d.ts
+++ b/packages/store/src/generator-helpers.d.ts
@@ -64,7 +64,7 @@ export function generatedWhereBuilderHelper(
  *   wherePart?: string,
  *   nestedIndex?: number,
  * }} options
- * @return {import("../types/advanced-types").QueryPart<any[]>}
+ * @returns {import("../types/advanced-types").QueryPart<any[]>}
  */
 export function generatedQueryBuilderHelper(
   entity: EntityQueryBuilder,

--- a/packages/store/src/generator-helpers.js
+++ b/packages/store/src/generator-helpers.js
@@ -248,7 +248,7 @@ export function generatedWhereBuilderHelper(
  *   wherePart?: string,
  *   nestedIndex?: number,
  * }} options
- * @return {import("../types/advanced-types").QueryPart<any[]>}
+ * @returns {import("../types/advanced-types").QueryPart<any[]>}
  */
 export function generatedQueryBuilderHelper(
   entity,

--- a/scripts/create-release.js
+++ b/scripts/create-release.js
@@ -25,7 +25,7 @@ export const cliDefinition = {
  *
  * @param {import("@compas/stdlib").Logger} logger
  * @param {import("@compas/cli").CliExecutorState} state
- * @return {Promise<import("@compas/cli").CliResult>}
+ * @returns {Promise<import("@compas/cli").CliResult>}
  */
 async function cliExecutor(logger, state) {
   const rawRef = environment.GITHUB_REF ?? "";

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -34,7 +34,7 @@ export const cliDefinition = {
  *
  * @param {import("@compas/stdlib").Logger} logger
  * @param {import("@compas/cli").CliExecutorState} state
- * @return {Promise<import("@compas/cli").CliResult>}
+ * @returns {Promise<import("@compas/cli").CliResult>}
  */
 async function cliExecutor(logger, state) {
   const packages = [


### PR DESCRIPTION

Closes #1429

BREAKING CHANGE:
- JSDoc related ESLint rules are enabled by default locally now, they were already enabled on `CI=true`.
- Add `.cache` to your `.gitignore`. Or specify another ESLint cache directory via `--eslint-cache-location`.