### PR TITLE
feat(cli): improve printing of 'actual' values in `t.ok` and `t.notOk`

### DIFF
--- a/packages/cli/src/testing/runner.js
+++ b/packages/cli/src/testing/runner.js
@@ -162,7 +162,7 @@ function ok(state, value, message) {
     type: "ok",
     passed,
     meta: {
-      actual: passed,
+      actual: value,
       expected: true,
     },
     message,
@@ -181,7 +181,7 @@ function notOk(state, value, message) {
     type: "notOk",
     passed,
     meta: {
-      actual: passed,
+      actual: value,
       expected: false,
     },
     message,


### PR DESCRIPTION
Closes #1836