### PR TITLE
feat(code-gen): openApi generator more strict and extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "email": "dirkdev98@gmail.com"
     },
     {
-      "name": "Daniël Hansen"
+      "name": "Daniël Hansen",
+      "email": "hi@danielhansen.nl"
     }
   ],
   "homepage": "https://compasjs.com",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,8 @@
       "email": "dirkdev98@gmail.com"
     },
     {
-      "name": "Daniël Hansen"
+      "name": "Daniël Hansen",
+      "email": "hi@danielhansen.nl"
     }
   ],
   "homepage": "https://compasjs.com",

--- a/packages/code-gen/package.json
+++ b/packages/code-gen/package.json
@@ -23,7 +23,8 @@
       "email": "dirkdev98@gmail.com"
     },
     {
-      "name": "Daniël Hansen"
+      "name": "Daniël Hansen",
+      "email": "hi@danielhansen.nl"
     }
   ],
   "homepage": "https://compasjs.com",

--- a/packages/code-gen/src/generator/openAPI/generator.d.ts
+++ b/packages/code-gen/src/generator/openAPI/generator.d.ts
@@ -1,6 +1,6 @@
 /**
  * @typedef GenerateOpenApiFileOpts
- * @property {import("./index.js").OpenApiOpts} openApiOptions
+ * @property {import("./index.js").OpenApiExtensions} openApiExtensions
  * @property {string[]} enabledGroups
  * @property {boolean} verbose
  */
@@ -14,7 +14,7 @@ export function generateOpenApiFile(
   options: GenerateOpenApiFileOpts,
 ): string;
 export type GenerateOpenApiFileOpts = {
-  openApiOptions: import("./index.js").OpenApiOpts;
+  openApiExtensions: import("./index.js").OpenApiExtensions;
   enabledGroups: string[];
   verbose: boolean;
 };

--- a/packages/code-gen/src/generator/openAPI/generator.d.ts
+++ b/packages/code-gen/src/generator/openAPI/generator.d.ts
@@ -1,6 +1,7 @@
 /**
  * @typedef GenerateOpenApiFileOpts
  * @property {import("./index.js").OpenApiExtensions} openApiExtensions
+ * @property {import("./index.js").OpenApiRouteExtensions} openApiRouteExtensions
  * @property {string[]} enabledGroups
  * @property {boolean} verbose
  */
@@ -15,6 +16,7 @@ export function generateOpenApiFile(
 ): string;
 export type GenerateOpenApiFileOpts = {
   openApiExtensions: import("./index.js").OpenApiExtensions;
+  openApiRouteExtensions: import("./index.js").OpenApiRouteExtensions;
   enabledGroups: string[];
   verbose: boolean;
 };

--- a/packages/code-gen/src/generator/openAPI/generator.js
+++ b/packages/code-gen/src/generator/openAPI/generator.js
@@ -12,8 +12,10 @@ import {
  */
 const OPENAPI_SPEC_TEMPLATE = {
   openapi: "3.0.3",
-  paths: {},
+  info: {},
+  servers: [],
   tags: [],
+  paths: {},
   components: {
     schemas: {
       AppError: {
@@ -33,13 +35,11 @@ const OPENAPI_SPEC_TEMPLATE = {
       },
     },
   },
-  // pass-through (settings)
-  servers: [],
 };
 
 /**
  * @typedef GenerateOpenApiFileOpts
- * @property {import("./index.js").OpenApiOpts} openApiOptions
+ * @property {import("./index.js").OpenApiExtensions} openApiExtensions
  * @property {string[]} enabledGroups
  * @property {boolean} verbose
  */
@@ -105,10 +105,10 @@ export function generateOpenApiFile(structure, options) {
 
     // transform components
     const schemas = transformComponents(structure, groupComponents);
-    openApiSpec.components.schemas = {
-      ...openApiSpec.components.schemas,
-      ...schemas,
-    };
+    openApiSpec.components.schemas = Object.assign(
+      schemas,
+      openApiSpec.components.schemas,
+    );
   }
 
   // determine compas version
@@ -119,13 +119,20 @@ export function generateOpenApiFile(structure, options) {
 
   // set meta
   openApiSpec.info = {
-    title: `${options.openApiOptions?.title ?? process.env.APP_NAME}`,
-    description: options.openApiOptions?.description ?? "",
-    version: options.openApiOptions?.version ?? "0.0.0",
+    title: `${options.openApiExtensions?.title ?? process.env.APP_NAME}`,
+    description: options.openApiExtensions?.description ?? "",
+    version: options.openApiExtensions?.version ?? "0.0.0",
   };
 
   // set servers, if any (pass-trough settings)
-  openApiSpec.servers = options.openApiOptions?.servers ?? [];
+  openApiSpec.servers = options.openApiExtensions?.servers ?? [];
+
+  // merge components, if any (pass-trough settings)
+  openApiSpec.components = Object.assign(
+    options.openApiExtensions?.components,
+    {},
+    openApiSpec.components,
+  );
 
   return openApiSpec;
 }

--- a/packages/code-gen/src/generator/openAPI/generator.js
+++ b/packages/code-gen/src/generator/openAPI/generator.js
@@ -33,10 +33,6 @@ const OPENAPI_SPEC_TEMPLATE = {
       },
     },
   },
