### PR TITLE
fix(code-gen): import structure without cache in `generateTypes` and `generateOpenAPI`

### DIFF
--- a/packages/code-gen/src/generate-types.js
+++ b/packages/code-gen/src/generate-types.js
@@ -2,7 +2,7 @@
 
 import { rmSync } from "fs";
 import { pathToFileURL } from "url";
-import { isPlainObject, pathJoin } from "@compas/stdlib";
+import { isPlainObject, pathJoin, uuid } from "@compas/stdlib";
 import { generate, writeFiles } from "./generator/index.js";
 
 /**
@@ -198,7 +198,7 @@ async function validateAndReadStructureFiles(options) {
 
     // @ts-ignore
     const { structure, compasGenerateSettings: options } = await import(
-      pathToFileURL(structureFile)
+      `${pathToFileURL(structureFile)}?v=${uuid()}`
     );
 
     if (isPlainObject(structure) && isPlainObject(options)) {

--- a/packages/code-gen/src/generator/openAPI/index.js
+++ b/packages/code-gen/src/generator/openAPI/index.js
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "fs";
 import { pathToFileURL } from "url";
-import { isPlainObject } from "@compas/stdlib";
+import { isPlainObject, uuid } from "@compas/stdlib";
 import { addGroupsToGeneratorInput } from "../../generate.js";
 import { linkupReferencesInStructure } from "../linkup-references.js";
 import { generateOpenApiFile } from "./generator.js";
@@ -49,7 +49,7 @@ export async function generateOpenApi(logger, options) {
 
   const { compasApiStructureString } = await import(
     // @ts-ignore
-    pathToFileURL(options.inputPath)
+    `${pathToFileURL(options.inputPath)}?v=${uuid()}`
   );
 
   /**


### PR DESCRIPTION
Some scripts could have imported the structure file and then generated a new version before calling `generateTypes` or `generateOpenAPI`. These two would then use the ES Module cached version, instead of using the newly generated version.

Closes #1699
