### PR TITLE
feat(store): add support for file access tokens

### DIFF
--- a/packages/code-gen/src/generator/router/invalidations.js
+++ b/packages/code-gen/src/generator/router/invalidations.js
@@ -119,8 +119,11 @@ function processInvalidation(context, route, invalidation) {
           continue;
         }
 
-        invalidation.properties.specification =
-          invalidation.properties.specification ?? {};
+        invalidation.properties.specification = invalidation.properties
+          .specification ?? {
+          params: {},
+          query: {},
+        };
         invalidation.properties.specification[specificationKey] =
           invalidation.properties.specification[specificationKey] ?? {};
         invalidation.properties.specification[specificationKey][targetParam] = [

--- a/packages/store/index.d.ts
+++ b/packages/store/index.d.ts
@@ -48,8 +48,8 @@ export {
   copyFile,
   getFileStream,
   syncDeletedFiles,
-  fileGetSignedAccessToken,
-  fileVerifyAndDecodeAccessToken,
+  fileSignAccessToken,
+  fileVerifyAccessToken,
 } from "./src/files.js";
 export {
   hoistChildrenToParent,

--- a/packages/store/index.d.ts
+++ b/packages/store/index.d.ts
@@ -48,6 +48,8 @@ export {
   copyFile,
   getFileStream,
   syncDeletedFiles,
+  fileGetSignedAccessToken,
+  fileVerifyAndDecodeAccessToken,
 } from "./src/files.js";
 export {
   hoistChildrenToParent,

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -30,7 +30,8 @@
  */
 
 /**
- * @typedef {import("./src/session-transport.js").SessionTransportSettings} SessionTransportSettings
+ * @typedef {import("./src/session-transport.js").SessionTransportSettings}
+ *   SessionTransportSettings
  */
 
 export { structure as storeStructure } from "./src/generated/common/structure.js";
@@ -74,6 +75,8 @@ export {
   copyFile,
   getFileStream,
   syncDeletedFiles,
+  fileSignAccessToken,
+  fileVerifyAndDecodeAccessToken,
 } from "./src/files.js";
 
 export {

--- a/packages/store/index.js
+++ b/packages/store/index.js
@@ -76,7 +76,7 @@ export {
   getFileStream,
   syncDeletedFiles,
   fileSignAccessToken,
-  fileVerifyAndDecodeAccessToken,
+  fileVerifyAccessToken,
 } from "./src/files.js";
 
 export {

--- a/packages/store/src/files.d.ts
+++ b/packages/store/src/files.d.ts
@@ -131,7 +131,7 @@ export function syncDeletedFiles(
  * Generate a signed string, based on the file id and the max age that it is allowed ot
  * be accessed.
  *
- * @see {fileVerifyAndDecodeAccessToken}
+ * @see {fileVerifyAccessToken}
  *
  * @param {{
  *   fileId: string,
@@ -140,7 +140,7 @@ export function syncDeletedFiles(
  * }} options
  * @returns {string}
  */
-export function fileGetSignedAccessToken(options: {
+export function fileSignAccessToken(options: {
   fileId: string;
   signingKey: string;
   maxAgeInSeconds: number;
@@ -149,16 +149,18 @@ export function fileGetSignedAccessToken(options: {
  * Verify and decode the fileAccessToken returning the fileId that it was signed for.
  * Returns an Either<fileId: string, AppError>
  *
- * @see {fileGetSignedAccessToken}
+ * @see {fileSignAccessToken}
  *
  * @param {{
  *   fileAccessToken: string,
  *   signingKey: string,
+ *   expectedFileId: string,
  * }} options
- * @returns {import("@compas/stdlib").Either<string, import("@compas/stdlib").AppError>}
+ * @returns {void}
  */
-export function fileVerifyAndDecodeAccessToken(options: {
+export function fileVerifyAccessToken(options: {
   fileAccessToken: string;
   signingKey: string;
-}): import("@compas/stdlib").Either<string, import("@compas/stdlib").AppError>;
+  expectedFileId: string;
+}): void;
 //# sourceMappingURL=files.d.ts.map

--- a/packages/store/src/files.d.ts
+++ b/packages/store/src/files.d.ts
@@ -127,4 +127,38 @@ export function syncDeletedFiles(
   minio: import("../types/advanced-types").MinioClient,
   bucketName: string,
 ): Promise<number>;
+/**
+ * Generate a signed string, based on the file id and the max age that it is allowed ot
+ * be accessed.
+ *
+ * @see {fileVerifyAndDecodeAccessToken}
+ *
+ * @param {{
+ *   fileId: string,
+ *   signingKey: string,
+ *   maxAgeInSeconds: number,
+ * }} options
+ * @returns {string}
+ */
+export function fileGetSignedAccessToken(options: {
+  fileId: string;
+  signingKey: string;
+  maxAgeInSeconds: number;
+}): string;
+/**
+ * Verify and decode the fileAccessToken returning the fileId that it was signed for.
+ * Returns an Either<fileId: string, AppError>
+ *
+ * @see {fileGetSignedAccessToken}
+ *
+ * @param {{
+ *   fileAccessToken: string,
+ *   signingKey: string,
+ * }} options
+ * @returns {import("@compas/stdlib").Either<string, import("@compas/stdlib").AppError>}
+ */
+export function fileVerifyAndDecodeAccessToken(options: {
+  fileAccessToken: string;
+  signingKey: string;
+}): import("@compas/stdlib").Either<string, import("@compas/stdlib").AppError>;
 //# sourceMappingURL=files.d.ts.map

--- a/packages/store/src/files.js
+++ b/packages/store/src/files.js
@@ -5,6 +5,7 @@ import {
   fileTypeFromFile,
   fileTypeStream,
 } from "file-type";
+import { decode, sign, verify } from "jws";
 import mime from "mime-types";
 import { queries } from "./generated.js";
 import { queryFile } from "./generated/database/file.js";
@@ -95,8 +96,7 @@ export async function createOrUpdateFile(
       const result = await fileTypeFromFile(source);
       contentType = result?.mime;
     } else if (
-      typeof source?.pipe === "function" &&
-      // @ts-ignore
+      typeof source?.pipe === "function" && // @ts-ignore
       typeof source?._read === "function"
     ) {
       // @ts-ignore
@@ -253,4 +253,102 @@ export async function syncDeletedFiles(sql, minio, bucketName) {
   await minio.removeObjects(bucketName, deletingSet);
 
   return deletingSet.length;
+}
+
+/**
+ * Generate a signed string, based on the file id and the max age that it is allowed ot
+ * be accessed.
+ *
+ * @see {fileVerifyAndDecodeAccessToken}
+ *
+ * @param {{
+ *   fileId: string,
+ *   signingKey: string,
+ *   maxAgeInSeconds: number,
+ * }} options
+ * @returns {string}
+ */
+export function fileSignAccessToken(options) {
+  if (
+    typeof options.fileId !== "string" ||
+    typeof options.signingKey !== "string" ||
+    typeof options.maxAgeInSeconds !== "number"
+  ) {
+    throw AppError.serverError({
+      message:
+        "Incorrect arguments to 'fileSignAccessToken'. Expects fileId: string, signingKey: string, maxAgeInSeconds: number.",
+    });
+  }
+
+  const d = new Date();
+  d.setSeconds(d.getSeconds() + options.maxAgeInSeconds);
+
+  return sign({
+    header: {
+      alg: "HS256",
+      typ: "JWT",
+    },
+    secret: options.signingKey,
+    payload: {
+      fileId: options.fileId,
+      exp: Math.floor(d.getTime() / 1000),
+    },
+  });
+}
+
+/**
+ * Verify and decode the fileAccessToken returning the fileId that it was signed for.
+ * Returns an Either<fileId: string, AppError>
+ *
+ * @see {fileSignAccessToken}
+ *
+ * @param {{
+ *   fileAccessToken: string,
+ *   signingKey: string,
+ * }} options
+ * @returns {import("@compas/stdlib").Either<string, import("@compas/stdlib").AppError>}
+ */
+export function fileVerifyAndDecodeAccessToken(options) {
+  if (
+    typeof options.fileAccessToken !== "string" ||
+    typeof options.signingKey !== "string"
+  ) {
+    throw AppError.serverError({
+      message:
+        "Incorrect arguments to 'fileVerifyAndDecodeSignedAccessToken'. Expects fileAccessToken: string, signingKey: string.",
+    });
+  }
+
+  const isValid = verify(options.fileAccessToken, "HS256", options.signingKey);
+
+  if (!isValid) {
+    return {
+      error: AppError.validationError(
+        "file.verifyAndDecodeAccessToken.invalidToken",
+        {},
+      ),
+    };
+  }
+
+  const decoded = decode(options.fileAccessToken);
+
+  if (decoded.payload.exp * 1000 < Date.now()) {
+    return {
+      error: AppError.validationError(
+        `file.verifyAndDecodeAccessToken.expiredToken`,
+      ),
+    };
+  }
+
+  if (isNil(decoded.payload.fileId)) {
+    return {
+      error: AppError.validationError(
+        `file.verifyAndDecodeAccessToken.invalidToken`,
+      ),
+    };
+  }
+
+  return {
+    value: decoded.payload.fileId,
+  };
 }

--- a/packages/store/src/files.test.js
+++ b/packages/store/src/files.test.js
@@ -1,9 +1,12 @@
 import { createReadStream, createWriteStream, readFileSync } from "fs";
 import { mainTestFn, test } from "@compas/cli";
 import { AppError, isNil, uuid } from "@compas/stdlib";
+import { decode } from "jws";
 import {
   copyFile,
   createOrUpdateFile,
+  fileSignAccessToken,
+  fileVerifyAndDecodeAccessToken,
   getFileStream,
   syncDeletedFiles,
 } from "./files.js";
@@ -218,6 +221,119 @@ test("store/files", async (t) => {
     }).exec(sql);
 
     t.ok(isNil(file));
+  });
+
+  t.test("fileSignAccessToken", (t) => {
+    t.test("all options are mandatory", (t) => {
+      try {
+        fileSignAccessToken({
+          fileId: uuid(),
+          signingKey: 5,
+        });
+      } catch (e) {
+        t.ok(AppError.instanceOf(e));
+        t.equal(e.status, 500);
+      }
+
+      try {
+        fileSignAccessToken({
+          signingKey: uuid(),
+          maxAgeInSeconds: 5,
+        });
+      } catch (e) {
+        t.ok(AppError.instanceOf(e));
+        t.equal(e.status, 500);
+      }
+    });
+
+    t.test("returns string", (t) => {
+      const result = fileSignAccessToken({
+        fileId: uuid(),
+        signingKey: uuid(),
+        maxAgeInSeconds: 5,
+      });
+
+      const decoded = decode(result);
+
+      t.equal(typeof result, "string");
+      t.ok(uuid.isValid(decoded.payload.fileId));
+    });
+  });
+
+  t.test("fileVerifyAndDecodeAccessToken", (t) => {
+    t.test("all options are mandatory", (t) => {
+      try {
+        fileVerifyAndDecodeAccessToken({
+          fileAccessToken: uuid(),
+        });
+      } catch (e) {
+        t.ok(AppError.instanceOf(e));
+        t.equal(e.status, 500);
+      }
+
+      try {
+        fileVerifyAndDecodeAccessToken({
+          signingKey: uuid(),
+        });
+      } catch (e) {
+        t.ok(AppError.instanceOf(e));
+        t.equal(e.status, 500);
+      }
+    });
+
+    t.test("handles unknown signingKey", (t) => {
+      const accessToken = fileSignAccessToken({
+        fileId: uuid(),
+        signingKey: uuid(),
+        maxAgeInSeconds: 5,
+      });
+
+      const { error } = fileVerifyAndDecodeAccessToken({
+        fileAccessToken: accessToken,
+        signingKey: uuid(),
+      });
+
+      t.equal(typeof accessToken, "string");
+      t.ok(AppError.instanceOf(error));
+      t.equal(error.status, 400);
+      t.ok(error.key.includes("invalidToken"));
+    });
+
+    t.test("handles expired token", (t) => {
+      const signingKey = uuid();
+      const accessToken = fileSignAccessToken({
+        fileId: uuid(),
+        signingKey,
+        maxAgeInSeconds: -5,
+      });
+
+      const { error } = fileVerifyAndDecodeAccessToken({
+        fileAccessToken: accessToken,
+        signingKey,
+      });
+
+      t.equal(typeof accessToken, "string");
+      t.ok(AppError.instanceOf(error));
+      t.equal(error.status, 400);
+      t.ok(error.key.includes("expiredToken"));
+    });
+
+    t.test("returns value", (t) => {
+      const fileId = uuid();
+      const signingKey = uuid();
+      const accessToken = fileSignAccessToken({
+        fileId,
+        signingKey,
+        maxAgeInSeconds: 5,
+      });
+
+      const { value } = fileVerifyAndDecodeAccessToken({
+        fileAccessToken: accessToken,
+        signingKey,
+      });
+
+      t.equal(fileId, value);
+    });
   });
 
   t.test("destroy test db", async (t) => {

--- a/packages/store/src/query.d.ts
+++ b/packages/store/src/query.d.ts
@@ -9,8 +9,9 @@
  * @template T
  *
  * @param {TemplateStringsArray | string[]} strings
- * @param {...(import("../types/advanced-types").QueryPartArg | import("../types/advanced-types").QueryPartArg[])}
- *   values
+ * @param {...(import("../types/advanced-types").QueryPartArg
+ *   | import("../types/advanced-types").QueryPartArg[]
+ *   )} values
  * @returns {import("../types/advanced-types").QueryPart<T>}
  */
 export function query<T>(


### PR DESCRIPTION
Signed access to a specific file id, with an expiration.

Like the session store, this uses its own signing internally. We may want to expose this logic at some point and deprecate these functions.

This is a big step in dropping cookie support.

References #1307

TODO;
- [x] Docs
- [ ] Example?
- [x] How can a user add logic to decide which file is 'public' and which one can only be access via a short lived access token?