### PR TITLE
chore(docs): remove last updated from pages

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -2,7 +2,6 @@ module.exports = {
   lang: "en-US",
   title: "Compas",
   description: "Unified backend tooling",
-  lastUpdated: true,
 
   themeConfig: {
     repo: "compasjs/compas",
@@ -11,7 +10,6 @@ module.exports = {
 
     editLinks: true,
     editLinkText: "Edit this page on GitHub",
-    lastUpdated: "Last updated",
 
     nav: [
       {


### PR DESCRIPTION
This was always wrong because it uses git checkout time, instead of last changed time.