### PR TITLE
feat(eslint-plugin): add check-event-name rule

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -42,6 +42,7 @@ module.exports = {
       rules: {
         // Plugin rules
         "@compas/enforce-event-stop": "error",
+        "@compas/check-event-name": "error",
 
         // ESLint base
         "default-case-last": "error",
@@ -109,5 +110,6 @@ module.exports = {
   },
   rules: {
     "enforce-event-stop": require("./lint-rules/enforce-event-stop"),
+    "check-event-name": require("./lint-rules/check-event-name"),
   },
 };

--- a/packages/eslint-plugin/lint-rules/check-event-name.js
+++ b/packages/eslint-plugin/lint-rules/check-event-name.js
@@ -1,0 +1,125 @@
+/* eslint-disable import/no-commonjs */
+
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: `Suggest that the 'event.name' passed to 'eventStart' is a derivative from the function name.`,
+    },
+    hasSuggestions: true,
+
+    messages: {
+      consistentEventName:
+        "Use an event name that can be derived from the function name",
+      replaceEventName: `Replace eventName with {{value}}`,
+    },
+  },
+
+  create(context) {
+    let currentFunction;
+
+    function processFunctionStart(node) {
+      currentFunction = {
+        parent: currentFunction,
+        node,
+        isAsyncEventFunction: node.async && node.params[0]?.name === "event",
+        functionName: node.id?.name,
+      };
+    }
+
+    function processFunctionEnd() {
+      currentFunction = currentFunction.parent;
+    }
+
+    return {
+      // Manage function scopes
+      ":function": processFunctionStart,
+      ":function:exit": processFunctionEnd,
+
+      // Process `eventStart` calls
+      "CallExpression[callee.name='eventStart']"(node) {
+        if (
+          !currentFunction.isAsyncEventFunction ||
+          !currentFunction.functionName ||
+          currentFunction.functionName.length === 0
+        ) {
+          return;
+        }
+
+        if (node.arguments?.length !== 2) {
+          return;
+        }
+
+        let value = undefined;
+        if (node.arguments[1].type === "Literal") {
+          value = node.arguments[1].value;
+        }
+
+        if (
+          node.arguments[1].type === "TemplateLiteral" &&
+          node.arguments[1].expressions.length === 0 &&
+          node.arguments[1].quasis.length === 1
+        ) {
+          value = node.arguments[1].quasis[0].value.raw;
+        }
+
+        if (!value) {
+          return;
+        }
+
+        const fnNameParts = currentFunction.functionName
+          .split(/(?=[A-Z])/)
+          .map((it) => it.toLowerCase());
+        const validEventNames = calculateValidEventNames(fnNameParts);
+
+        if (validEventNames.includes(value)) {
+          return;
+        }
+
+        context.report({
+          node: node.arguments[1],
+          messageId: "consistentEventName",
+          suggest: validEventNames.map((it) => {
+            return {
+              messageId: "replaceEventName",
+              data: {
+                value: it,
+              },
+              fix: function (fixer) {
+                return fixer.replaceText(node.arguments[1], `"${it}"`);
+              },
+            };
+          }),
+        });
+      },
+    };
+  },
+};
+
+function calculateValidEventNames(parts) {
+  const result = [];
+
+  if (parts.length === 1) {
+    return parts;
+  }
+
+  for (let i = 1; i < parts.length; ++i) {
+    let str = "";
+
+    for (let j = 0; j < parts.length; ++j) {
+      if (j === 0) {
+        str += parts[j];
+      } else if (i === j) {
+        str += ".";
+        str += parts[j];
+      } else {
+        str += parts[j][0].toUpperCase() + parts[j].substring(1);
+      }
+    }
+
+    result.push(str);
+  }
+
+  return result;
+}

