### PR TITLE
feat(stdlib): add `setGlobalLoggerOptions` and 'extendGlobalLoggerContext`

### DIFF
--- a/docs/features/logger-and-events.md
+++ b/docs/features/logger-and-events.md
@@ -32,9 +32,6 @@ Parameters:
   - `stream` (Stream): The stream to write to, defaults to `process.stdout`.
     This is the intended use case. Although streams to files may work, this is
     not supported. This option is ignored if the printer is `ndjson`.
-  - `pinoOptions`: Specify a custom Pino transport or destination. See the
-    [Pino docs](https://getpino.io) for more information. This field is only
-    used if the printer is `ndjson`.
   - `ctx` (object): Any context to add to log lines. This value is copied
     immediately on logger creation, so changes made via a reference, will not be
     reflected.
@@ -52,6 +49,22 @@ A logger is a plain JavaScript object with 3 functions:
 
 The info and error function accept a single argument that is logged. This
 happens in a single `write` call when pretty printing or not.
+
+### setGlobalLogOptions
+
+There is also some global log configuration that can be set. For now these
+options only apply to the 'ndjson' logger. You can specify a custom Pino
+transport or destination that is used for all loggers created after calling this
+function. See the [Pino docs](https://getpino.io) for more information on what
+you can pass in.
+
+### extendGlobalLoggerContext
+
+An application is able to gradually add more information to the shared context
+used by loggers. All properties added via this function will end up in each log
+line like the 'ctx' option of 'newLogger'. You can still overwrite values via
+the `ctx` option of `newLogger`. The added properties will only show up in
+loggers created after calling this function.
 
 ### On log levels and processing
 

--- a/packages/cli/src/code-mod/constants.d.ts
+++ b/packages/cli/src/code-mod/constants.d.ts
@@ -1,14 +1,15 @@
 export const PARALLEL_COUNT: number;
 /**
- * @type {Object<string, {
+ * @type {Record<string, {
  *    description: string,
  *    exec: (event: InsightEvent, verbose: boolean) => Promise<void>
  * }>}
  */
-export const codeModMap: {
-  [x: string]: {
+export const codeModMap: Record<
+  string,
+  {
     description: string;
     exec: (event: InsightEvent, verbose: boolean) => Promise<void>;
-  };
-};
+  }
+>;
 //# sourceMappingURL=constants.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/index.d.ts
+++ b/packages/code-gen/src/generator/openAPI/index.d.ts
@@ -11,7 +11,7 @@
  * @property {string} [description]
  */
 /**
- * @typedef {Object<string,object>} OpenApiRouteExtensions
+ * @typedef {Record<string, object>} OpenApiRouteExtensions
  */
 /**
  * @typedef {object} GenerateOpenApiOpts
@@ -41,19 +41,13 @@ export type OpenApiExtensionsInfo = {
   title?: string | undefined;
   description?: string | undefined;
 };
-export type OpenApiRouteExtensions = {
-  [x: string]: object;
-};
+export type OpenApiRouteExtensions = Record<string, object>;
 export type GenerateOpenApiOpts = {
   inputPath: string;
   outputFile: string;
   enabledGroups?: string[] | undefined;
   verbose?: boolean | undefined;
   openApiExtensions?: OpenApiExtensions | undefined;
-  openApiRouteExtensions?:
-    | {
-        [x: string]: any;
-      }
-    | undefined;
+  openApiRouteExtensions?: Record<string, any> | undefined;
 };
 //# sourceMappingURL=index.d.ts.map

--- a/packages/code-gen/src/generator/openAPI/transform.d.ts
+++ b/packages/code-gen/src/generator/openAPI/transform.d.ts
@@ -3,7 +3,7 @@
  *
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
- * @returns {{parameters?: Object[]}}
+ * @returns {{parameters?: object[]}}
  */
 export function transformParams(
   structure: import("../../generated/common/types").CodeGenStructure,
@@ -17,14 +17,14 @@ export function transformParams(
  * @param {import("../../generated/common/types").CodeGenStructure} structure
  * @param {import("../../generated/common/types").CodeGenRouteType} route
  * @param {Record<string, any>} existingSchemas
- * @returns {{requestBody?: Object}}
+ * @returns {{requestBody?: object}}
  */
 export function transformBody(
   structure: import("../../generated/common/types").CodeGenStructure,
   route: import("../../generated/common/types").CodeGenRouteType,
   existingSchemas: Record<string, any>,
 ): {
-  requestBody?: any;
+  requestBody?: object;
 };
 /**
  * @param {import("../../generated/common/types").CodeGenStructure} structure

--- a/packages/code-gen/src/template.d.ts
+++ b/packages/code-gen/src/template.d.ts
@@ -36,15 +36,11 @@ export function executeTemplate(name: string, data: any): string;
  * } ProcessDirectoryOptions
  */
 /**
- * @type {{context: Object<string, Function>, globals: Object<string, Function>}}
+ * @type {{context: Record<string, Function>, globals: Record<string, Function>}}
  */
 export const templateContext: {
-  context: {
-    [x: string]: Function;
-  };
-  globals: {
-    [x: string]: Function;
-  };
+  context: Record<string, Function>;
+  globals: Record<string, Function>;
 };
 export type ProcessDirectoryOptions =
   import("@compas/stdlib").ProcessDirectoryOptions;

--- a/packages/stdlib/index.d.ts
+++ b/packages/stdlib/index.d.ts
@@ -1,6 +1,5 @@
 export { uuid } from "./src/datatypes.js";
 export { AppError } from "./src/error.js";
-export { newLogger } from "./src/logger/logger.js";
 export type Either<T, E> = import("./types/advanced-types").Either<T, E>;
 export type EitherN<T, E> = import("./types/advanced-types").EitherN<T, E>;
 export type Logger = import("./types/advanced-types").Logger;
@@ -47,6 +46,11 @@ export {
   filenameForModule,
   dirnameForModule,
 } from "./src/utils.js";
+export {
+  newLogger,
+  extendGlobalLoggerContext,
+  setGlobalLoggerOptions,
+} from "./src/logger/logger.js";
 export { bytesToHumanReadable, printProcessMemoryUsage } from "./src/memory.js";
 export {
   newEvent,

--- a/packages/stdlib/index.js
+++ b/packages/stdlib/index.js
@@ -75,7 +75,11 @@ export {
   dirnameForModule,
 } from "./src/utils.js";
 
-export { newLogger } from "./src/logger/logger.js";
+export {
+  newLogger,
+  extendGlobalLoggerContext,
+  setGlobalLoggerOptions,
+} from "./src/logger/logger.js";
 
 export { bytesToHumanReadable, printProcessMemoryUsage } from "./src/memory.js";
 

--- a/packages/stdlib/src/logger/logger.d.ts
+++ b/packages/stdlib/src/logger/logger.d.ts
@@ -1,6 +1,20 @@
 /**
- * @typedef {import("../../types/advanced-types").LoggerOptions} LoggerOptions
+ * Shallow assigns properties of the provided context to the global context.
+ * These properties can still be overwritten by providing the 'ctx' property when
+ * creating a new Logger.
+ *
+ * @param {Record<string, any>} context
  */
+export function extendGlobalLoggerContext(context: Record<string, any>): void;
+/**
+ * Set various logger options, affecting loggers created after calling this function.
+ *
+ * @param {GlobalLoggerOptions} options
+ */
+export function setGlobalLoggerOptions({
+  pinoTransport,
+  pinoDestination,
+}: GlobalLoggerOptions): void;
 /**
  * Create a new logger instance
  *
@@ -14,4 +28,22 @@ export function newLogger(
 ): import("../../types/advanced-types.js").Logger;
 export type LoggerOptions =
   import("../../types/advanced-types").LoggerOptions<any>;
+export type GlobalLoggerOptions = {
+  /**
+   * Set pino
+   * transport, only used if the printer is 'ndjson'.
+   */
+  pinoTransport?:
+    | pino.TransportSingleOptions<unknown>
+    | pino.TransportMultiOptions<unknown>
+    | pino.TransportPipelineOptions<unknown>
+    | undefined;
+  /**
+   * Set Pino
+   * destination, only used if the printer is 'ndjson' and no 'pinoTransport' is
+   * provided. Use `pino.destination()` create the destination or provide a stream.
+   */
+  pinoDestination?: import("pino").DestinationStream | undefined;
+};
+import { pino } from "pino";
 //# sourceMappingURL=logger.d.ts.map

--- a/packages/stdlib/src/logger/logger.test.js
+++ b/packages/stdlib/src/logger/logger.test.js
@@ -1,5 +1,6 @@
 import { mainTestFn, test } from "@compas/cli";
-import { newLogger } from "./logger.js";
+import pino from "pino";
+import { newLogger, setGlobalLoggerOptions } from "./logger.js";
 
 mainTestFn(import.meta);
 
@@ -7,15 +8,16 @@ test("stdlib/logger", (t) => {
   const getLogInstanceWithMockedWrite = () => {
     const logLines = [];
 
-    const logger = newLogger({
-      printer: "ndjson",
-      pinoOptions: {
-        destination: {
-          write(line) {
-            logLines.push(JSON.parse(line));
-          },
+    setGlobalLoggerOptions({
+      pinoDestination: {
+        write(line) {
+          logLines.push(JSON.parse(line));
         },
       },
+    });
+
+    const logger = newLogger({
+      printer: "ndjson",
     });
 
     return { logger, logLines };
@@ -64,5 +66,10 @@ test("stdlib/logger", (t) => {
     t.equal(logLines[1].message, 5);
     t.equal(logLines[2].message, "foo");
     t.deepEqual(logLines[3].message, { foo: "bar" });
+  });
+
+  t.test("teardown", (t) => {
+    setGlobalLoggerOptions({ pinoDestination: pino.destination(1) });
+    t.pass();
   });
 });

--- a/packages/stdlib/src/utils.js
+++ b/packages/stdlib/src/utils.js
@@ -5,9 +5,10 @@ import { setFlagsFromString } from "v8";
 import { runInNewContext } from "vm";
 import { newLogger } from "@compas/stdlib";
 import dotenv from "dotenv";
-import { refreshEnvironmentCache } from "./env.js";
+import { environment, isProduction, refreshEnvironmentCache } from "./env.js";
 import { AppError } from "./error.js";
 import { isNil } from "./lodash.js";
+import { extendGlobalLoggerContext } from "./logger/logger.js";
 
 /**
  * @typedef {import("../types/advanced-types.js").Logger} Logger
@@ -79,6 +80,12 @@ export function mainFn(meta, cb) {
   dotenv.config();
 
   refreshEnvironmentCache();
+
+  if (isProduction() && environment.APP_NAME) {
+    extendGlobalLoggerContext({
+      application: environment.APP_NAME,
+    });
+  }
 
   const logger = newLogger({
     ctx: { type: name },

--- a/packages/stdlib/types/advanced-types.d.ts
+++ b/packages/stdlib/types/advanced-types.d.ts
@@ -1,6 +1,4 @@
 import { RandomUUIDOptions } from "crypto";
-import Pino from "pino";
-import { SonicBoom } from "sonic-boom";
 
 import { AppError } from "../src/error.js";
 
@@ -125,25 +123,6 @@ export interface LoggerOptions<T extends LoggerContext> {
    * The stream to write the logs to, is not used for the 'ndjson' printer
    */
   stream?: NodeJS.WriteStream;
-
-  /**
-   * Supported Pino options if the 'ndjson' logger is used
-   */
-  pinoOptions?:
-    | {
-        transport?:
-          | Pino.TransportSingleOptions
-          | Pino.TransportMultiOptions
-          | Pino.TransportPipelineOptions;
-        destination?:
-          | string
-          | number
-          | Pino.DestinationObjectOptions
-          | Pino.DestinationStream
-          | NodeJS.WritableStream
-          | SonicBoom;
-      }
-    | undefined;
 
   /**
    * Context that should be logged in all log lines. e.g

--- a/packages/store/src/queue.d.ts
+++ b/packages/store/src/queue.d.ts
@@ -108,11 +108,11 @@ export function getNextScheduledAt(
  * Useful for testing if jobs are created.
  *
  * @param {Postgres} sql
- * @returns {Promise<Object<string, QueryResultStoreJob[]>>}
+ * @returns {Promise<Record<string, QueryResultStoreJob[]>>}
  */
-export function getUncompletedJobsByName(sql: Postgres): Promise<{
-  [x: string]: QueryResultStoreJob[];
-}>;
+export function getUncompletedJobsByName(
+  sql: Postgres,
+): Promise<Record<string, QueryResultStoreJob[]>>;
 /**
  * The queue system is based on 'static' units of work to be done in the background.
  * It supports the following:


### PR DESCRIPTION

We need this because loggers can be created via Compas internals like the log middleware provided by @compas/server.

Closes #1539

BREAKING CHANGE:
- Removed support for `pinoOption` via `newLogger`. Pass these to `setGlobalLoggerOptions` as `pinoTransport` and `pinoDestination`.