### PR TITLE
feat(cli): suppress info logs by default.

### DIFF
--- a/docs/features/test-and-bench-runner.md
+++ b/docs/features/test-and-bench-runner.md
@@ -33,9 +33,11 @@ test("my test", (t) => {
 ### Running tests
 
 There are two ways to run tests. The short way is to use `compas test` which
-will run all test files in your project. There is also the option to run a test
-file directly like `node ./file.test.js` or `compas run ./file.test.js`.
-However, to do this you need to add the following to your test file:
+will run all test files in your project. It supports various flags like
+`--with-logs` to enable all info-logs in your project. By default, the test
+runner only logs errors. There is also the option to run a test file directly
+like `node ./file.test.js` or `compas run ./file.test.js`. However, to do this,
+you need to add the following to your test file:
 
 ```js
 import { mainTestFn } from "@compas/cli";
@@ -44,7 +46,8 @@ mainTestFn(import.meta);
 ```
 
 It works based on `mainFn` as explained in the
-[cli page](/features/cli.html#mainfn).
+[cli page](/features/cli.html#mainfn). Running your test file like this, will
+also enable all your logs.
 
 ### Setup and teardown per test file
 

--- a/packages/cli/src/testing/config.js
+++ b/packages/cli/src/testing/config.js
@@ -1,6 +1,11 @@
 import { existsSync } from "fs";
 import { pathToFileURL } from "url";
-import { pathJoin } from "@compas/stdlib";
+import {
+  environment,
+  loggerGetGlobalDestination,
+  loggerSetGlobalDestination,
+  pathJoin,
+} from "@compas/stdlib";
 import {
   ignoreDirectories,
   setGlobalSetup,
@@ -23,6 +28,17 @@ const configPath = pathJoin(process.cwd(), "test/config.js");
 export async function loadTestConfig() {
   if (!existsSync(configPath)) {
     return;
+  }
+
+  if (environment._COMPAS_TEST_WITH_LOGS === "false") {
+    const destination = loggerGetGlobalDestination();
+    loggerSetGlobalDestination({
+      write(msg) {
+        if (msg.includes(` error[`) || msg.includes(`"level":"error"`)) {
+          destination.write(msg);
+        }
+      },
+    });
   }
 
   // @ts-ignore

--- a/packages/cli/src/testing/runner.js
+++ b/packages/cli/src/testing/runner.js
@@ -1,6 +1,6 @@
 import { AssertionError, deepStrictEqual } from "assert";
 import { url } from "inspector";
-import { isNil } from "@compas/stdlib";
+import { isNil, newLogger } from "@compas/stdlib";
 import { setTestTimeout, state, testLogger, timeout } from "./state.js";
 
 /**
@@ -107,7 +107,11 @@ export const test = subTest.bind(undefined, state);
 
 function createRunnerForState(testState, abortSignal) {
   return {
-    log: testLogger,
+    log: newLogger({
+      ctx: {
+        name: testState.name,
+      },
+    }),
     signal: abortSignal,
     ok: ok.bind(undefined, testState),
     notOk: notOk.bind(undefined, testState),

--- a/packages/cli/src/testing/state.test.js
+++ b/packages/cli/src/testing/state.test.js
@@ -1,5 +1,5 @@
 import { test } from "./runner.js";
-import { areTestsRunning, testLogger, timeout } from "./state.js";
+import { areTestsRunning, timeout } from "./state.js";
 import { mainTestFn } from "./utils.js";
 
 mainTestFn(import.meta);

--- a/packages/cli/src/testing/state.test.js
+++ b/packages/cli/src/testing/state.test.js
@@ -16,7 +16,8 @@ test("cli/test/state", (t) => {
   });
 
   t.test("test logger is available", (t) => {
-    t.equal(t.log, testLogger);
+    t.equal(typeof t.log.info, "function");
+    t.equal(typeof t.log.error, "function");
   });
 
   t.test("set timeout of child test", (t) => {

--- a/packages/cli/src/testing/utils.js
+++ b/packages/cli/src/testing/utils.js
@@ -1,5 +1,4 @@
 import { mainFn } from "@compas/stdlib";
-import treeKill from "tree-kill";
 import { areTestsRunning, setAreTestRunning, setTestLogger } from "./state.js";
 import { runTestsInProcess } from "./worker-internal.js";
 
@@ -26,12 +25,6 @@ export function mainTestFn(meta) {
     const exitCode = await runTestsInProcess({
       singleFileMode: true,
     });
-
-    if (exitCode !== 0) {
-      return new Promise((r) => {
-        treeKill(process.pid, exitCode, r);
-      });
-    }
 
     process.exit(exitCode);
   });

--- a/packages/stdlib/index.d.ts
+++ b/packages/stdlib/index.d.ts
@@ -46,6 +46,7 @@ export {
 } from "./src/utils.js";
 export {
   newLogger,
+  loggerGetGlobalDestination,
   loggerSetGlobalDestination,
   loggerGetPrettyPrinter,
   loggerExtendGlobalContext,

--- a/packages/stdlib/index.js
+++ b/packages/stdlib/index.js
@@ -76,6 +76,7 @@ export {
 
 export {
   newLogger,
+  loggerGetGlobalDestination,
   loggerSetGlobalDestination,
   loggerGetPrettyPrinter,
   loggerExtendGlobalContext,

--- a/packages/stdlib/src/logger.d.ts
+++ b/packages/stdlib/src/logger.d.ts
@@ -20,6 +20,15 @@ export function loggerSetGlobalDestination(
   destination: import("pino").DestinationStream,
 ): void;
 /**
+ * Returns the current pino destination.
+ *
+ * This can be used to temporarily set a different destination for the newly created
+ * loggers and then reusing the destination for the rest of your application.
+ *
+ * @returns {import("pino").DestinationStream}
+ */
+export function loggerGetGlobalDestination(): import("pino").DestinationStream;
+/**
  * Set the global root pino instance. We use a single instance, so the same destination
  * will be used for all sub loggers.
  *

--- a/packages/stdlib/src/logger.js
+++ b/packages/stdlib/src/logger.js
@@ -29,9 +29,9 @@ import { loggerWriteGithubActions, loggerWritePretty } from "./log-writers.js";
 const globalContext = {};
 
 /**
- * @type {boolean}
+ * @type {import("pino").DestinationStream|undefined}
  */
-let didSetLogger = false;
+let globalDestination = undefined;
 
 /**
  * @type {import("pino").Logger}
@@ -66,8 +66,21 @@ export function loggerExtendGlobalContext(context) {
  * @param {import("pino").DestinationStream} destination
  */
 export function loggerSetGlobalDestination(destination) {
-  didSetLogger = true;
+  globalDestination = destination;
   rootInstance = loggerBuildRootInstance(destination);
+}
+
+/**
+ * Returns the current pino destination.
+ *
+ * This can be used to temporarily set a different destination for the newly created
+ * loggers and then reusing the destination for the rest of your application.
+ *
+ * @returns {import("pino").DestinationStream}
+ */
+export function loggerGetGlobalDestination() {
+  // @ts-expect-error
+  return globalDestination;
 }
 
 /**
@@ -125,11 +138,9 @@ export function newLogger(options) {
  * 'ndjson', 'github-actions'.
  */
 export function loggerDetermineDefaultDestination() {
-  if (didSetLogger) {
+  if (globalDestination) {
     return;
   }
-
-  didSetLogger = true;
 
   const isProd = isProduction();
   const isGitHubActions = environment.GITHUB_ACTIONS === "true";

--- a/src/testing.js
+++ b/src/testing.js
@@ -26,7 +26,9 @@ export const testBucketName = uuid();
  * @returns {Promise<void>}
  */
 export async function injectTestServices() {
-  sql = await createTestPostgresDatabase();
+  sql = await createTestPostgresDatabase({
+    onnotice: () => {},
+  });
   minioClient = newMinioClient({});
 
   await ensureBucket(minioClient, testBucketName, "eu-central-1");


### PR DESCRIPTION
Introduces `compas test --with-logs` to enable all logs.

Closes #1930

BREAKING CHANGES:
- When tests are executed via `compas test`, the info logs are suppressed by default. To enable all info logs, either use `compas test --with-logs` or run a specific test file with `mainTestFn` via `compas run ./file.test.js`.