### PR TITLE
feat(cli): remove `enforceSingleAssertion` option from test config

### DIFF
--- a/docs/features/test-and-bench-runner.md
+++ b/docs/features/test-and-bench-runner.md
@@ -119,9 +119,6 @@ the defaults is below:
 // Individual test timeout, i.e. the function provided to `test` and `t.test`
 export const timeout = 2500;
 
-// Enforce that every test has at least a single subtest (i.e. t.test()) or an assertion (t.pass())
-export const enforceSingleAssertion = true;
-
 export async function setup() {
   // Global setup function
 }
@@ -262,8 +259,8 @@ test("willThrow really throws", (t) => {
 });
 ```
 
-When `enforceSingleAssertion` is set to `true` in the config, the above is more
-idiomatically written as:
+Since the test runner enforces that each `test` or `t.test` should either do an
+assertion or call `t.test`, the above is more idiomatically written as:
 
 ```js
 mainTestFn(import.meta);
@@ -320,11 +317,6 @@ When tests are executed, a config file attempted to be loaded from
 
 A configurable timeout in milliseconds. This is enforced for every callback
 provided to `test` or `t.test`. Defaults to 2.5 seconds.
-
-**enforceSingleAssertion**
-
-The runner enforces that every `test()` and `t.test()` call does at least a
-single assertion or creates at least a single subtest.
 
 **setup**
 

--- a/docs/references/cli.md
+++ b/docs/references/cli.md
@@ -274,11 +274,9 @@ tests.
 
 Global configuration can be applied to the test runners via a 'test/config.js'
 file. A global timeout can be configured by setting 'export const timeout =
-2500;'. The value is specified in milliseconds. By default, every subtest should
-have at least a single assertion or register a subtest via 't.test()'. To
-disable this, you can set 'export const enforceSingleAssertion = false'. There
-is also a global 'setup' and 'teardown' function that can be exported from the
-'test/config.js' file. They may return a Promise.
+2500;'. The value is specified in milliseconds. There is also a global 'setup'
+and 'teardown' function that can be exported from the 'test/config.js' file.
+They may return a Promise.
 
 To prevent flaky tests, '--randomize-rounds' can be used. This shuffles the
 order in which the tests are started. And prevents dependencies between test

--- a/packages/cli/src/compas/commands/test.js
+++ b/packages/cli/src/compas/commands/test.js
@@ -38,7 +38,6 @@ Test files should be ordinary JavaScript files. By calling 'mainTestFn' at the t
   
 Global configuration can be applied to the test runners via a 'test/config.js' file.
 A global timeout can be configured by setting 'export const timeout = 2500;'. The value is specified in milliseconds.
-By default, every subtest should have at least a single assertion or register a subtest via 't.test()'. To disable this, you can set 'export const enforceSingleAssertion = false'.
 There is also a global 'setup' and 'teardown' function that can be exported from the 'test/config.js' file. They may return a Promise.
 
 To prevent flaky tests, '--randomize-rounds' can be used. This shuffles the order in which the tests are started. And prevents dependencies between test files. Making it easier to run a single test file via for examples 'compas run ./path/to/file.test.js'.

--- a/packages/cli/src/testing/config.js
+++ b/packages/cli/src/testing/config.js
@@ -1,12 +1,7 @@
 import { existsSync } from "fs";
 import { pathToFileURL } from "url";
-import { isNil, pathJoin } from "@compas/stdlib";
-import {
-  setEnforceSingleAssertion,
-  setGlobalSetup,
-  setGlobalTeardown,
-  setTestTimeout,
-} from "./state.js";
+import { pathJoin } from "@compas/stdlib";
+import { setGlobalSetup, setGlobalTeardown, setTestTimeout } from "./state.js";
 
 const configPath = pathJoin(process.cwd(), "test/config.js");
 
@@ -34,10 +29,6 @@ export async function loadTestConfig() {
       );
     }
     setTestTimeout(config.timeout);
-  }
-
-  if (!isNil(config?.enforceSingleAssertion)) {
-    setEnforceSingleAssertion(config.enforceSingleAssertion);
   }
 
   setGlobalSetup(config?.setup);

