### PR TITLE
feat(lint-config): add preferredTypes for primitives, objects and records

### DIFF
--- a/packages/cli/src/code-mod/constants.js
+++ b/packages/cli/src/code-mod/constants.js
@@ -5,7 +5,7 @@ import { executeCodeModVZeroDotZeroDotHundredFortySix } from "./mods/v0.0.146.js
 export const PARALLEL_COUNT = Math.max(cpus().length - 1, 1);
 
 /**
- * @type {Object<string, {
+ * @type {Record<string, {
  *    description: string,
  *    exec: (event: InsightEvent, verbose: boolean) => Promise<void>
  * }>}

--- a/packages/cli/src/code-mod/mods/v0.0.142.js
+++ b/packages/cli/src/code-mod/mods/v0.0.142.js
@@ -124,7 +124,7 @@ async function listGeneratedReactQueryFiles(event) {
  *
  * @param {InsightEvent} event
  * @param {string[]} fileList
- * @returns {Promise<Object<string, { parameters: string [] }>>}
+ * @returns {Promise<Record<string, {parameters: string[]}>>}
  */
 async function collectGeneratedReactQueryHooks(event, fileList) {
   eventStart(event, "v00142.collectGeneratedReactQueryHooks");

--- a/packages/code-gen/src/generator/openAPI/generator.js
+++ b/packages/code-gen/src/generator/openAPI/generator.js
@@ -119,7 +119,7 @@ export function generateOpenApiFile(structure, options) {
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
  * @param {Record<string, any>} existingSchemas
- * @returns {Object}
+ * @returns {object}
  */
 function constructResponse(structure, route, existingSchemas) {
   const contentAppError = {

--- a/packages/code-gen/src/generator/openAPI/index.js
+++ b/packages/code-gen/src/generator/openAPI/index.js
@@ -20,7 +20,7 @@ import { generateOpenApiFile } from "./generator.js";
  */
 
 /**
- * @typedef {Object<string,object>} OpenApiRouteExtensions
+ * @typedef {Record<string, object>} OpenApiRouteExtensions
  */
 
 /**

--- a/packages/code-gen/src/generator/openAPI/transform.js
+++ b/packages/code-gen/src/generator/openAPI/transform.js
@@ -5,7 +5,7 @@ import { isNil } from "@compas/stdlib";
  *
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
- * @returns {{parameters?: Object[]}}
+ * @returns {{parameters?: object[]}}
  */
 export function transformParams(structure, route) {
   if (!route?.params && !route?.query) {
@@ -102,7 +102,7 @@ export function transformParams(structure, route) {
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
  * @param {Record<string, any>} existingSchemas
- * @returns {{requestBody?: Object}}
+ * @returns {{requestBody?: object}}
  */
 export function transformBody(structure, route, existingSchemas) {
   const content = {};

--- a/packages/code-gen/src/template.js
+++ b/packages/code-gen/src/template.js
@@ -15,7 +15,7 @@ import { lowerCaseFirst, upperCaseFirst } from "./utils.js";
  */
 
 /**
- * @type {{context: Object<string, Function>, globals: Object<string, Function>}}
+ * @type {{context: Record<string, Function>, globals: Record<string, Function>}}
  */
 export const templateContext = {
   globals: {

--- a/packages/lint-config/index.js
+++ b/packages/lint-config/index.js
@@ -16,6 +16,18 @@ const settings = {
   settings: {
     jsdoc: {
       mode: "typescript",
+      preferredTypes: {
+        Object: "object",
+        "object<>": "Record<>",
+        "Object<>": "Record<>",
+        "object.<>": "Record<>",
+        "Object.<>": "Record<>",
+        "Array.<>": "[]",
+        "Array<>": "[]",
+        String: "string",
+        Boolean: "boolean",
+        Number: "number",
+      },
     },
   },
   parser: "@babel/eslint-parser",

--- a/packages/store/src/queue.js
+++ b/packages/store/src/queue.js
@@ -669,7 +669,7 @@ export function getNextScheduledAt(scheduledAt, interval) {
  * Useful for testing if jobs are created.
  *
  * @param {Postgres} sql
- * @returns {Promise<Object<string, QueryResultStoreJob[]>>}
+ * @returns {Promise<Record<string, QueryResultStoreJob[]>>}
  */
 export async function getUncompletedJobsByName(sql) {
   const jobs = await queryJob({

--- a/packages/store/src/session-store.js
+++ b/packages/store/src/session-store.js
@@ -6,7 +6,7 @@ import {
   newEventFromEvent,
   uuid,
 } from "@compas/stdlib";
-import crc from "crc";
+import { crc32 } from "crc";
 import { createSign, createVerify } from "jws";
 import { queries } from "./generated.js";
 import { querySessionStore } from "./generated/database/sessionStore.js";
@@ -720,7 +720,7 @@ export async function sessionStoreVerifyAndDecodeJWT(
  * @returns {string}
  */
 function sessionStoreChecksumForData(data) {
-  return crc.crc32(JSON.stringify(data ?? {})).toString(16);
+  return crc32(JSON.stringify(data ?? {})).toString(16);
 }
 
 /**


### PR DESCRIPTION

BREAKING CHANGE:
- Linter prefers `object` over `Object`, `boolean` over `Boolean`, `Record<string,number>[]` over `Array<Object<string, number>>` etc. The linter will try to autofix this, but may require multiple runs.