### PR TITLE
chore: support Node.js 18

### DIFF
--- a/.env
+++ b/.env
@@ -1,16 +1,13 @@
 NODE_ENV=development
 APP_NAME=compas
 
-POSTGRES_HOST=localhost:5432
+POSTGRES_HOST=127.0.0.1:5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 
-MINIO_URI=localhost
+MINIO_URI=127.0.0.1
 MINIO_PORT=9000
 MINIO_ACCESS_KEY=minio
 MINIO_SECRET_KEY=minio123
 
 CORS_URL=http://localhost:3000
-COOKIE_URL=compas.test.dev
-PROXY_URL=https://compas-e2e.dirkdevisser.dev
-API_URL=http://localhost:4000

--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16, 17]
+        node: [16, 18]
         postgres_version: [12, 13]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [16, 18]
     runs-on: ${{ matrix.os }}
     env:
       CI: true
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16, 17]
+        node: [16, 18]
         postgres_version: [12, 13]
     runs-on: ${{ matrix.os }}
     env:
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [18]
     runs-on: ${{ matrix.os }}
     env:
       CI: true

--- a/docs/features/postgres-and-minio.md
+++ b/docs/features/postgres-and-minio.md
@@ -52,11 +52,11 @@ following to you `.env` file:
 ```txt
 APP_NAME=compastodo
 # Postgres
-POSTGRES_HOST=localhost:5432
+POSTGRES_HOST=127.0.0.1:5432
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 # Minio
-MINIO_URI=localhost
+MINIO_URI=127.0.0.1
 MINIO_PORT=9000
 MINIO_ACCESS_KEY=minio
 MINIO_SECRET_KEY=minio123

--- a/docs/references/cli.md
+++ b/docs/references/cli.md
@@ -92,7 +92,7 @@ a time.
 
 PostgreSQL credentials:
 
-> postgresql://postgres:postgres@localhost:5432/postgres
+> postgresql://postgres:postgres@127.0.0.1:5432/postgres
 
 Minio credentials:
 


### PR DESCRIPTION
BREAKING CHANGE:
- `POSTGRES_HOST` and `MINIO_URI` should use `127.0.0.1` instead of `localhost` when using Node.js 18+.