### PR TITLE
fix(server): ensure log level is inherited from AppError

### DIFF
--- a/packages/server/src/middleware/error.js
+++ b/packages/server/src/middleware/error.js
@@ -34,8 +34,11 @@ export function errorHandler(opts) {
       let log = ctx.log.info;
 
       if (!AppError.instanceOf(error)) {
-        log = ctx.log.error;
         err = new AppError("error.server.internal", 500, {}, error);
+      }
+
+      if (error.status === 500) {
+        log = ctx.log.error;
       }
 
       ctx.status = err.status;


### PR DESCRIPTION
Ensure log entry `level` property is correct for AppError.serverErrors