-  externalDocs: {
-    description: "Find more info here (Compas)",
-    url: "https://compasjs.com/",
-  },
   // pass-through (settings)
   servers: [],
 };

--- a/packages/code-gen/src/generator/openAPI/generator.js
+++ b/packages/code-gen/src/generator/openAPI/generator.js
@@ -40,6 +40,7 @@ const OPENAPI_SPEC_TEMPLATE = {
 /**
  * @typedef GenerateOpenApiFileOpts
  * @property {import("./index.js").OpenApiExtensions} openApiExtensions
+ * @property {import("./index.js").OpenApiRouteExtensions} openApiRouteExtensions
  * @property {string[]} enabledGroups
  * @property {boolean} verbose
  */
@@ -90,6 +91,8 @@ export function generateOpenApiFile(structure, options) {
         // requestBody (with files, if any)
         ...transformBody(structure, route),
         responses: constructResponse(structure, route),
+        // @ts-ignore
+        ...(options.openApiRouteExtensions?.[route.uniqueName] ?? {}),
       };
     }
 

--- a/packages/code-gen/src/generator/openAPI/generator.js
+++ b/packages/code-gen/src/generator/openAPI/generator.js
@@ -102,7 +102,9 @@ export function generateOpenApiFile(structure, options) {
      */
     // @ts-ignore
     const groupComponents = Object.values(groupStructure).filter(
-      (it) => it.type !== "route",
+      // Strip params types because they're transformed inline
+      // @ts-ignore
+      (it) => it.type !== "route" && !it.uniqueName.endsWith("Params"),
     );
 
     // transform components

--- a/packages/code-gen/src/generator/openAPI/index.d.ts
+++ b/packages/code-gen/src/generator/openAPI/index.d.ts
@@ -1,17 +1,19 @@
 /**
- * @typedef {object} OpenApiOpts
- * @property {string|undefined} [version]
- * @property {string|undefined} [title]
- * @property {string|undefined} [description]
- * @property {any[]|undefined} [servers]
+ * @typedef {object} OpenApiExtensions
+ * @property {string} [version]
+ * @property {string} [title]
+ * @property {string} [description]
+ * @property {any[]} [servers]
+ * @property {any[]} [components]
  */
 /**
  * @typedef {object} GenerateOpenApiOpts
  * @property {string} inputPath
  * @property {string} outputFile
- * @property {OpenApiOpts} [openApiOptions]
- * @property {string[]|undefined} [enabledGroups]
- * @property {boolean|undefined} [verbose]
+ * @property {OpenApiExtensions} [openApiExtensions]
+ * @property {Object<string,{security:string[]}>} [routeExtensions]
+ * @property {string[]} [enabledGroups]
+ * @property {boolean} [verbose]
  */
 /**
  * @param {Logger} logger
@@ -22,16 +24,24 @@ export function generateOpenApi(
   logger: Logger,
   options: GenerateOpenApiOpts,
 ): Promise<void>;
-export type OpenApiOpts = {
+export type OpenApiExtensions = {
   version?: string | undefined;
   title?: string | undefined;
   description?: string | undefined;
   servers?: any[] | undefined;
+  components?: any[] | undefined;
 };
 export type GenerateOpenApiOpts = {
   inputPath: string;
   outputFile: string;
-  openApiOptions?: OpenApiOpts | undefined;
+  openApiExtensions?: OpenApiExtensions | undefined;
+  routeExtensions?:
+    | {
+        [x: string]: {
+          security: string[];
+        };
+      }
+    | undefined;
   enabledGroups?: string[] | undefined;
   verbose?: boolean | undefined;
 };

--- a/packages/code-gen/src/generator/openAPI/index.d.ts
+++ b/packages/code-gen/src/generator/openAPI/index.d.ts
@@ -1,10 +1,14 @@
 /**
  * @typedef {object} OpenApiExtensions
+ * @property {OpenApiExtensionsInfo} [info]
+ * @property {any[]} [servers]
+ * @property {any[]} [components]
+ */
+/**
+ * @typedef {object} OpenApiExtensionsInfo
  * @property {string} [version]
  * @property {string} [title]
  * @property {string} [description]
- * @property {any[]} [servers]
- * @property {any[]} [components]
  */
 /**
  * @typedef {Object<string,object>} OpenApiRouteExtensions
@@ -28,11 +32,14 @@ export function generateOpenApi(
   options: GenerateOpenApiOpts,
 ): Promise<void>;
 export type OpenApiExtensions = {
+  info?: OpenApiExtensionsInfo | undefined;
+  servers?: any[] | undefined;
+  components?: any[] | undefined;
+};
+export type OpenApiExtensionsInfo = {
   version?: string | undefined;
   title?: string | undefined;
   description?: string | undefined;
-  servers?: any[] | undefined;
-  components?: any[] | undefined;
 };
 export type OpenApiRouteExtensions = {
   [x: string]: object;

--- a/packages/code-gen/src/generator/openAPI/index.d.ts
+++ b/packages/code-gen/src/generator/openAPI/index.d.ts
@@ -7,13 +7,16 @@
  * @property {any[]} [components]
  */
 /**
+ * @typedef {Object<string,object>} OpenApiRouteExtensions
+ */
+/**
  * @typedef {object} GenerateOpenApiOpts
  * @property {string} inputPath
  * @property {string} outputFile
- * @property {OpenApiExtensions} [openApiExtensions]
- * @property {Object<string,{security:string[]}>} [routeExtensions]
  * @property {string[]} [enabledGroups]
  * @property {boolean} [verbose]
+ * @property {OpenApiExtensions} [openApiExtensions]
+ * @property {OpenApiRouteExtensions} [openApiRouteExtensions]
  */
 /**
  * @param {Logger} logger
@@ -31,18 +34,19 @@ export type OpenApiExtensions = {
   servers?: any[] | undefined;
   components?: any[] | undefined;
 };
+export type OpenApiRouteExtensions = {
+  [x: string]: object;
+};
 export type GenerateOpenApiOpts = {
   inputPath: string;
   outputFile: string;
-  openApiExtensions?: OpenApiExtensions | undefined;
-  routeExtensions?:
-    | {
-        [x: string]: {
-          security: string[];
-        };
-      }
-    | undefined;
   enabledGroups?: string[] | undefined;
   verbose?: boolean | undefined;
+  openApiExtensions?: OpenApiExtensions | undefined;
+  openApiRouteExtensions?:
+    | {
+        [x: string]: any;
+      }
+    | undefined;
 };
 //# sourceMappingURL=index.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/index.js
+++ b/packages/code-gen/src/generator/openAPI/index.js
@@ -7,11 +7,16 @@ import { generateOpenApiFile } from "./generator.js";
 
 /**
  * @typedef {object} OpenApiExtensions
+ * @property {OpenApiExtensionsInfo} [info]
+ * @property {any[]} [servers]
+ * @property {any[]} [components]
+ */
+
+/**
+ * @typedef {object} OpenApiExtensionsInfo
  * @property {string} [version]
  * @property {string} [title]
  * @property {string} [description]
- * @property {any[]} [servers]
- * @property {any[]} [components]
  */
 
 /**

--- a/packages/code-gen/src/generator/openAPI/index.js
+++ b/packages/code-gen/src/generator/openAPI/index.js
@@ -15,13 +15,17 @@ import { generateOpenApiFile } from "./generator.js";
  */
 
 /**
+ * @typedef {Object<string,object>} OpenApiRouteExtensions
+ */
+
+/**
  * @typedef {object} GenerateOpenApiOpts
  * @property {string} inputPath
  * @property {string} outputFile
- * @property {OpenApiExtensions} [openApiExtensions]
- * @property {Object<string,{security:string[]}>} [routeExtensions]
  * @property {string[]} [enabledGroups]
  * @property {boolean} [verbose]
+ * @property {OpenApiExtensions} [openApiExtensions]
+ * @property {OpenApiRouteExtensions} [openApiRouteExtensions]
  */
 
 /**
@@ -63,6 +67,24 @@ export async function generateOpenApi(logger, options) {
         )}"`,
       );
     }
+  }
+
+  // Create set of RouteExtensions uniqueNames, pop one by one.
+  // if name left, a uniqueName is provided that does not exist
+  const routeExtensionsUniqueNames = new Set(
+    Object.keys(options?.openApiRouteExtensions ?? {}),
+  );
+  for (const group of Object.values(structure)) {
+    for (const type of Object.values(group)) {
+      routeExtensionsUniqueNames.delete(type.uniqueName);
+    }
+  }
+  if (routeExtensionsUniqueNames.size > 0) {
+    throw new Error(
+      `RouteExtension(s) provided for non existing uniqueName: ${Array.from(
+        routeExtensionsUniqueNames,
+      ).join(",")}`,
+    );
   }
 
   // if no enabledGroups are provided, take all groups in structure (without compas group)

--- a/packages/code-gen/src/generator/openAPI/index.js
+++ b/packages/code-gen/src/generator/openAPI/index.js
@@ -6,20 +6,22 @@ import { linkupReferencesInStructure } from "../linkup-references.js";
 import { generateOpenApiFile } from "./generator.js";
 
 /**
- * @typedef {object} OpenApiOpts
- * @property {string|undefined} [version]
- * @property {string|undefined} [title]
- * @property {string|undefined} [description]
- * @property {any[]|undefined} [servers]
+ * @typedef {object} OpenApiExtensions
+ * @property {string} [version]
+ * @property {string} [title]
+ * @property {string} [description]
+ * @property {any[]} [servers]
+ * @property {any[]} [components]
  */
 
 /**
  * @typedef {object} GenerateOpenApiOpts
  * @property {string} inputPath
  * @property {string} outputFile
- * @property {OpenApiOpts} [openApiOptions]
- * @property {string[]|undefined} [enabledGroups]
- * @property {boolean|undefined} [verbose]
+ * @property {OpenApiExtensions} [openApiExtensions]
+ * @property {Object<string,{security:string[]}>} [routeExtensions]
+ * @property {string[]} [enabledGroups]
+ * @property {boolean} [verbose]
  */
 
 /**
@@ -28,7 +30,7 @@ import { generateOpenApiFile } from "./generator.js";
  * @returns {Promise<void>}
  */
 export async function generateOpenApi(logger, options) {
-  options.openApiOptions = options?.openApiOptions ?? {};
+  options.openApiExtensions = options?.openApiExtensions ?? {};
 
   if (options.verbose) {
     logger.info({
@@ -40,6 +42,10 @@ export async function generateOpenApi(logger, options) {
     // @ts-ignore
     pathToFileURL(options.inputPath)
   );
+
+  /**
+   * @type {import("../../generated/common/types").CodeGenContext}
+   */
   const structure = JSON.parse(compasApiStructureString);
   if (!isPlainObject(structure)) {
     throw new Error(

--- a/packages/code-gen/src/generator/openAPI/transform.d.ts
+++ b/packages/code-gen/src/generator/openAPI/transform.d.ts
@@ -40,15 +40,12 @@ export function transformResponse(
   uniqueNameSet: Set<string>,
 ): any;
 /**
- *
- * @param {Object<string,import("../../generated/common/types").CodeGenStructure>} flattenStructure
+ * @param {import("../../generated/common/types").CodeGenStructure} groupStructure
  * @param {Set<string>} uniqueNameSet
  * @returns {Object<string, any>}
  */
 export function transformComponents(
-  flattenStructure: {
-    [x: string]: import("../../generated/common/types").CodeGenStructure;
-  },
+  groupStructure: import("../../generated/common/types").CodeGenStructure,
   uniqueNameSet: Set<string>,
 ): {
   [x: string]: any;

--- a/packages/code-gen/src/generator/openAPI/transform.d.ts
+++ b/packages/code-gen/src/generator/openAPI/transform.d.ts
@@ -3,13 +3,11 @@
  *
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
- * @param {Set<string>} uniqueNameSet
  * @returns {{parameters?: Object[]}}
  */
 export function transformParams(
   structure: import("../../generated/common/types").CodeGenStructure,
   route: import("../../generated/common/types").CodeGenRouteType,
-  uniqueNameSet: Set<string>,
 ): {
   parameters?: any[] | undefined;
 };
@@ -18,36 +16,25 @@ export function transformParams(
  *
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
- * @param {Set<string>} uniqueNameSet
+ * @param {Record<string, any>} existingSchemas
  * @returns {{requestBody?: Object}}
  */
 export function transformBody(
   structure: import("../../generated/common/types").CodeGenStructure,
   route: import("../../generated/common/types").CodeGenRouteType,
-  uniqueNameSet: Set<string>,
+  existingSchemas: Record<string, any>,
 ): {
   requestBody?: any;
 };
 /**
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
- * @param {Set<string>} uniqueNameSet
+ * @param {Record<string, any>} existingSchemas
  * @returns {any}
  */
 export function transformResponse(
   structure: import("../../generated/common/types").CodeGenStructure,
   route: import("../../generated/common/types").CodeGenRouteType,
-  uniqueNameSet: Set<string>,
+  existingSchemas: Record<string, any>,
 ): any;
-/**
- * @param {import("../../generated/common/types").CodeGenStructure} groupStructure
- * @param {Set<string>} uniqueNameSet
- * @returns {Object<string, any>}
- */
-export function transformComponents(
-  groupStructure: import("../../generated/common/types").CodeGenStructure,
-  uniqueNameSet: Set<string>,
-): {
-  [x: string]: any;
-};
 //# sourceMappingURL=transform.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/transform.d.ts
+++ b/packages/code-gen/src/generator/openAPI/transform.d.ts
@@ -1,38 +1,55 @@
 /**
+ * Transforms compas query params to OpenApi parameters objects
+ *
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
- * @returns {any}
+ * @param {Set<string>} uniqueNameSet
+ * @returns {{parameters?: Object[]}}
  */
 export function transformParams(
   structure: import("../../generated/common/types").CodeGenStructure,
   route: import("../../generated/common/types").CodeGenRouteType,
-): any;
+  uniqueNameSet: Set<string>,
+): {
+  parameters?: any[] | undefined;
+};
 /**
+ * Transform compas body and files to OpenApi requestBody object
+ *
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
- * @returns {any}
+ * @param {Set<string>} uniqueNameSet
+ * @returns {{requestBody?: Object}}
  */
 export function transformBody(
   structure: import("../../generated/common/types").CodeGenStructure,
   route: import("../../generated/common/types").CodeGenRouteType,
-): any;
+  uniqueNameSet: Set<string>,
+): {
+  requestBody?: any;
+};
 /**
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
+ * @param {Set<string>} uniqueNameSet
  * @returns {any}
  */
 export function transformResponse(
   structure: import("../../generated/common/types").CodeGenStructure,
   route: import("../../generated/common/types").CodeGenRouteType,
+  uniqueNameSet: Set<string>,
 ): any;
 /**
- * @param {import("../../generated/common/types").CodeGenStructure} structure
- * @param {(import("../../generated/common/types").CodeGenType)[]} components
+ *
+ * @param {Object<string,import("../../generated/common/types").CodeGenStructure>} flattenStructure
+ * @param {Set<string>} uniqueNameSet
  * @returns {Object<string, any>}
  */
 export function transformComponents(
-  structure: import("../../generated/common/types").CodeGenStructure,
-  components: import("../../generated/common/types").CodeGenType[],
+  flattenStructure: {
+    [x: string]: import("../../generated/common/types").CodeGenStructure;
+  },
+  uniqueNameSet: Set<string>,
 ): {
   [x: string]: any;
 };

--- a/packages/code-gen/src/generator/openAPI/transform.js
+++ b/packages/code-gen/src/generator/openAPI/transform.js
@@ -176,9 +176,12 @@ export function transformComponents(structure, components) {
    * @returns {any}
    */
   function transformTypes(component) {
-    const property = {
-      description: component.docString,
-    };
+    const property = {};
+
+    // set description, if docString is not empty
+    if (component.docString.length !== 0) {
+      property.description = component.docString;
+    }
 
     switch (component.type) {
       // primitive

--- a/packages/code-gen/src/generator/openAPI/transform.js
+++ b/packages/code-gen/src/generator/openAPI/transform.js
@@ -71,6 +71,8 @@ export function transformParams(structure, route) {
       case "reference":
         return transformGenType(
           key,
+
+          // @ts-ignore
           structure[param.reference.group][param.reference.name],
           paramType,
         );
@@ -110,9 +112,8 @@ export function transformBody(structure, route, existingSchemas) {
     return {};
   }
 
-  if (field?.reference) {
-    content.schema = transformTypes(structure, existingSchemas, field);
-  }
+  // @ts-ignore
+  content.schema = transformTypes(structure, existingSchemas, field);
 
   const contentType = route?.files ? "multipart/form-data" : "application/json";
 
@@ -144,10 +145,12 @@ export function transformResponse(structure, route, existingSchemas) {
     },
   };
 
-  if (route.response?.reference) {
+  if (route.response) {
     response.content["application/json"].schema = transformTypes(
       structure,
       existingSchemas,
+
+      // @ts-ignore
       route.response,
     );
   }
@@ -160,22 +163,24 @@ export function transformResponse(structure, route, existingSchemas) {
  *
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {Record<string, any>} existingSchemas
- * @param {import("../../generated/common/types").CodeGenType & {
- *   docString: string,
- * }} type
+ * @param {import("../../generated/common/types").CodeGenType} type
  * @returns {any}
  */
 function transformTypes(structure, existingSchemas, type) {
   let property = {};
 
   // set description, if docString is not empty
+  // @ts-ignore
   if (type.docString.length !== 0) {
+    // @ts-ignore
     property.description = type.docString;
   }
 
+  // @ts-ignore
   if (type.uniqueName && !isNil(existingSchemas[type.uniqueName])) {
     // We already went through this type, so just short circuit
     return {
+      // @ts-ignore
       $ref: `#/components/schemas/${type.uniqueName}`,
     };
   }
@@ -272,6 +277,8 @@ function transformTypes(structure, existingSchemas, type) {
       property = transformTypes(
         structure,
         existingSchemas,
+
+        // @ts-ignore
         structure[type.reference.group][type.reference.name],
       );
       break;
@@ -280,6 +287,7 @@ function transformTypes(structure, existingSchemas, type) {
       Object.assign(property, {
         type: "object",
         anyOf: Object.entries(type.values).reduce((curr, [, property]) => {
+          // @ts-ignore
           curr.push(transformTypes(structure, existingSchemas, property));
           return curr;
         }, []),
@@ -289,14 +297,18 @@ function transformTypes(structure, existingSchemas, type) {
 
   // If schema is named, we add it to the top level 'components.schemas' and we can
   // return a reference instead of the buildup property.
+  // @ts-ignore
   if (type.uniqueName) {
     // Only overwrite if not exists, since the first time the full property will be
     // build, but afterwards we only get a reference back.
+    // @ts-ignore
     if (isNil(existingSchemas[type.uniqueName])) {
+      // @ts-ignore
       existingSchemas[type.uniqueName] = property;
     }
 
     return {
+      // @ts-ignore
       $ref: `#/components/schemas/${type.uniqueName}`,
     };
   }

--- a/packages/code-gen/src/generator/openAPI/transform.js
+++ b/packages/code-gen/src/generator/openAPI/transform.js
@@ -165,15 +165,14 @@ export function transformResponse(structure, route, uniqueNameSet) {
 }
 
 /**
- *
- * @param {Object<string,import("../../generated/common/types").CodeGenStructure>} flattenStructure
+ * @param {import("../../generated/common/types").CodeGenStructure} groupStructure
  * @param {Set<string>} uniqueNameSet
  * @returns {Object<string, any>}
  */
-export function transformComponents(flattenStructure, uniqueNameSet) {
+export function transformComponents(groupStructure, uniqueNameSet) {
   const schemas = {};
 
-  const components = Object.values(flattenStructure).filter((it) =>
+  const components = Object.values(groupStructure).filter((it) =>
     // @ts-ignore
     uniqueNameSet.has(it.uniqueName),
   );

--- a/packages/code-gen/test/e2e/openapi.test.js
+++ b/packages/code-gen/test/e2e/openapi.test.js
@@ -143,11 +143,46 @@ test("code-gen/e2e/openapi", async (t) => {
       inputPath: serverGeneratedDirectory,
       outputFile,
       enabledGroups: ["server", "group"],
-      openApiOptions: {
+      openApiExtensions: {
         version: "0.0.99",
         title: "Compas Test server OpenAPI Docs",
         description: "Lorem ipsum",
         servers: [{ url: "https://api.compasjs.com" }],
+        components: {
+          securitySchemes: {
+            production: {
+              type: "oauth2",
+              flows: {
+                clientCredentials: {
+                  tokenUrl: "https://api.compasjs.com/token",
+                  scopes: {
+                    read: "Allow to read",
+                  },
+                },
+              },
+            },
+            acceptance: {
+              type: "oauth2",
+              flows: {
+                clientCredentials: {
+                  tokenUrl: "https://api.compasjs.com/token",
+                  scopes: {
+                    read: "Allow to read",
+                    write: "Allow to write",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      routeExtensions: {
+        fooBar: {
+          security: {
+            acceptance: ["read", "write"],
+            production: ["read"],
+          },
+        },
       },
     });
 

--- a/packages/code-gen/test/e2e/openapi.test.js
+++ b/packages/code-gen/test/e2e/openapi.test.js
@@ -43,6 +43,7 @@ test("code-gen/e2e/openapi", async (t) => {
           T.object("root").keys({
             value: T.object("nested").keys({
               bool: T.bool(),
+              // input: T.reference("server", "input"),
             }),
           }),
         ),
@@ -179,10 +180,10 @@ test("code-gen/e2e/openapi", async (t) => {
       openApiRouteExtensions: {
         GroupUpload: {
           // used one of server routes
-          security: {
-            acceptance: ["read", "write"],
-            production: ["read"],
-          },
+          security: [
+            { acceptance: ["read", "write"] },
+            { production: ["read"] },
+          ],
         },
       },
     });

--- a/packages/code-gen/test/e2e/openapi.test.js
+++ b/packages/code-gen/test/e2e/openapi.test.js
@@ -145,9 +145,11 @@ test("code-gen/e2e/openapi", async (t) => {
       outputFile,
       enabledGroups: ["server", "group"],
       openApiExtensions: {
-        version: "0.0.99",
-        title: "Compas Test server OpenAPI Docs",
-        description: "Lorem ipsum",
+        info: {
+          version: "0.0.99",
+          title: "Compas Test server OpenAPI Docs",
+          description: "Lorem ipsum",
+        },
         servers: [{ url: "https://api.compasjs.com" }],
         components: {
           securitySchemes: {
@@ -189,6 +191,26 @@ test("code-gen/e2e/openapi", async (t) => {
     });
 
     t.pass();
+  });
+
+  t.test("error with unknown uniqueName / routes", async (t) => {
+    try {
+      const app = new App();
+      await app.generateOpenApi({
+        inputPath: serverGeneratedDirectory,
+        outputFile,
+        enabledGroups: ["server"],
+        openApiExtensions: {},
+        openApiRouteExtensions: {
+          NonExistingKey: {}, // <-- incorrect
+        },
+      });
+    } catch (e) {
+      t.equal(
+        e.message,
+        `RouteExtension(s) provided for non existing uniqueName: NonExistingKey`,
+      );
+    }
   });
 
   t.test("assert spec version", async (t) => {

--- a/packages/code-gen/test/e2e/route-invalidation.test.js
+++ b/packages/code-gen/test/e2e/route-invalidation.test.js
@@ -321,8 +321,6 @@ test("code-gen/e2e/route-invalidation", (t) => {
 
     const sourceWithoutNewLines = source.split(/\r?\n/gi).join("");
 
-    t.log.info(sourceWithoutNewLines);
-
     t.test("get - skips hookOptions", (t) => {
       t.ok(
         sourceWithoutNewLines.includes(

--- a/packages/code-gen/test/utils.test.js
+++ b/packages/code-gen/test/utils.test.js
@@ -16,6 +16,7 @@ import { App } from "../src/App.js";
  *   add?: Parameters<typeof App.prototype.add>,
  *   extend?: Parameters<typeof App.prototype.extend>[],
  *   extendWithOpenApi?: Parameters<typeof App.prototype.extendWithOpenApi>[],
+ *
  * }|TypeBuilderLike[]} input
  * @param {GenerateOpts} [opts]
  * @returns {Promise<{ stdout: string, exitCode: number }>}

--- a/packages/lint-config/package.json
+++ b/packages/lint-config/package.json
@@ -27,7 +27,8 @@
       "email": "dirkdev98@gmail.com"
     },
     {
-      "name": "Daniël Hansen"
+      "name": "Daniël Hansen",
+      "email": "hi@danielhansen.nl"
     }
   ],
   "homepage": "https://compasjs.com",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,8 @@
       "email": "dirkdev98@gmail.com"
     },
     {
-      "name": "Daniël Hansen"
+      "name": "Daniël Hansen",
+      "email": "hi@danielhansen.nl"
     }
   ],
   "homepage": "https://compasjs.com",

--- a/packages/stdlib/package.json
+++ b/packages/stdlib/package.json
@@ -25,7 +25,8 @@
       "email": "dirkdev98@gmail.com"
     },
     {
-      "name": "Daniël Hansen"
+      "name": "Daniël Hansen",
+      "email": "hi@danielhansen.nl"
     }
   ],
   "homepage": "https://compasjs.com",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -32,7 +32,8 @@
       "email": "dirkdev98@gmail.com"
     },
     {
-      "name": "Daniël Hansen"
+      "name": "Daniël Hansen",
+      "email": "hi@danielhansen.nl"
     }
   ],
   "homepage": "https://compasjs.com",

--- a/src/testing.js
+++ b/src/testing.js
@@ -1,5 +1,4 @@
-import { mkdir } from "fs/promises";
-import { rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { uuid } from "@compas/stdlib";
 import { createTestPostgresDatabase } from "@compas/store";
 


### PR DESCRIPTION
Extend the generator with (security) pass-through properties. Also make generator output more strict (and clean).

- [x] Remove `externalDocs` properties. Because used incorrectly
- [x] Strip empty `description` properties on components
- [x] Exclude `Params` reference types, because there're not used 
- [x] Update author name/email in package.json (s)
- [x] Change property order of generated spec: make more human readable
- [x] Resolve used refs
- [x] Rename `openApiOptions` to `openApiExtension`
- [x] Implement pass-through properties (security)
    - [x] Add `components` on `openApiExtension`
    - [x] Add `routeExtensions`


Target spec
```js
await app.generateOpenApi({
  inputPath: "./generated/testing/server",
  outputFile: "./generated/testing/server/common/openapi.json",
  enabledGroups: ["server", "group"],
  openApiExtensions: {
    version: "0.0.99",
    title: "Compas Test server OpenAPI Docs",
    description: "Lorem ipsum",
    servers: [{ url: "https://api.compasjs.com" }],
    components: {
      securitySchemes: {
        production: {
          type: "oauth2",
          flows: {
            clientCredentials: {
              tokenUrl: "https://api.compasjs.com/token",
              scopes: {
                read: "Allow to read",
              },
            },
          },
        },
        acceptance: {
          type: "oauth2",
          flows: {
            clientCredentials: {
              tokenUrl: "https://api.compasjs.com/token",
              scopes: {
                read: "Allow to read",
                write: "Allow to write",
              },
            },
          },
        },
      },
    },
  },
  routeExtensions: {
    fooBar: {
       security: [
          { acceptance: ["read", "write"] },
          { production: ["read"] },
       ],
    },
  },
});
```

Closes: https://github.com/compasjs/compas/issues/1520