### PR TITLE
feat(code-gen): return `foundKeys` and `expectedKeys` in `validator.o…

### DIFF
--- a/examples/session-handling/src/generated/common/anonymous-validators.js
+++ b/examples/session-handling/src/generated/common/anonymous-validators.js
@@ -393,7 +393,10 @@ export function anonymousValidator1649918931(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1649918931],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -601,7 +604,10 @@ export function anonymousValidator1347962962(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1347962962],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -687,7 +693,10 @@ export function anonymousValidator1027736033(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1027736033],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -795,7 +804,10 @@ export function anonymousValidator592157009(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys592157009],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -858,7 +870,10 @@ export function anonymousValidator1221278603(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1221278603],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1223,7 +1238,10 @@ export function anonymousValidator2144828802(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2144828802],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1340,7 +1358,10 @@ export function anonymousValidator599447075(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys599447075],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1905,7 +1926,10 @@ export function anonymousValidator1781782332(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1781782332],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2072,7 +2096,10 @@ export function anonymousValidator503384244(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys503384244],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2202,7 +2229,10 @@ export function anonymousValidator1337490931(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1337490931],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2614,7 +2644,10 @@ export function anonymousValidator2074494218(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2074494218],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2978,7 +3011,10 @@ export function anonymousValidator1257773835(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1257773835],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3227,7 +3263,10 @@ export function anonymousValidator1577551207(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1577551207],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3294,7 +3333,10 @@ export function anonymousValidator1430489818(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1430489818],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3394,7 +3436,10 @@ export function anonymousValidator600974204(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys600974204],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3461,7 +3506,10 @@ export function anonymousValidator1334934277(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1334934277],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3549,7 +3597,10 @@ export function anonymousValidator2007164840(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2007164840],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3775,7 +3826,10 @@ export function anonymousValidator1511542790(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1511542790],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3838,7 +3892,10 @@ export function anonymousValidator1442950861(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1442950861],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3901,7 +3958,10 @@ export function anonymousValidator553023933(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys553023933],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3964,7 +4024,10 @@ export function anonymousValidator661036808(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys661036808],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4187,7 +4250,10 @@ export function anonymousValidator1925201648(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1925201648],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4253,7 +4319,10 @@ export function anonymousValidator1476139765(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1476139765],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4316,7 +4385,10 @@ export function anonymousValidator1247704095(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1247704095],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4379,7 +4451,10 @@ export function anonymousValidator1462381984(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1462381984],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4480,7 +4555,10 @@ export function anonymousValidator1992090661(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1992090661],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4543,7 +4621,10 @@ export function anonymousValidator962402990(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys962402990],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4644,7 +4725,10 @@ export function anonymousValidator617486747(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys617486747],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4970,7 +5054,10 @@ export function anonymousValidator165104378(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys165104378],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5094,7 +5181,10 @@ export function anonymousValidator1802084014(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1802084014],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5425,7 +5515,10 @@ export function anonymousValidator600940900(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys600940900],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5699,7 +5792,10 @@ export function anonymousValidator286367525(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys286367525],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5869,7 +5965,10 @@ export function anonymousValidator2102646924(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2102646924],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6131,7 +6230,10 @@ export function anonymousValidator1516794677(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1516794677],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6335,7 +6437,10 @@ export function anonymousValidator84897941(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys84897941],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6597,7 +6702,10 @@ export function anonymousValidator1345595702(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1345595702],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6885,7 +6993,10 @@ export function anonymousValidator163358845(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys163358845],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7126,7 +7237,10 @@ export function anonymousValidator280827708(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys280827708],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7344,7 +7458,10 @@ export function anonymousValidator362930508(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys362930508],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7565,7 +7682,10 @@ export function anonymousValidator1864958291(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1864958291],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7708,7 +7828,10 @@ export function anonymousValidator310044624(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys310044624],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7811,7 +7934,10 @@ export function anonymousValidator343387919(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys343387919],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7936,7 +8062,10 @@ export function anonymousValidator1856722848(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1856722848],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -8020,7 +8149,10 @@ export function anonymousValidator2093168415(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2093168415],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };

--- a/packages/cli/src/generated/common/anonymous-validators.js
+++ b/packages/cli/src/generated/common/anonymous-validators.js
@@ -262,7 +262,10 @@ export function anonymousValidator229352914(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys229352914],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -366,7 +369,10 @@ export function anonymousValidator695211961(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys695211961],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -553,7 +559,10 @@ export function anonymousValidator385137474(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys385137474],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -763,7 +772,10 @@ export function anonymousValidator121992102(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys121992102],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -901,7 +913,10 @@ export function anonymousValidator596368827(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys596368827],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -968,7 +983,10 @@ export function anonymousValidator1885876481(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1885876481],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1100,7 +1118,10 @@ export function anonymousValidator1833756126(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1833756126],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1231,7 +1252,10 @@ export function anonymousValidator589626564(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys589626564],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1352,7 +1376,10 @@ export function anonymousValidator90605215(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys90605215],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1473,7 +1500,10 @@ export function anonymousValidator703944173(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys703944173],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1661,7 +1691,10 @@ export function anonymousValidator1437995341(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1437995341],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };

--- a/packages/code-gen/src/generated/common/anonymous-validators.js
+++ b/packages/code-gen/src/generated/common/anonymous-validators.js
@@ -2447,7 +2447,10 @@ export function anonymousValidator1006716453(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1006716453],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5074,7 +5077,10 @@ export function anonymousValidator729128062(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys729128062],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5198,7 +5204,10 @@ export function anonymousValidator1592295867(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1592295867],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5322,7 +5331,10 @@ export function anonymousValidator1045315509(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1045315509],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5446,7 +5458,10 @@ export function anonymousValidator564383959(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys564383959],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5571,7 +5586,10 @@ export function anonymousValidator817949617(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys817949617],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5696,7 +5714,10 @@ export function anonymousValidator67350838(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys67350838],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5821,7 +5842,10 @@ export function anonymousValidator210116167(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys210116167],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5948,7 +5972,10 @@ export function anonymousValidator1331366345(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1331366345],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6074,7 +6101,10 @@ export function anonymousValidator2008271825(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2008271825],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6195,7 +6225,10 @@ export function anonymousValidator914281176(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys914281176],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6321,7 +6354,10 @@ export function anonymousValidator1152297043(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1152297043],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6446,7 +6482,10 @@ export function anonymousValidator40811832(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys40811832],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6571,7 +6610,10 @@ export function anonymousValidator825072268(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys825072268],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6637,7 +6679,10 @@ export function anonymousValidator398159942(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys398159942],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6762,7 +6807,10 @@ export function anonymousValidator860724709(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys860724709],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7211,7 +7259,10 @@ export function anonymousValidator682118687(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys682118687],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7375,7 +7426,10 @@ export function anonymousValidator980814292(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys980814292],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7503,7 +7557,10 @@ export function anonymousValidator1664519436(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1664519436],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7624,7 +7681,10 @@ export function anonymousValidator1287070944(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1287070944],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };

--- a/packages/code-gen/src/generator/validator.js
+++ b/packages/code-gen/src/generator/validator.js
@@ -1028,7 +1028,10 @@ function anonymousValidatorObject(context, imports, type) {
               return {
                 errors: [
                   {
-                    propertyPath, key: "validator.object.strict", info: { extraKey: key },
+                    propertyPath, key: "validator.object.strict", info: {
+                      expectedKeys: [ ...objectKeys${hash} ],
+                      foundKeys: [ ...Object.keys(value) ],
+                    },
                   }
                 ],
               };

--- a/packages/code-gen/test/e2e/sql.test.js
+++ b/packages/code-gen/test/e2e/sql.test.js
@@ -866,7 +866,7 @@ test("code-gen/e2e/sql", async (t) => {
       t.ok(AppError.instanceOf(e));
       t.equal(e.key, `validator.error`);
       t.equal(e.info["$.userBuilder.where"].key, "validator.object.strict");
-      t.equal(e.info["$.userBuilder.where"].info.extraKey, "foo");
+      t.deepEqual(e.info["$.userBuilder.where"].info.foundKeys, ["foo"]);
     }
   });
 

--- a/packages/store/src/generated/common/anonymous-validators.js
+++ b/packages/store/src/generated/common/anonymous-validators.js
@@ -501,7 +501,10 @@ export function anonymousValidator2144828802(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2144828802],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -714,7 +717,10 @@ export function anonymousValidator599447075(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys599447075],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1239,7 +1245,10 @@ export function anonymousValidator1781782332(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1781782332],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1406,7 +1415,10 @@ export function anonymousValidator503384244(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys503384244],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1556,7 +1568,10 @@ export function anonymousValidator1337490931(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1337490931],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -1928,7 +1943,10 @@ export function anonymousValidator2074494218(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2074494218],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2197,7 +2215,10 @@ export function anonymousValidator1257773835(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1257773835],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2446,7 +2467,10 @@ export function anonymousValidator1577551207(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1577551207],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2513,7 +2537,10 @@ export function anonymousValidator1430489818(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1430489818],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2613,7 +2640,10 @@ export function anonymousValidator600974204(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys600974204],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2680,7 +2710,10 @@ export function anonymousValidator1334934277(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1334934277],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2809,7 +2842,10 @@ export function anonymousValidator2007164840(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2007164840],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -2965,7 +3001,10 @@ export function anonymousValidator1511542790(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1511542790],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3028,7 +3067,10 @@ export function anonymousValidator1442950861(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1442950861],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3091,7 +3133,10 @@ export function anonymousValidator553023933(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys553023933],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3154,7 +3199,10 @@ export function anonymousValidator661036808(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys661036808],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3377,7 +3425,10 @@ export function anonymousValidator1925201648(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1925201648],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3443,7 +3494,10 @@ export function anonymousValidator1476139765(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1476139765],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3506,7 +3560,10 @@ export function anonymousValidator1247704095(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1247704095],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3569,7 +3626,10 @@ export function anonymousValidator1462381984(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1462381984],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3710,7 +3770,10 @@ export function anonymousValidator1992090661(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1992090661],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3773,7 +3836,10 @@ export function anonymousValidator962402990(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys962402990],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -3874,7 +3940,10 @@ export function anonymousValidator617486747(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys617486747],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4200,7 +4269,10 @@ export function anonymousValidator165104378(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys165104378],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4347,7 +4419,10 @@ export function anonymousValidator1802084014(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1802084014],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -4798,7 +4873,10 @@ export function anonymousValidator600940900(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys600940900],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5072,7 +5150,10 @@ export function anonymousValidator286367525(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys286367525],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5242,7 +5323,10 @@ export function anonymousValidator2102646924(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2102646924],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5504,7 +5588,10 @@ export function anonymousValidator1516794677(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1516794677],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5737,7 +5824,10 @@ export function anonymousValidator84897941(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys84897941],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -5999,7 +6089,10 @@ export function anonymousValidator1345595702(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1345595702],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6345,7 +6438,10 @@ export function anonymousValidator163358845(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys163358845],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6649,7 +6745,10 @@ export function anonymousValidator280827708(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys280827708],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -6867,7 +6966,10 @@ export function anonymousValidator362930508(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys362930508],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7088,7 +7190,10 @@ export function anonymousValidator1864958291(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1864958291],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7190,7 +7295,10 @@ export function anonymousValidator310044624(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys310044624],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7293,7 +7401,10 @@ export function anonymousValidator343387919(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys343387919],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7418,7 +7529,10 @@ export function anonymousValidator1856722848(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys1856722848],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };
@@ -7502,7 +7616,10 @@ export function anonymousValidator2093168415(value, propertyPath) {
           {
             propertyPath,
             key: "validator.object.strict",
-            info: { extraKey: key },
+            info: {
+              expectedKeys: [...objectKeys2093168415],
+              foundKeys: [...Object.keys(value)],
+            },
           },
         ],
       };


### PR DESCRIPTION
…bject.strict` errors

Closes #1828

BREAKING CHANGE:
- `info.extraKey` is replaced by `info.expectedKeys` and `info.foundKeys` in `validator.object.strict` errors. See [#1828](https://github.com/compasjs/compas/issues/1828) for more information.