### PR TITLE
feat(compas): use sub entrypoints (`compas/cli`) instead of a single entrypoint

### DIFF
--- a/packages/compas/index.d.ts
+++ b/packages/compas/index.d.ts
@@ -1,6 +1,0 @@
-export * from "@compas/cli";
-export * from "@compas/code-gen";
-export * from "@compas/server";
-export * from "@compas/stdlib";
-export * from "@compas/store";
-//# sourceMappingURL=index.d.ts.map

--- a/packages/compas/index.js
+++ b/packages/compas/index.js
@@ -1,5 +1,0 @@
-export * from "@compas/cli";
-export * from "@compas/code-gen";
-export * from "@compas/server";
-export * from "@compas/stdlib";
-export * from "@compas/store";

--- a/packages/compas/package.json
+++ b/packages/compas/package.json
@@ -2,8 +2,13 @@
   "name": "compas",
   "version": "0.0.209",
   "description": "Unified backend tooling",
-  "main": "./index.js",
-  "exports": "./index.js",
+  "exports": {
+    "./cli": "./src/exports/cli.js",
+    "./code-gen": "./src/exports/code-gen.js",
+    "./server": "./src/exports/server.js",
+    "./stdlib": "./src/exports/stdlib.js",
+    "./store": "./src/exports/store.js"
+  },
   "types": "./index.d.ts",
   "type": "module",
   "keywords": [

--- a/packages/compas/src/exports/cli.d.ts
+++ b/packages/compas/src/exports/cli.d.ts
@@ -1,0 +1,2 @@
+export * from "@compas/cli";
+//# sourceMappingURL=cli.d.ts.map

--- a/packages/compas/src/exports/cli.js
+++ b/packages/compas/src/exports/cli.js
@@ -1,0 +1,1 @@
+export * from "@compas/cli";

--- a/packages/compas/src/exports/code-gen.d.ts
+++ b/packages/compas/src/exports/code-gen.d.ts
@@ -1,0 +1,2 @@
+export * from "@compas/code-gen";
+//# sourceMappingURL=code-gen.d.ts.map

--- a/packages/compas/src/exports/code-gen.js
+++ b/packages/compas/src/exports/code-gen.js
@@ -1,0 +1,1 @@
+export * from "@compas/code-gen";

--- a/packages/compas/src/exports/exports.test.js
+++ b/packages/compas/src/exports/exports.test.js
@@ -1,0 +1,12 @@
+/* eslint-disable import/no-unresolved */
+import { test, mainTestFn } from "compas/cli";
+
+mainTestFn(import.meta);
+
+test("compas/exports", async (t) => {
+  await import("compas/code-gen");
+  await import("compas/server");
+  await import("compas/stdlib");
+  await import("compas/store");
+  t.pass();
+});

--- a/packages/compas/src/exports/server.d.ts
+++ b/packages/compas/src/exports/server.d.ts
@@ -1,0 +1,2 @@
+export * from "@compas/server";
+//# sourceMappingURL=server.d.ts.map

--- a/packages/compas/src/exports/server.js
+++ b/packages/compas/src/exports/server.js
@@ -1,0 +1,1 @@
+export * from "@compas/server";

--- a/packages/compas/src/exports/stdlib.d.ts
+++ b/packages/compas/src/exports/stdlib.d.ts
@@ -1,0 +1,2 @@
+export * from "@compas/stdlib";
+//# sourceMappingURL=stdlib.d.ts.map

--- a/packages/compas/src/exports/stdlib.js
+++ b/packages/compas/src/exports/stdlib.js
@@ -1,0 +1,1 @@
+export * from "@compas/stdlib";

--- a/packages/compas/src/exports/store.d.ts
+++ b/packages/compas/src/exports/store.d.ts
@@ -1,0 +1,2 @@
+export * from "@compas/store";
+//# sourceMappingURL=store.d.ts.map

--- a/packages/compas/src/exports/store.js
+++ b/packages/compas/src/exports/store.js
@@ -1,0 +1,1 @@
+export * from "@compas/store";


### PR DESCRIPTION
This gives us flexibility to add other features to this package.
However, this hurts discoverability a bit, since now you have to check the 5 specific exports for the thing you need.

BREAKING CHANGE:
- Change any direct `compas` import to `compas/pkg` or `@compas/pkg`.