### PR TITLE
feat(code-gen): cleanup soft delete support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,11 +117,16 @@ const [authorOfPost] = await queryUser({
 await queries.userInsert(sql, { email: "bar@foo.com", name: "Compas " });
 
 // soft delete
-await queries.postDelete(sql, { id: "c532ac2a-4489-4b50-a061-12b2aa9a5df2" });
+await queries.postUpdate(sql, {
+  update: {
+    deletedAt: new Date(),
+  },
+  where: { id: "c532ac2a-4489-4b50-a061-12b2aa9a5df2" },
+});
 // Search include soft deleted posts
 await queryPost({ where: { deletedAtIncludeNotNull: true } });
 // permanent delete
-await queries.postDeletePermanent(sql, {
+await queries.postDelete(sql, {
   id: "c532ac2a-4489-4b50-a061-12b2aa9a5df2",
 });
 ```

--- a/packages/code-gen/src/generator/sql/query-basics.js
+++ b/packages/code-gen/src/generator/sql/query-basics.js
@@ -38,11 +38,6 @@ export function generateBaseQueries(context, imports, type, src) {
     src.push(insertQuery(context, imports, type));
     src.push(upsertQueryByPrimaryKey(context, imports, type));
     src.push(getUpdateQuery(context, imports, type));
-
-    if (type.queryOptions.withSoftDeletes) {
-      names.push(`${type.name}DeletePermanent`);
-      src.push(softDeleteQuery(context, imports, type));
-    }
   }
 
   src.push(`export const ${type.name}Queries = { ${names.join(", ")} };`);
@@ -85,9 +80,7 @@ function deleteQuery(context, imports, type) {
      * @param {${type.uniqueName}Where} [where={}]
      * @returns {Promise<void>}
      */
-    async function ${type.name}Delete${
-    type.queryOptions.withSoftDeletes ? "Permanent" : ""
-  }(sql,
+    async function ${type.name}Delete(sql,
                                                                                 where = {}
     ) {
       ${
@@ -99,78 +92,6 @@ function deleteQuery(context, imports, type) {
         DELETE FROM ${type.queryOptions.schema}"${type.name}" ${type.shortName}
         WHERE $\{${type.name}Where(where)}
         \`.exec(sql);
-    }
-  `;
-}
-
-/**
- * @param {import("../../generated/common/types").CodeGenContext} context
- * @param {import("../utils").ImportCreator} imports
- * @param {CodeGenObjectType} type
- */
-function softDeleteQuery(context, imports, type) {
-  const affectedRelations = [];
-  for (const relation of type.relations) {
-    if (["oneToOneReverse", "oneToMany"].indexOf(relation.subType) === -1) {
-      continue;
-    }
-    const referenceQueryOptions =
-      relation.reference.reference.queryOptions ?? {};
-    if (
-      referenceQueryOptions.withSoftDeletes &&
-      !referenceQueryOptions.isView
-    ) {
-      affectedRelations.push(relation);
-    }
-  }
-
-  const { key: primaryKey } = getPrimaryKeyWithType(type);
-
-  return js`
-    /**
-     * @param {Postgres} sql
-     * @param {${type.uniqueName}Where} [where={}]
-     * @param {{ skipCascade?: boolean }} [options={}]
-     * @returns {Promise<void>}
-     */
-    async function ${type.name}Delete(sql, where = {}, options = {}) {
-      ${affectedRelations.length > 0 ? "const result =" : ""}
-      await query\`
-        UPDATE ${type.queryOptions.schema}"${type.name}" ${type.shortName}
-        SET "deletedAt" = now()
-        WHERE $\{${type.name}Where(where)}
-        RETURNING "${primaryKey}"
-        \`.exec(sql);
-
-      ${() => {
-        if (affectedRelations.length > 0) {
-          return js`
-            if (options.skipCascade || result.length === 0) {
-              return;
-            }
-
-            const ids = result.map(it => it.${primaryKey});
-            await Promise.all([
-                                ${affectedRelations
-                                  .filter(
-                                    (it) =>
-                                      !it.reference.reference.queryOptions
-                                        .isView,
-                                  )
-                                  .map((it) => {
-                                    if (it.reference.reference !== type) {
-                                      imports.destructureImport(
-                                        `${it.reference.reference.name}Queries`,
-                                        `./${it.reference.reference.name}.js`,
-                                      );
-                                    }
-                                    return `${it.reference.reference.name}Queries.${it.reference.reference.name}Delete(sql, { ${it.referencedKey}In: ids })`;
-                                  })
-                                  .join(",\n  ")}
-                              ]);
-          `;
-        }
-      }}
     }
   `;
 }

--- a/packages/store/src/files.d.ts
+++ b/packages/store/src/files.d.ts
@@ -111,7 +111,7 @@ export function copyFile(
   targetBucket?: string | undefined,
 ): Promise<StoreFile>;
 /**
- * File deletes should be done via `queries.storeFileDeletePermanent()`. By calling this
+ * File deletes should be done via `queries.storeFileDelete()`. By calling this
  * function, all files that don't exist in the database will be removed from the S3
  * bucket.
  *

--- a/packages/store/src/files.js
+++ b/packages/store/src/files.js
@@ -213,7 +213,7 @@ export async function copyFile(
 }
 
 /**
- * File deletes should be done via `queries.storeFileDeletePermanent()`. By calling this
+ * File deletes should be done via `queries.storeFileDelete()`. By calling this
  * function, all files that don't exist in the database will be removed from the S3
  * bucket.
  *
@@ -226,9 +226,8 @@ export async function copyFile(
  */
 export async function syncDeletedFiles(sql, minio, bucketName) {
   // Delete transformed copies of deleted files
-  await queries.fileDeletePermanent(sql, {
+  await queries.fileDelete(sql, {
     $raw: query`meta->>'transformedFromOriginal' IS NOT NULL AND NOT EXISTS (SELECT FROM "file" f2 WHERE f2.id = (meta->>'transformedFromOriginal')::uuid)`,
-    deletedAtIncludeNotNull: true,
   });
 
   const minioObjectsPromise = listObjects(minio, bucketName);

--- a/packages/store/src/files.test.js
+++ b/packages/store/src/files.test.js
@@ -185,7 +185,7 @@ test("store/files", async (t) => {
   });
 
   t.test("deleteFile", async (t) => {
-    await queries.fileDeletePermanent(sql, { id: storedFiles[0].id });
+    await queries.fileDelete(sql, { id: storedFiles[0].id });
     t.pass();
   });
 

--- a/packages/store/src/generated/database/file.d.ts
+++ b/packages/store/src/generated/database/file.d.ts
@@ -105,7 +105,6 @@ export namespace fileQueries {
   export { fileInsert };
   export { fileUpsertOnId };
   export { fileUpdate };
-  export { fileDeletePermanent };
 }
 export namespace fileQueryBuilderSpec {
   export const name: string;
@@ -133,17 +132,11 @@ declare function fileCount(
 /**
  * @param {Postgres} sql
  * @param {StoreFileWhere} [where={}]
- * @param {{ skipCascade?: boolean }} [options={}]
  * @returns {Promise<void>}
  */
 declare function fileDelete(
   sql: Postgres,
   where?: StoreFileWhere | undefined,
-  options?:
-    | {
-        skipCascade?: boolean | undefined;
-      }
-    | undefined,
 ): Promise<void>;
 /**
  * @param {Postgres} sql
@@ -177,14 +170,5 @@ declare function fileUpsertOnId(
  * @type {StoreFileUpdateFn}
  */
 declare const fileUpdate: StoreFileUpdateFn;
-/**
- * @param {Postgres} sql
- * @param {StoreFileWhere} [where={}]
- * @returns {Promise<void>}
- */
-declare function fileDeletePermanent(
-  sql: Postgres,
-  where?: StoreFileWhere | undefined,
-): Promise<void>;
 export {};
 //# sourceMappingURL=file.d.ts.map

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -9,7 +9,6 @@ import {
   validateStoreFileWhere,
 } from "../store/validators.js";
 import {
-  fileGroupQueries,
   fileGroupQueryBuilderSpec,
   fileGroupWhere,
   fileGroupWhereSpec,
@@ -321,7 +320,7 @@ WHERE ${fileWhere(where)}
  * @param {StoreFileWhere} [where={}]
  * @returns {Promise<void>}
  */
-async function fileDeletePermanent(sql, where = {}) {
+async function fileDelete(sql, where = {}) {
   where.deletedAtIncludeNotNull = true;
   return await query`
 DELETE FROM "file" f
@@ -429,32 +428,12 @@ const fileUpdate = async (sql, input) => {
   // @ts-ignore
   return undefined;
 };
-/**
- * @param {Postgres} sql
- * @param {StoreFileWhere} [where={}]
- * @param {{ skipCascade?: boolean }} [options={}]
- * @returns {Promise<void>}
- */
-async function fileDelete(sql, where = {}, options = {}) {
-  const result = await query`
-UPDATE "file" f
-SET "deletedAt" = now()
-WHERE ${fileWhere(where)}
-RETURNING "id"
-`.exec(sql);
-  if (options.skipCascade || result.length === 0) {
-    return;
-  }
-  const ids = result.map((it) => it.id);
-  await Promise.all([fileGroupQueries.fileGroupDelete(sql, { fileIn: ids })]);
-}
 export const fileQueries = {
   fileCount,
   fileDelete,
   fileInsert,
   fileUpsertOnId,
   fileUpdate,
-  fileDeletePermanent,
 };
 export const fileQueryBuilderSpec = {
   name: "file",

--- a/packages/store/src/generated/database/fileGroup.d.ts
+++ b/packages/store/src/generated/database/fileGroup.d.ts
@@ -107,7 +107,6 @@ export namespace fileGroupQueries {
   export { fileGroupInsert };
   export { fileGroupUpsertOnId };
   export { fileGroupUpdate };
-  export { fileGroupDeletePermanent };
 }
 export const fileGroupQueryBuilderSpec: any;
 /**
@@ -122,17 +121,11 @@ declare function fileGroupCount(
 /**
  * @param {Postgres} sql
  * @param {StoreFileGroupWhere} [where={}]
- * @param {{ skipCascade?: boolean }} [options={}]
  * @returns {Promise<void>}
  */
 declare function fileGroupDelete(
   sql: Postgres,
   where?: StoreFileGroupWhere | undefined,
-  options?:
-    | {
-        skipCascade?: boolean | undefined;
-      }
-    | undefined,
 ): Promise<void>;
 /**
  * @param {Postgres} sql
@@ -166,14 +159,5 @@ declare function fileGroupUpsertOnId(
  * @type {StoreFileGroupUpdateFn}
  */
 declare const fileGroupUpdate: StoreFileGroupUpdateFn;
-/**
- * @param {Postgres} sql
- * @param {StoreFileGroupWhere} [where={}]
- * @returns {Promise<void>}
- */
-declare function fileGroupDeletePermanent(
-  sql: Postgres,
-  where?: StoreFileGroupWhere | undefined,
-): Promise<void>;
 export {};
 //# sourceMappingURL=fileGroup.d.ts.map

--- a/packages/store/src/generated/database/fileGroup.js
+++ b/packages/store/src/generated/database/fileGroup.js
@@ -370,7 +370,7 @@ WHERE ${fileGroupWhere(where)}
  * @param {StoreFileGroupWhere} [where={}]
  * @returns {Promise<void>}
  */
-async function fileGroupDeletePermanent(sql, where = {}) {
+async function fileGroupDelete(sql, where = {}) {
   where.deletedAtIncludeNotNull = true;
   return await query`
 DELETE FROM "fileGroup" fg
@@ -483,32 +483,12 @@ const fileGroupUpdate = async (sql, input) => {
   // @ts-ignore
   return undefined;
 };
-/**
- * @param {Postgres} sql
- * @param {StoreFileGroupWhere} [where={}]
- * @param {{ skipCascade?: boolean }} [options={}]
- * @returns {Promise<void>}
- */
-async function fileGroupDelete(sql, where = {}, options = {}) {
-  const result = await query`
-UPDATE "fileGroup" fg
-SET "deletedAt" = now()
-WHERE ${fileGroupWhere(where)}
-RETURNING "id"
-`.exec(sql);
-  if (options.skipCascade || result.length === 0) {
-    return;
-  }
-  const ids = result.map((it) => it.id);
-  await Promise.all([fileGroupQueries.fileGroupDelete(sql, { parentIn: ids })]);
-}
 export const fileGroupQueries = {
   fileGroupCount,
   fileGroupDelete,
   fileGroupInsert,
   fileGroupUpsertOnId,
   fileGroupUpdate,
-  fileGroupDeletePermanent,
 };
 export const fileGroupQueryBuilderSpec = {
   name: "fileGroup",

--- a/packages/store/src/generated/database/index.d.ts
+++ b/packages/store/src/generated/database/index.d.ts
@@ -79,11 +79,6 @@ export const queries: {
   fileDelete: (
     sql: import("../../../types/advanced-types.js").Postgres,
     where?: StoreFileWhere | undefined,
-    options?:
-      | {
-          skipCascade?: boolean | undefined;
-        }
-      | undefined,
   ) => Promise<void>;
   fileInsert: (
     sql: import("../../../types/advanced-types.js").Postgres,
@@ -100,10 +95,6 @@ export const queries: {
     options?: {} | undefined,
   ) => Promise<StoreFile[]>;
   fileUpdate: StoreFileUpdateFnInput;
-  fileDeletePermanent: (
-    sql: import("../../../types/advanced-types.js").Postgres,
-    where?: StoreFileWhere | undefined,
-  ) => Promise<void>;
   fileGroupCount: (
     sql: import("../../../types/advanced-types.js").Postgres,
     where?: StoreFileGroupWhere | undefined,
@@ -111,11 +102,6 @@ export const queries: {
   fileGroupDelete: (
     sql: import("../../../types/advanced-types.js").Postgres,
     where?: StoreFileGroupWhere | undefined,
-    options?:
-      | {
-          skipCascade?: boolean | undefined;
-        }
-      | undefined,
   ) => Promise<void>;
   fileGroupInsert: (
     sql: import("../../../types/advanced-types.js").Postgres,
@@ -132,9 +118,5 @@ export const queries: {
     options?: {} | undefined,
   ) => Promise<StoreFileGroup[]>;
   fileGroupUpdate: StoreFileGroupUpdateFnInput;
-  fileGroupDeletePermanent: (
-    sql: import("../../../types/advanced-types.js").Postgres,
-    where?: StoreFileGroupWhere | undefined,
-  ) => Promise<void>;
 };
 //# sourceMappingURL=index.d.ts.map

--- a/packages/store/src/send-transformed-image.test.js
+++ b/packages/store/src/send-transformed-image.test.js
@@ -197,7 +197,7 @@ test("store/send-transformed-image", async (t) => {
   t.test("return webp if allowed - but remove original", async (t) => {
     const existingTransformForKey =
       five.meta.transforms[`compas-image-transform-webp1-w5-q60`];
-    await queries.fileDeletePermanent(sql, { id: existingTransformForKey });
+    await queries.fileDelete(sql, { id: existingTransformForKey });
 
     const response = await apiClient.request({
       method: "GET",


### PR DESCRIPTION
Closes #1091

BREAKING CHANGE:
- Entities that use soft delete should use `queries.entityUpdate(sql, { update: { deletedAt: new Date() }, where, })` instead of `queries.entityDelete`
- The generated `queries.entityDeletePermanent`
is removed, and instead `queries.entityDelete` will always permanently delete a record, even if it was soft deleted.