--- a/packages/cli/src/testing/runner.js
+++ b/packages/cli/src/testing/runner.js
@@ -1,13 +1,7 @@
 import { AssertionError, deepStrictEqual } from "assert";
 import { url } from "inspector";
 import { isNil } from "@compas/stdlib";
-import {
-  enforceSingleAssertion,
-  setTestTimeout,
-  state,
-  testLogger,
-  timeout,
-} from "./state.js";
+import { setTestTimeout, state, testLogger, timeout } from "./state.js";
 
 /**
  * @param {import("./state").TestState} testState
@@ -83,7 +77,6 @@ export async function runTestsRecursively(testState, isDebugging = !!url()) {
   mutateRunnerEnablingWarnings(runner);
 
   if (
-    enforceSingleAssertion &&
     testState.children.length === 0 &&
     testState.assertions.length === 0 &&
     isNil(testState.caughtException)
@@ -91,7 +84,7 @@ export async function runTestsRecursively(testState, isDebugging = !!url()) {
     // Only enforce an assertion when no child tests are registered, and when the
     // current test didn't exit with a 'caughtException'.
     testState.caughtException = new Error(
-      `Test did not execute any assertions. This is enforced via the 'enforceSingleAssertion' value in 'test/config.js'.`,
+      `Test did not execute any assertions. It should do at least a single assertion like 't.pass()' or register a subtest via 't.test()'.`,
     );
     delete testState.caughtException.stack;
   }

--- a/packages/cli/src/testing/runner.test.js
+++ b/packages/cli/src/testing/runner.test.js
@@ -57,7 +57,7 @@ test("cli/testing/runner", (t) => {
     await runTestsRecursively(state, false);
 
     t.ok(state.caughtException);
-    t.ok(state.caughtException.message.includes("enforceSingleAssertion"));
+    t.ok(state.caughtException.message.includes("at least a single"));
   });
 
   t.test(

--- a/packages/cli/src/testing/state.d.ts
+++ b/packages/cli/src/testing/state.d.ts
@@ -17,12 +17,6 @@ export function setTestLogger(logger: Logger): void;
  */
 export function setTestTimeout(value: any): void;
 /**
- * Set enforcement of an passing assertion in test callbacks
- *
- * @param {boolean} enforce
- */
-export function setEnforceSingleAssertion(enforce: boolean): void;
-/**
  * Only accepts the value if it is a function
  */
 export function setGlobalSetup(value: any): void;
@@ -69,10 +63,6 @@ export let areTestsRunning: boolean;
  * @type {number}
  */
 export let timeout: number;
-/**
- * @type {boolean}
- */
-export let enforceSingleAssertion: boolean;
 /**
  * @type {function(): (void|Promise<void>)}
  */

--- a/packages/cli/src/testing/state.js
+++ b/packages/cli/src/testing/state.js
@@ -47,11 +47,6 @@ export let areTestsRunning = false;
 export let timeout = 2500;
 
 /**
- * @type {boolean}
- */
-export let enforceSingleAssertion = false;
-
-/**
  * @type {function(): (void|Promise<void>)}
  */
 export let globalSetup = noop;
@@ -95,15 +90,6 @@ export function setTestLogger(logger) {
  */
 export function setTestTimeout(value) {
   timeout = value;
-}
-
-/**
- * Set enforcement of an passing assertion in test callbacks
- *
- * @param {boolean} enforce
- */
-export function setEnforceSingleAssertion(enforce) {
-  enforceSingleAssertion = enforce;
 }
 
 /**

--- a/test/config.js
+++ b/test/config.js
@@ -8,8 +8,6 @@ import { destroyTestServices, injectTestServices } from "../src/testing.js";
 
 export const timeout = 2000;
 
-export const enforceSingleAssertion = true;
-
 export async function setup() {
   const sql = await createTestPostgresDatabase();
   await setPostgresDatabaseTemplate(sql);


### PR DESCRIPTION
BREAKING CHANGE:
- All tests now require at least a single assertion or registration of a subtest