### PR TITLE
feat(store): support Postgres native environment variables

### DIFF
--- a/packages/store/src/postgres.js
+++ b/packages/store/src/postgres.js
@@ -13,11 +13,17 @@ export function buildAndCheckOpts(opts) {
       },
       no_prepare: true,
       ssl: isProduction() ? "require" : "prefer",
-      database: environment.POSTGRES_DATABASE ?? environment.APP_NAME,
-      user: environment.POSTGRES_USER,
-      password: environment.POSTGRES_PASSWORD,
-      host: environment.POSTGRES_HOST,
-      port: environment.POSTGRES_PORT,
+      database:
+        environment.POSTGRES_DATABASE ??
+        environment.PGDATABASE ??
+        environment.APP_NAME,
+      user:
+        environment.POSTGRES_USER ??
+        environment.PGUSERNAME ??
+        environment.PGUSER,
+      password: environment.POSTGRES_PASSWORD ?? environment.PGPASSWORD,
+      host: environment.POSTGRES_HOST ?? environment.PGHOST,
+      port: environment.POSTGRES_PORT ?? environment.PGPORT,
       max: 15,
       types: {
         // Used by


### PR DESCRIPTION
Closes #1928

BREAKING CHANGE:
- `process.env.PGDATABASE` is used before `process.env.APP_NAME` as the database name for Postgres connections