### PR TITLE
fix(code-gen): correctly prioritze existing named items in the structure

### DIFF
--- a/packages/code-gen/src/structure/structureHoistNamedItems.js
+++ b/packages/code-gen/src/structure/structureHoistNamedItems.js
@@ -21,10 +21,12 @@ export function structureHoistNamedItems(structure) {
       return type;
     }
 
-    structureAddType(structure, type);
-
-    if (metadata.isNamedType) {
+    // @ts-expect-error
+    if (metadata.isNamedType && structure[type.group]?.[type.name]) {
       return type;
+      // @ts-expect-error
+    } else if (!structure[type.group]?.[type.name]) {
+      structureAddType(structure, type);
     }
 
     // @ts-expect-error

--- a/packages/code-gen/src/structure/structureHoistNamedItems.test.js
+++ b/packages/code-gen/src/structure/structureHoistNamedItems.test.js
@@ -1,0 +1,47 @@
+import { mainTestFn, test } from "@compas/cli";
+import { structureHoistNamedItems } from "./structureHoistNamedItems.js";
+
+mainTestFn(import.meta);
+
+test("code-gen/structure/structureHoistNamedItems", (t) => {
+  t.test("should not overwritten named items", (t) => {
+    const structure = {
+      group2: {
+        bar: {
+          type: "object",
+          name: "bar",
+          group: "group2",
+          isOptional: false,
+          keys: {},
+          relations: [],
+        },
+      },
+      group1: {
+        baz: {
+          type: "object",
+          name: "baz",
+          group: "group1",
+          keys: {
+            ref: {
+              type: "object",
+              keys: {},
+              relations: [],
+            },
+          },
+          relations: [],
+        },
+      },
+    };
+
+    structure.group1.baz.keys.ref = {
+      ...structure.group2.bar,
+      isOptional: true,
+    };
+
+    t.log.info(structure);
+
+    structureHoistNamedItems(structure);
+
+    t.equal(structure.group2.bar.isOptional, false);
+  });
+});


### PR DESCRIPTION
If a named item was copied as is in the structure, and then mutated, it would override the initial named item.