### PR TITLE
feat(server): remove `leakError` support

### DIFF
--- a/packages/code-gen/src/generator/common.js
+++ b/packages/code-gen/src/generator/common.js
@@ -33,47 +33,45 @@ function generateCommonApiClientFile(context) {
 
   if (context.options.isNodeServer) {
     contents += js`
-         import { AppError, streamToBuffer } from "@compas/stdlib";
+      import { AppError, streamToBuffer } from "@compas/stdlib";
 
-         export function handleError(e, group, name) {
-            // Validator error
-            if (AppError.instanceOf(e)) {
-               e.key = \`response.$\{group}.$\{name}.$\{e.key}\`
-               throw e;
+      export function handleError(e, group, name) {
+        // Validator error
+        if (AppError.instanceOf(e)) {
+          e.key = \`response.$\{group}.$\{name}.$\{e.key}\`
+          throw e;
+        }
+
+        if (typeof e?.response?.data?.pipe === "function") {
+          // Handle response streams
+          return streamToBuffer(e.response.data).then(buffer => {
+            try {
+              e.response.data = JSON.parse(buffer.toString("utf8"));
+            } catch {
+              // Unknown error
+              throw new AppError(\`response.$\{group}.$\{name}\`,
+                                 e.response?.status ?? 500, {
+                                   data: e?.response?.data, headers: e?.response?.headers
+                                 }, e,
+              );
             }
 
-            if (typeof e?.response?.data?.pipe === "function") {
-               // Handle response streams
-               return streamToBuffer(e.response.data).then(buffer => {
-                  try {
-                     e.response.data = JSON.parse(buffer.toString("utf8"));
-                  } catch {
-                     // Unknown error
-                     throw new AppError(\`response.$\{group}.$\{name}\`,
-                                        e.response?.status ?? 500, {
-                                           data: e?.response?.data,
-                                           headers: e?.response?.headers
-                                        }, e,
-                     );
-                  }
+            return handleError(e, group, name);
+          });
+        }
 
-                  return handleError(e, group, name);
-               });
-            }
+        // Server AppError
+        const { key, info } = e.response?.data ?? {};
+        if (typeof key === "string" && !!info && typeof info === "object") {
+          throw new AppError(key, e.response.status, info, e);
+        }
 
-            // Server AppError
-            const { key, info } = e.response?.data ?? {};
-            if (typeof key === "string" && !!info && typeof info === "object") {
-               throw new AppError(key, e.response.status, info, e);
-            }
-
-            // Unknown error
-            throw new AppError(\`response.$\{group}.$\{name}\`, e.response?.status ?? 500,
-                               { data: e?.response?.data, headers: e?.response?.headers },
-                               e,
-            );
-         }
-      `;
+        // Unknown error
+        throw new AppError(\`response.$\{group}.$\{name}\`, e.response?.status ?? 500,
+                           { data: e?.response?.data, headers: e?.response?.headers }, e,
+        );
+      }
+    `;
   }
 
   if (context.options.useTypescript) {
@@ -113,13 +111,9 @@ export const useApi = () => {
 
 export type AppErrorResponse = AxiosError<{
   key?: string;
-  message?: string;
+  status?: number;
+  requestId?: number;
   info?: {
-    _error?: {
-      name?: string;
-      message?: string;
-      stack?: string[];
-    };
     [key: string]: any;
   }
 }>

--- a/packages/code-gen/src/generator/openAPI/generator.js
+++ b/packages/code-gen/src/generator/openAPI/generator.js
@@ -33,6 +33,9 @@ const OPENAPI_SPEC_TEMPLATE = {
           status: {
             type: "number",
           },
+          requestId: {
+            type: "string",
+          },
         },
       },
     },

--- a/packages/server/src/app.d.ts
+++ b/packages/server/src/app.d.ts
@@ -26,8 +26,6 @@
  * @property {((ctx: Koa.Context, err: Error) => boolean)|undefined} [onError] Called
  *   before any logic, to let the user handle errors. If 'true' is returned, no other
  *   logic is applied.
- * @property {boolean|undefined} [leakError] Adds the stacktrace and error cause to the
- *    response. Useful on development and staging environments.
  */
 /**
  * @typedef {object} HeaderOptions
@@ -108,11 +106,6 @@ export type ErrorHandlerOptions = {
    * logic is applied.
    */
   onError?: ((ctx: Koa.Context, err: Error) => boolean) | undefined;
-  /**
-   * Adds the stacktrace and error cause to the
-   * response. Useful on development and staging environments.
-   */
-  leakError?: boolean | undefined;
 };
 export type HeaderOptions = {
   /**

--- a/packages/server/src/app.js
+++ b/packages/server/src/app.js
@@ -38,8 +38,6 @@ import {
  * @property {((ctx: Koa.Context, err: Error) => boolean)|undefined} [onError] Called
  *   before any logic, to let the user handle errors. If 'true' is returned, no other
  *   logic is applied.
- * @property {boolean|undefined} [leakError] Adds the stacktrace and error cause to the
- *    response. Useful on development and staging environments.
  */
 
 /**

--- a/packages/server/src/app.test.js
+++ b/packages/server/src/app.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 import { mainTestFn, test } from "@compas/cli";
-import { AppError, isPlainObject } from "@compas/stdlib";
+import { AppError, isNil, isPlainObject } from "@compas/stdlib";
 import Axios from "axios";
 import { closeTestApp, createTestAppAndClient, getApp } from "../index.js";
 
@@ -51,10 +51,15 @@ test("server/app", (t) => {
       t.fail("404, so axios should have thrown");
     } catch ({ response }) {
       t.equal(response.status, 404);
+
+      t.ok(response.data.requestId);
+      delete response.data.requestId;
+
       t.deepEqual(response.data, {
         key: "error.server.notFound",
-        message: "error.server.notFound",
         info: {},
+        status: 404,
+        type: "api_error",
       });
     }
   });
@@ -65,10 +70,15 @@ test("server/app", (t) => {
       t.fail("500, so axios should have thrown");
     } catch ({ response }) {
       t.equal(response.status, 500);
+
+      t.ok(response.data.requestId);
+      delete response.data.requestId;
+
       t.deepEqual(response.data, {
         key: "error.server.internal",
-        message: "error.server.internal",
         info: { foo: true },
+        status: 500,
+        type: "api_error",
       });
     }
   });
@@ -80,7 +90,7 @@ test("server/app", (t) => {
       t.equal(response.status, 500);
       t.equal(response.data.key, response.data.key);
       t.equal(response.data.key, "error.server.internal");
-      t.ok(Array.isArray(response.data.stack));
+      t.ok(isNil(response.data.stack));
     }
   });
 

--- a/packages/server/src/middleware/log.js
+++ b/packages/server/src/middleware/log.js
@@ -97,10 +97,12 @@ export function logMiddleware(app, options) {
 
   return async (ctx, next) => {
     const startTime = process.hrtime.bigint();
+    const requestId = uuid();
+    ctx.requestId = requestId;
     ctx.log = newLogger({
       ctx: {
         type: "http",
-        requestId: uuid(),
+        requestId,
       },
     });
 

--- a/packages/stdlib/src/error.d.ts
+++ b/packages/stdlib/src/error.d.ts
@@ -53,7 +53,8 @@ export class AppError extends Error {
   /**
    * Format any error skipping the stack automatically for nested errors
    *
-   * @param {AppError | Error | undefined | null | {} | string | number | boolean | Function | unknown} [e]
+   * @param {AppError | Error | undefined | null | {} | string | number | boolean |
+   *   Function | unknown} [e]
    * @returns {Record<string, any>}
    */
   static format(


### PR DESCRIPTION
Closes #1757

BREAKING CHANGE:
- The `stack` and `cause` properties are never sent to the client.
- Error responses should have a `requestId` property, referencing to the logs with `stack` and `cause` properties.