### PR TITLE
fix(code-gen): resolve out of group refs in router generator

### DIFF
--- a/examples/session-handling/src/generated/common/router.js
+++ b/examples/session-handling/src/generated/common/router.js
@@ -4,8 +4,8 @@
 import { compose } from "@compas/server";
 import { AppError, eventRename } from "@compas/stdlib";
 import { authHandlers } from "../auth/controller.js";
-import * as authValidators from "../auth/validators.js";
 import { compasHandlers } from "../compas/controller.js";
+import * as authValidators from "../auth/validators.js";
 import * as compasValidators from "../compas/validators.js";
 import { compasApiStructureString } from "./structure.js";
 

--- a/packages/code-gen/src/generator/router/templates/routerFile.tmpl
+++ b/packages/code-gen/src/generator/router/templates/routerFile.tmpl
@@ -1,9 +1,23 @@
 import { compose } from "@compas/server";
 import { AppError, eventRename } from "@compas/stdlib";
+{{ const importControllerSet = new Set(); }}
+{{ const importValidatorSet = new Set(); }}
 {{ for (const group of Object.keys(structure)) { }}
     {{ const hasRouteObject = Object.values(structure[group]).find(it => it.type === "route"); }}
     {{ if (hasRouteObject === undefined) { continue; } }}
+    {{ importControllerSet.add(group); }}
+    {{ importValidatorSet.add(group); }}
+    {{ for (const r of Object.values(structure[group])) { }}
+      {{ if (r.params) { importValidatorSet.add(r.params.reference.group); } }}
+      {{ if (r.query) { importValidatorSet.add(r.query.reference.group); } }}
+      {{ if (r.body) { importValidatorSet.add(r.body.reference.group); } }}
+      {{ if (r.files) { importValidatorSet.add(r.files.reference.group); } }}
+    {{ } }}
+{{ } }}
+{{ for (const group of importControllerSet) { }}
     import { {{= group }}Handlers } from "../{{=group }}/controller{{= importExtension }}";
+{{ } }}
+{{ for (const group of importValidatorSet) { }}
     import * as {{= group }}Validators from "../{{= group }}/validators{{= importExtension }}";
 {{ } }}
 


### PR DESCRIPTION
This is due to the new structure api dump which dumps the resolved references instead of the intermediate references.