--- a/packages/eslint-plugin/test/check-event-name.js
+++ b/packages/eslint-plugin/test/check-event-name.js
@@ -1,0 +1,100 @@
+/* eslint-disable import/no-commonjs,import/order */
+
+const rule = require("../lint-rules/check-event-name.js");
+const RuleTester = require("eslint").RuleTester;
+const { join } = require("path");
+
+const ruleTester = new RuleTester({
+  parser: join(process.cwd(), "./node_modules/@babel/eslint-parser"),
+  parserOptions: {
+    requireConfigFile: false,
+    babelOptions: {
+      plugins: ["@babel/plugin-syntax-class-properties"],
+    },
+  },
+  env: {
+    node: true,
+    es2021: true,
+  },
+});
+
+ruleTester.run("check-event-name", rule, {
+  valid: [
+    {
+      code: `function fooBar() { }`,
+    },
+    {
+      code: `const foo = function() {  eventStart(event, "bar"); }`,
+    },
+    {
+      code: `async function fooBar(event) {  eventStart(event, "foo.bar"); }`,
+    },
+    {
+      code: `async function fooBar(event) {  eventStart(event, \`foo.bar\`); }`,
+    },
+    {
+      code: `async function fooBar(event) {  const name = "foo";  eventStart(event, \`$\{name}.bar\`); }`,
+    },
+    {
+      code: `async function fooBar(event) {  const name = "foo.bar";  eventStart(event, name); }`,
+    },
+    {
+      code: `async function foo(event) {  eventStart(event, "foo"); }`,
+    },
+    {
+      code: `async function fooBar(event) {  eventStart(event, "foo.bar"); }`,
+    },
+    {
+      code: `async function fooBarBaz(event) {  eventStart(event, "foo.barBaz"); }`,
+    },
+    {
+      code: `async function fooBarBaz(event) {  eventStart(event, "fooBar.baz"); }`,
+    },
+    {
+      code: `async function fooBarBazQuix(event) {  eventStart(event, "foo.barBazQuix"); }`,
+    },
+    {
+      code: `async function fooBarBazQuix(event) {  eventStart(event, "fooBar.bazQuix"); }`,
+    },
+    {
+      code: `async function fooBarBazQuix(event) {  eventStart(event, "fooBarBaz.quix"); }`,
+    },
+  ],
+  invalid: [
+    {
+      code: `async function fooBar(event) { eventStart(event, "foo"); }`,
+      errors: [
+        {
+          message: rule.meta.messages.consistentEventName,
+          suggestions: [
+            {
+              messageId: "replaceEventName",
+              data: { value: "foo.bar" },
+              output: `async function fooBar(event) { eventStart(event, "foo.bar"); }`,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: `async function fooBarBaz(event) { eventStart(event, "fooBarBaz"); }`,
+      errors: [
+        {
+          message: rule.meta.messages.consistentEventName,
+          suggestions: [
+            {
+              messageId: "replaceEventName",
+              data: { value: "foo.barBaz" },
+              output: `async function fooBarBaz(event) { eventStart(event, "foo.barBaz"); }`,
+            },
+            {
+              messageId: "replaceEventName",
+              data: { value: "fooBar.baz" },
+              output: `async function fooBarBaz(event) { eventStart(event, "fooBar.baz"); }`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/test/rules.test.mjs
+++ b/packages/eslint-plugin/test/rules.test.mjs
@@ -4,7 +4,7 @@ import { spawn } from "@compas/stdlib";
 mainTestFn(import.meta);
 
 test("eslint-plugin", async (t) => {
-  for (const f of ["enforce-event-stop.js"]) {
+  for (const f of ["enforce-event-stop.js", "check-event-name.js"]) {
     t.test(f, async (t) => {
       const { exitCode } = await spawn(`node`, [
         `./packages/eslint-plugin/test/${f}`,


### PR DESCRIPTION
Validates if the value passed to `eventStart` can be derived from the function name.

Closes #1713

BREAKING CHANGE:
- Enabled the `@compas/check-event-name` rule in `@compas/full` ESLint config.