### PR TITLE
feat(store,code-gen): support image/avif in `sendTransformedImage`

### DIFF
--- a/packages/code-gen/src/builders/FileType.d.ts
+++ b/packages/code-gen/src/builders/FileType.d.ts
@@ -6,6 +6,12 @@ export class FileType extends TypeBuilder {
   };
   constructor(group: any, name: any);
   /**
+   * Provide mimetypes which are statically checked based on what the client sends as the mimetype.
+   *
+   * Common mimetypes for images, as supported by {@link sendTransformedImage}:
+   * - image/png, image/jpeg, image/jpg, image/webp, image/avif, image/gif
+   *
+   *
    * @param {...string} mimeTypes
    * @returns {FileType}
    */

--- a/packages/code-gen/src/builders/FileType.js
+++ b/packages/code-gen/src/builders/FileType.js
@@ -17,6 +17,12 @@ export class FileType extends TypeBuilder {
   }
 
   /**
+   * Provide mimetypes which are statically checked based on what the client sends as the mimetype.
+   *
+   * Common mimetypes for images, as supported by {@link sendTransformedImage}:
+   * - image/png, image/jpeg, image/jpg, image/webp, image/avif, image/gif
+   *
+   *
    * @param {...string} mimeTypes
    * @returns {FileType}
    */

--- a/packages/store/src/files.d.ts
+++ b/packages/store/src/files.d.ts
@@ -7,6 +7,10 @@
  * possible to validate the inferred content type. This also overwrites the passed in
  * content type.
  *
+ * You can set `allowedContentTypes` to `image/png, image/jpeg, image/jpg, image/webp,
+ * image/avif, image/gif` if you only want to accept files that can be sent by
+ * {@link sendTransformedImage}.
+ *
  * @since 0.1.0
  *
  * @param {import("../types/advanced-types").Postgres} sql

--- a/packages/store/src/files.js
+++ b/packages/store/src/files.js
@@ -38,6 +38,10 @@ const fileQueries = {
  * possible to validate the inferred content type. This also overwrites the passed in
  * content type.
  *
+ * You can set `allowedContentTypes` to `image/png, image/jpeg, image/jpg, image/webp,
+ * image/avif, image/gif` if you only want to accept files that can be sent by
+ * {@link sendTransformedImage}.
+ *
  * @since 0.1.0
  *
  * @param {import("../types/advanced-types").Postgres} sql

--- a/packages/store/src/send-transformed-image.d.ts
+++ b/packages/store/src/send-transformed-image.d.ts
@@ -10,7 +10,15 @@
  */
 /**
  * Wraps 'server'.sendFile, to include an image transformer compatible with Next.js image
- * loader. Only works if the input file is an image.
+ * loader. Only works if the input file is an image. It caches the results on in the
+ * file.meta.
+ *
+ * Supported extensions: image/png, image/jpeg, image/jpg, image/webp, image/avif,
+ * image/gif. See {@link FileType#mimeTypes} and {@link createOrUpdateFile} to enforce
+ * this on file upload.
+ *
+ * Prefers to transform the image to `image/webp` or `image/avif` if the client supports
+ * it.
  *
  * @param {typeof import("@compas/server").sendFile} sendFile
  * @param {import("koa").Context} ctx

--- a/packages/store/src/send-transformed-image.test.js
+++ b/packages/store/src/send-transformed-image.test.js
@@ -138,7 +138,7 @@ test("store/send-transformed-image", async (t) => {
 
     await reloadFileRecords();
 
-    t.ok(!isNil(five.meta.transforms[`compas-image-transform-webp0-w5-q75`]));
+    t.ok(!isNil(five.meta.transforms[`compas-image-transform-none-w5-q75`]));
   });
 
   t.test("reuse earlier transform", async (t) => {
@@ -153,7 +153,7 @@ test("store/send-transformed-image", async (t) => {
 
     await reloadFileRecords();
 
-    t.ok(!isNil(five.meta.transforms[`compas-image-transform-webp0-w5-q75`]));
+    t.ok(!isNil(five.meta.transforms[`compas-image-transform-none-w5-q75`]));
     t.equal(Object.keys(five.meta.transforms).length, 1);
   });
 
@@ -170,7 +170,7 @@ test("store/send-transformed-image", async (t) => {
     await reloadFileRecords();
 
     t.equal(response.headers["content-type"], "image/webp");
-    t.ok(!isNil(five.meta.transforms[`compas-image-transform-webp1-w5-q60`]));
+    t.ok(!isNil(five.meta.transforms[`compas-image-transform-webp-w5-q60`]));
   });
 
   t.test("return webp if allowed - reuse", async (t) => {
@@ -184,19 +184,19 @@ test("store/send-transformed-image", async (t) => {
     });
 
     const existingTransformForKey =
-      five.meta.transforms[`compas-image-transform-webp1-w5-q60`];
+      five.meta.transforms[`compas-image-transform-webp-w5-q60`];
     await reloadFileRecords();
 
     t.equal(response.headers["content-type"], "image/webp");
     t.equal(
-      five.meta.transforms[`compas-image-transform-webp1-w5-q60`],
+      five.meta.transforms[`compas-image-transform-webp-w5-q60`],
       existingTransformForKey,
     );
   });
 
   t.test("return webp if allowed - but remove original", async (t) => {
     const existingTransformForKey =
-      five.meta.transforms[`compas-image-transform-webp1-w5-q60`];
+      five.meta.transforms[`compas-image-transform-webp-w5-q60`];
     await queries.fileDelete(sql, { id: existingTransformForKey });
 
     const response = await apiClient.request({
@@ -212,7 +212,7 @@ test("store/send-transformed-image", async (t) => {
 
     t.equal(response.headers["content-type"], "image/webp");
     t.notEqual(
-      five.meta.transforms[`compas-image-transform-webp1-w5-q60`],
+      five.meta.transforms[`compas-image-transform-webp-w5-q60`],
       existingTransformForKey,
     );
   });


### PR DESCRIPTION
Also updates the doc blocks for `FileType#mimeTypes` and `createOrUpdateFile` to reference the appropriate content / mime type list

Closes #1801