### PR TITLE
fix(code-gen): correctly shake out unused types in dumped api structure

### DIFF
--- a/packages/code-gen/src/builders/OmitType.d.ts
+++ b/packages/code-gen/src/builders/OmitType.d.ts
@@ -3,6 +3,7 @@ export class OmitType extends TypeBuilder {
     keys: never[];
   };
   constructor(group: any, name: any);
+  build(): any;
   /**
    * @param {ObjectType|Record<string, import("../../types/advanced-types").TypeBuilderLike>} builder
    * @returns {OmitType}

--- a/packages/code-gen/src/builders/OptionalType.d.ts
+++ b/packages/code-gen/src/builders/OptionalType.d.ts
@@ -1,6 +1,7 @@
 export class OptionalType extends TypeBuilder {
   static baseData: {};
   constructor(group: any, name: any);
+  build(): any;
   /**
    * @param {import("../../types/advanced-types").TypeBuilderLike} builder
    * @returns {OptionalType}

--- a/packages/code-gen/src/builders/PickType.d.ts
+++ b/packages/code-gen/src/builders/PickType.d.ts
@@ -3,6 +3,7 @@ export class PickType extends TypeBuilder {
     keys: never[];
   };
   constructor(group: any, name: any);
+  build(): any;
   /**
    * @param {ObjectType|Record<string, import("../../types/advanced-types").TypeBuilderLike>} builder
    * @returns {PickType}

--- a/packages/code-gen/src/builders/SearchableType.d.ts
+++ b/packages/code-gen/src/builders/SearchableType.d.ts
@@ -1,6 +1,7 @@
 export class SearchableType extends TypeBuilder {
   static baseData: {};
   constructor(group: any, name: any);
+  build(): any;
   /**
    * @param {import("../../types/advanced-types").TypeBuilderLike} builder
    * @returns {SearchableType}

--- a/packages/code-gen/src/generate.d.ts
+++ b/packages/code-gen/src/generate.d.ts
@@ -11,6 +11,17 @@ export function addGroupsToGeneratorInput(
   groups: string[],
 ): void;
 /**
+ * Find nested references and add to generatorInput in the correct group
+ *
+ * @param {CodeGenStructure} structure
+ * @param {CodeGenStructure} input
+ * @returns {void}
+ */
+export function includeReferenceTypes(
+  structure: CodeGenStructure,
+  input: CodeGenStructure,
+): void;
+/**
  * Using some more memory, but ensures a mostly consistent output.
  * JS Object iterators mostly follow insert order.
  * We do this so diffs are more logical

--- a/packages/code-gen/src/generate.js
+++ b/packages/code-gen/src/generate.js
@@ -26,7 +26,7 @@ export function addGroupsToGeneratorInput(input, structure, groups) {
  * @param {CodeGenStructure} input
  * @returns {void}
  */
-function includeReferenceTypes(structure, input) {
+export function includeReferenceTypes(structure, input) {
   const stack = [input];
 
   while (stack.length) {

--- a/packages/code-gen/src/generator/structure.js
+++ b/packages/code-gen/src/generator/structure.js
@@ -1,4 +1,4 @@
-import { addGroupsToGeneratorInput, addToData } from "../generate.js";
+import { addToData, includeReferenceTypes } from "../generate.js";
 import { js } from "./tag/index.js";
 
 /**
@@ -52,11 +52,7 @@ export function generateStructureFile(context) {
     }
 
     // Include recursive references that are used in route types
-    addGroupsToGeneratorInput(
-      apiStructure,
-      context.structure,
-      Object.keys(apiStructure),
-    );
+    includeReferenceTypes(context.structure, apiStructure);
 
     const string = JSON.stringify(apiStructure).replace(
       /(['\\])/gm,


### PR DESCRIPTION
It only shaked out unused groups, but not unused types in a group