### PR TITLE
feat(code-gen): add check to prevent double `oneToOne` creation

### DIFF
--- a/packages/code-gen/src/crud/e2e/nested.test.js
+++ b/packages/code-gen/src/crud/e2e/nested.test.js
@@ -174,18 +174,36 @@ test("code-gen/crud/e2e/nested", async (t) => {
       }
     });
 
-    t.test("apiRoleInfoCreate", async (t) => {
-      const { item } = await apiRoleInfoCreate(
-        axiosInstance,
-        {
-          roleId: role.id,
-        },
-        {
-          description: "Foo bar baz",
-        },
-      );
+    t.test("apiRoleInfoCreate", (t) => {
+      t.test("success", async (t) => {
+        const { item } = await apiRoleInfoCreate(
+          axiosInstance,
+          {
+            roleId: role.id,
+          },
+          {
+            description: "Foo bar baz",
+          },
+        );
 
-      t.equal(item.role, role.id);
+        t.equal(item.role, role.id);
+      });
+
+      t.test("fails - second time", async (t) => {
+        try {
+          await apiRoleInfoCreate(
+            axiosInstance,
+            {
+              roleId: role.id,
+            },
+            {
+              description: "Foo bar baz",
+            },
+          );
+        } catch (e) {
+          t.equal(e.key, "roleInfo.create.alreadyExists");
+        }
+      });
     });
 
     t.test("apiRoleInfoSingle", async (t) => {

--- a/packages/code-gen/src/crud/partials/routes.js
+++ b/packages/code-gen/src/crud/partials/routes.js
@@ -62,6 +62,9 @@ ${data.handlerName} = async (ctx, next) => {
  *     bodyKey: string,
  *     paramsKey: string,
  *   },
+ *   oneToOneChecks?: {
+ *     builder: string,
+ *   }
  * }} data
  * @returns {string}
  */
@@ -70,6 +73,23 @@ ${data.handlerName} = async (ctx, next) => {
   ${
     data.applyParams
       ? `ctx.validatedBody.${data.applyParams.bodyKey} = ctx.validatedParams.${data.applyParams.paramsKey};`
+      : ``
+  }
+  ${
+    data.oneToOneChecks
+      ? `
+  try {
+    const builder = ${data.oneToOneChecks.builder};
+    const exists = await ${data.crudName}Single(newEventFromEvent(ctx.event), sql, builder);
+    if (exists) {
+      throw AppError.validationError("${data.crudName}.create.alreadyExists");
+    }
+  } catch (e) {
+    if (e.key === "${data.crudName}.create.alreadyExists") {
+      throw e;
+    }
+  }
+`
       : ``
   }
   

--- a/packages/code-gen/src/crud/route-implementer.js
+++ b/packages/code-gen/src/crud/route-implementer.js
@@ -204,9 +204,22 @@ function crudGenerateRouteImplementationCreateRoute(
           paramsKey: crudCreateRouteParam(type.internalSettings.parent),
         }
       : undefined,
+    oneToOneChecks:
+      type.internalSettings.usedRelation?.subType === "oneToOneReverse"
+        ? {
+            builder: crudFormatBuilder(
+              crudGetBuilder(type, {
+                includeOwnParam: true,
+                includeJoins: false,
+                traverseParents: true,
+              }),
+            ),
+          }
+        : undefined,
   };
 
   importer.destructureImport(`newEventFromEvent`, "@compas/stdlib");
+  importer.destructureImport(`AppError`, "@compas/stdlib");
   importer.destructureImport(`${data.crudName}Transform`, "./events.js");
   importer.destructureImport(`${data.crudName}Create`, "./events.js");
   importer.destructureImport(


### PR DESCRIPTION
Creating multiple records in a `oneToOne` relation gives unexpected results. It also prevents usage of `single` and indirectly `update` and `delete` routes, since the `single` checks if only one record is returned from the provided builder.

/cc @tjonger 

References #1843