### PR TITLE
fix(code-gen): correctly generate types and api client for file uploads via React Native

### DIFF
--- a/examples/session-handling/src/generated/common/structure.js
+++ b/examples/session-handling/src/generated/common/structure.js
@@ -9,6 +9,7 @@ export const compasGenerateSettings = {
   isNodeServer: true,
   isNode: true,
   enabledGenerators: ["type", "validator", "router", "sql", "apiClient"],
+  environment: {},
   useTypescript: false,
   dumpStructure: false,
   dumpApiStructure: true,

--- a/packages/cli/src/generated/common/structure.d.ts
+++ b/packages/cli/src/generated/common/structure.d.ts
@@ -5,6 +5,7 @@ export namespace compasGenerateSettings {
   const isNodeServer: boolean;
   const isNode: boolean;
   const enabledGenerators: string[];
+  const environment: {};
   const useTypescript: boolean;
   const dumpStructure: boolean;
   const dumpApiStructure: boolean;

--- a/packages/cli/src/generated/common/structure.js
+++ b/packages/cli/src/generated/common/structure.js
@@ -9,6 +9,7 @@ export const compasGenerateSettings = {
   isNodeServer: false,
   isNode: true,
   enabledGenerators: ["validator", "type"],
+  environment: {},
   useTypescript: false,
   dumpStructure: true,
   dumpApiStructure: false,

--- a/packages/code-gen/src/App.d.ts
+++ b/packages/code-gen/src/App.d.ts
@@ -126,6 +126,19 @@ export type GenerateOpts = {
   isNode?: boolean | undefined;
   isNodeServer?: boolean | undefined;
   /**
+   * Options for conforming the output based on the
+   * specified environment and runtime.
+   */
+  environment?:
+    | {
+        /**
+         * Switch api client
+         * generation and corresponding types based on the available globals.
+         */
+        clientRuntime?: "browser" | "react-native" | undefined;
+      }
+    | undefined;
+  /**
    * Enabling specific generators.
    */
   enabledGenerators?:

--- a/packages/code-gen/src/App.js
+++ b/packages/code-gen/src/App.js
@@ -35,6 +35,10 @@ import { lowerCaseFirst } from "./utils.js";
  * @property {boolean|undefined} [isBrowser]
  * @property {boolean|undefined} [isNode]
  * @property {boolean|undefined} [isNodeServer]
+ * @property {object} [environment] Options for conforming the output based on the
+ *   specified environment and runtime.
+ * @property {"browser"|"react-native"} [environment.clientRuntime] Switch api client
+ *   generation and corresponding types based on the available globals.
  * @property {(
  *   "type"|
  *   "validator"|
@@ -65,6 +69,9 @@ const defaultGenerateOptionsBrowser = {
   isNodeServer: false,
   isNode: false,
   enabledGenerators: ["type", "apiClient", "reactQuery"],
+  environment: {
+    clientRuntime: "browser",
+  },
   useTypescript: true,
   dumpStructure: false,
   dumpApiStructure: false,
@@ -79,6 +86,7 @@ const defaultGenerateOptionsNodeServer = {
   isNodeServer: true,
   isNode: true,
   enabledGenerators: ["type", "validator", "sql", "router", "apiClient"],
+  environment: {},
   useTypescript: false,
   dumpStructure: false,
   dumpApiStructure: true,
@@ -93,6 +101,7 @@ const defaultGenerateOptionsNode = {
   isNodeServer: false,
   isNode: true,
   enabledGenerators: ["type", "validator"],
+  environment: {},
   useTypescript: false,
   dumpStructure: false,
   dumpApiStructure: false,
@@ -354,6 +363,13 @@ export class App {
       options.enabledGenerators.length > 0
         ? options.enabledGenerators
         : opts.enabledGenerators ?? [];
+
+    if (options.environment) {
+      opts.environment = {
+        ...(opts.environment ?? {}),
+        ...options.environment,
+      };
+    }
 
     // Quick hack so we can test if we have generated
     // before running the tests.

--- a/packages/code-gen/src/generated/common/structure.d.ts
+++ b/packages/code-gen/src/generated/common/structure.d.ts
@@ -5,6 +5,7 @@ export namespace compasGenerateSettings {
   const isNodeServer: boolean;
   const isNode: boolean;
   const enabledGenerators: string[];
+  const environment: {};
   const useTypescript: boolean;
   const dumpStructure: boolean;
   const dumpApiStructure: boolean;

--- a/packages/code-gen/src/generated/common/structure.js
+++ b/packages/code-gen/src/generated/common/structure.js
@@ -9,6 +9,7 @@ export const compasGenerateSettings = {
   isNodeServer: false,
   isNode: true,
   enabledGenerators: ["validator", "type"],
+  environment: {},
   useTypescript: false,
   dumpStructure: true,
   dumpApiStructure: false,

--- a/packages/code-gen/src/generator/apiClient/templates/apiClientFn.tmpl
+++ b/packages/code-gen/src/generator/apiClient/templates/apiClientFn.tmpl
@@ -63,7 +63,11 @@ export async function api{{= item.uniqueName }}(
         {{= options.useTypescript ? `// @ts-ignore` : "" }}
         const keyFiles = Array.isArray(files[key]) ? files[key] : [files[key]];
         for (const file of keyFiles) {
-          data.append(key, file.data, file.name);
+          {{ if (options.environment.clientRuntime === "react-native") { }}
+            data.append(key, file);
+          {{ } else { }}
+            data.append(key, file.data, file.name);
+          {{ } }}
         }
       }
     {{ } else if (item.body) { }}

--- a/packages/code-gen/src/generator/types.js
+++ b/packages/code-gen/src/generator/types.js
@@ -284,7 +284,13 @@ export function generateTypeDefinition(
       break;
     case "file":
       if (fileTypeIO === "input" && isBrowser) {
-        result += `{ name?: string, data: Blob }`;
+        if (context.options.environment.clientRuntime === "browser") {
+          result += `{ name?: string, data: Blob }`;
+        } else if (
+          context.options.environment.clientRuntime === "react-native"
+        ) {
+          result += `(string | {name?: string, type?: string, uri: string })`;
+        }
       } else if (fileTypeIO === "input" && isNode) {
         result += `{ name?: string, data: ReadableStream }`;
       } else if (fileTypeIO === "outputRouter") {

--- a/packages/code-gen/test/environment/react-native.test.js
+++ b/packages/code-gen/test/environment/react-native.test.js
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import { mainTestFn, test } from "@compas/cli";
+import { pathJoin } from "@compas/stdlib";
+import { TypeCreator } from "../../src/builders/index.js";
+import { codeGenToTemporaryDirectory } from "../utils.test.js";
+
+mainTestFn(import.meta);
+
+test("code-gen/environment/react-native", async (t) => {
+  const T = new TypeCreator("app");
+  const R = T.router("/app");
+
+  const { exitCode, generatedDirectory, stdout } =
+    await codeGenToTemporaryDirectory(
+      [
+        R.post("/file", "file").files({
+          file: T.file(),
+        }),
+      ],
+      {
+        isBrowser: true,
+        environment: {
+          clientRuntime: "react-native",
+        },
+      },
+    );
+
+  t.equal(exitCode, 0);
+
+  if (exitCode !== 0) {
+    t.log.error(stdout);
+  }
+
+  const apiClientPath = pathJoin(generatedDirectory, "app/apiClient.ts");
+  const apiClientSource = await readFile(apiClientPath, "utf-8");
+
+  const typesPath = pathJoin(generatedDirectory, "common/types.ts");
+  const typesSource = await readFile(typesPath, "utf-8");
+
+  // FormData.append has a different signature compared to Node.js FormData and Browser
+  // FormData;
+  t.ok(apiClientSource.includes("data.append(key, file);"));
+  t.ok(typesSource.includes("uri: string"));
+});

--- a/packages/store/src/generated/common/structure.d.ts
+++ b/packages/store/src/generated/common/structure.d.ts
@@ -5,6 +5,7 @@ export namespace compasGenerateSettings {
   const isNodeServer: boolean;
   const isNode: boolean;
   const enabledGenerators: string[];
+  const environment: {};
   const useTypescript: boolean;
   const dumpStructure: boolean;
   const dumpApiStructure: boolean;

--- a/packages/store/src/generated/common/structure.js
+++ b/packages/store/src/generated/common/structure.js
@@ -9,6 +9,7 @@ export const compasGenerateSettings = {
   isNodeServer: false,
   isNode: true,
   enabledGenerators: ["sql", "validator"],
+  environment: {},
   useTypescript: false,
   dumpStructure: true,
   dumpApiStructure: false,


### PR DESCRIPTION
This is done by accepting an `environment.clientRuntime` option via the generate options.

Closes #1908