### PR TITLE
feat(store): support inner- and left joins in the query builder

### DIFF
--- a/benchmark/query.bench.js
+++ b/benchmark/query.bench.js
@@ -78,7 +78,7 @@ bench("query - append where clause and exec", async (b) => {
   }
 });
 
-bench("query - querySessionStore ", async (b) => {
+bench("query - querySessionStore", async (b) => {
   await import("../packages/store/src/generated/database/index.js");
   const { querySessionStore } = await import(
     "../packages/store/src/generated/database/sessionStore.js"
@@ -97,7 +97,7 @@ bench("query - querySessionStore ", async (b) => {
   }
 });
 
-bench("query - querySessionStore with where ", async (b) => {
+bench("query - querySessionStore with where", async (b) => {
   await import("../packages/store/src/generated/database/index.js");
   const { querySessionStore } = await import(
     "../packages/store/src/generated/database/sessionStore.js"
@@ -118,7 +118,7 @@ bench("query - querySessionStore with where ", async (b) => {
   }
 });
 
-bench("query - querySessionStore nested ", async (b) => {
+bench("query - querySessionStore nested", async (b) => {
   await import("../packages/store/src/generated/database/index.js");
   const { querySessionStore } = await import(
     "../packages/store/src/generated/database/sessionStore.js"
@@ -129,6 +129,68 @@ bench("query - querySessionStore nested ", async (b) => {
     const q = querySessionStore({
       where: {},
       accessTokens: {},
+    });
+
+    q.queryPart.exec({
+      // eslint-disable-next-line no-unused-vars
+      unsafe(query, parameters) {
+        // Don't do any work here
+      },
+    });
+  }
+});
+
+bench("query - querySessionStore joins", async (b) => {
+  await import("../packages/store/src/generated/database/index.js");
+  const { querySessionStore } = await import(
+    "../packages/store/src/generated/database/sessionStore.js"
+  );
+  b.resetTime();
+
+  for (let i = 0; i < b.N; ++i) {
+    const q = querySessionStore({
+      leftJoin: {
+        accessTokens: {
+          shortName: "at",
+          innerJoin: {
+            refreshToken: {
+              shortName: "rt",
+            },
+          },
+        },
+      },
+    });
+
+    q.queryPart.exec({
+      // eslint-disable-next-line no-unused-vars
+      unsafe(query, parameters) {
+        // Don't do any work here
+      },
+    });
+  }
+});
+
+bench("query - querySessionStore joins + nested", async (b) => {
+  await import("../packages/store/src/generated/database/index.js");
+  const { querySessionStore } = await import(
+    "../packages/store/src/generated/database/sessionStore.js"
+  );
+  b.resetTime();
+
+  for (let i = 0; i < b.N; ++i) {
+    const q = querySessionStore({
+      where: {},
+      accessTokens: {},
+      leftJoin: {
+        accessTokens: {
+          shortName: "at",
+          innerJoin: {
+            refreshToken: {
+              shortName: "rt",
+            },
+          },
+        },
+      },
     });
 
     q.queryPart.exec({

--- a/examples/session-handling/src/generated/common/anonymous-validators.js
+++ b/examples/session-handling/src/generated/common/anonymous-validators.js
@@ -293,7 +293,10 @@ const objectKeys310044624 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
 ]);
+const objectKeys2062700716 = new Set([""]);
 const objectKeys343387919 = new Set([
   "where",
   "orderBy",
@@ -302,7 +305,10 @@ const objectKeys343387919 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
 ]);
+const objectKeys1245980333 = new Set([""]);
 const objectKeys2093168415 = new Set([
   "where",
   "orderBy",
@@ -311,7 +317,27 @@ const objectKeys2093168415 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
   "accessTokens",
+]);
+const objectKeys1346727779 = new Set(["accessTokens"]);
+const objectKeys588258860 = new Set([
+  "innerJoin",
+  "leftJoin",
+  "where",
+  "shortName",
+]);
+const objectKeys1418696316 = new Set([
+  "session",
+  "refreshToken",
+  "accessToken",
+]);
+const objectKeys927057687 = new Set([
+  "innerJoin",
+  "leftJoin",
+  "where",
+  "shortName",
 ]);
 const objectKeys1856722848 = new Set([
   "where",
@@ -321,6 +347,8 @@ const objectKeys1856722848 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
   "session",
   "refreshToken",
   "accessToken",
@@ -9970,7 +9998,72 @@ export function anonymousValidator1532767426(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("bucketName"|"contentLength"|"contentType"|"name"|"meta"|"id"|"createdAt"|"updatedAt")[], }>}
+ * @returns {EitherN<{}>}
+ */
+export function anonymousValidator2062700716(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys2062700716.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys2062700716],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreFileJoins>}
+ */
+export function anonymousValidator77636329(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator2062700716(value, propertyPath);
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("bucketName"|"contentLength"|"contentType"|"name"|"meta"|"id"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreFileJoins, "innerJoin"?: undefined|StoreFileJoins, }>}
  */
 export function anonymousValidator310044624(value, propertyPath) {
   if (isNil(value)) {
@@ -10093,6 +10186,28 @@ export function anonymousValidator310044624(value, propertyPath) {
       result["select"] = validatorResult.value;
     }
   }
+  {
+    const validatorResult = anonymousValidator77636329(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator77636329(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
   if (errors.length > 0) {
     return { errors };
   }
@@ -10200,7 +10315,72 @@ export function anonymousValidator582777968(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "orderBy"?: undefined|StoreJobOrderBy, "orderBySpec"?: undefined|StoreJobOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("id"|"isComplete"|"priority"|"scheduledAt"|"name"|"data"|"retryCount"|"handlerTimeout"|"createdAt"|"updatedAt")[], }>}
+ * @returns {EitherN<{}>}
+ */
+export function anonymousValidator1245980333(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys1245980333.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys1245980333],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreJobJoins>}
+ */
+export function anonymousValidator622747874(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator1245980333(value, propertyPath);
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "orderBy"?: undefined|StoreJobOrderBy, "orderBySpec"?: undefined|StoreJobOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("id"|"isComplete"|"priority"|"scheduledAt"|"name"|"data"|"retryCount"|"handlerTimeout"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreJobJoins, "innerJoin"?: undefined|StoreJobJoins, }>}
  */
 export function anonymousValidator343387919(value, propertyPath) {
   if (isNil(value)) {
@@ -10323,6 +10503,28 @@ export function anonymousValidator343387919(value, propertyPath) {
       result["select"] = validatorResult.value;
     }
   }
+  {
+    const validatorResult = anonymousValidator622747874(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator622747874(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
   if (errors.length > 0) {
     return { errors };
   }
@@ -10404,6 +10606,410 @@ export function anonymousValidator1791620536(value, propertyPath) {
     return { errors };
   }
   return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<string>}
+ */
+export function anonymousValidator929307826(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: "ss" };
+  }
+  if (typeof value !== "string") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.string.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (value.length === 0) {
+    return { value: "ss" };
+  }
+  return { value };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|{"innerJoin"?: undefined|StoreSessionStoreJoins, "leftJoin"?: undefined|StoreSessionStoreJoins, "where"?: undefined|StoreSessionStoreWhere, "shortName": string, }>}
+ */
+export function anonymousValidator927057687(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys927057687.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys927057687],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1582696858(
+      value["where"],
+      `${propertyPath}.where`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["where"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator929307826(
+      value["shortName"],
+      `${propertyPath}.shortName`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["shortName"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"session"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreJoins, "leftJoin"?: undefined|StoreSessionStoreJoins, "where"?: undefined|StoreSessionStoreWhere, "shortName": string, }, "refreshToken"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, "accessToken"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, }>}
+ */
+export function anonymousValidator1418696316(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys1418696316.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys1418696316],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator927057687(
+      value["session"],
+      `${propertyPath}.session`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["session"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator588258860(
+      value["refreshToken"],
+      `${propertyPath}.refreshToken`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["refreshToken"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator588258860(
+      value["accessToken"],
+      `${propertyPath}.accessToken`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["accessToken"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreSessionStoreTokenJoins>}
+ */
+export function anonymousValidator2053722097(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator1418696316(value, propertyPath);
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<string>}
+ */
+export function anonymousValidator1905115744(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: "sst" };
+  }
+  if (typeof value !== "string") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.string.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (value.length === 0) {
+    return { value: "sst" };
+  }
+  return { value };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }>}
+ */
+export function anonymousValidator588258860(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys588258860.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys588258860],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2053722097(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2053722097(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2065515599(
+      value["where"],
+      `${propertyPath}.where`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["where"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1905115744(
+      value["shortName"],
+      `${propertyPath}.shortName`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["shortName"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"accessTokens"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, }>}
+ */
+export function anonymousValidator1346727779(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys1346727779.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys1346727779],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator588258860(
+      value["accessTokens"],
+      `${propertyPath}.accessTokens`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["accessTokens"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreSessionStoreJoins>}
+ */
+export function anonymousValidator1594490360(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator1346727779(value, propertyPath);
 }
 /**
  * @param {*} value
@@ -10503,7 +11109,7 @@ export function anonymousValidator1827379372(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("expiresAt"|"revokedAt"|"createdAt"|"id"|"session"|"refreshToken")[], "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("expiresAt"|"revokedAt"|"createdAt"|"id"|"session"|"refreshToken")[], "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "innerJoin"?: undefined|StoreSessionStoreTokenJoins, "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator1856722848(value, propertyPath) {
   if (isNil(value)) {
@@ -10627,6 +11233,28 @@ export function anonymousValidator1856722848(value, propertyPath) {
     }
   }
   {
+    const validatorResult = anonymousValidator2053722097(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2053722097(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
+  {
     const validatorResult = anonymousValidator1827379372(
       value["session"],
       `${propertyPath}.session`,
@@ -10678,7 +11306,7 @@ export function anonymousValidator145903947(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("data"|"checksum"|"revokedAt"|"id"|"createdAt"|"updatedAt")[], "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("data"|"checksum"|"revokedAt"|"id"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreSessionStoreJoins, "innerJoin"?: undefined|StoreSessionStoreJoins, "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator2093168415(value, propertyPath) {
   if (isNil(value)) {
@@ -10799,6 +11427,28 @@ export function anonymousValidator2093168415(value, propertyPath) {
       errors.push(...validatorResult.errors);
     } else {
       result["select"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
     }
   }
   {

--- a/examples/session-handling/src/generated/common/types.d.ts
+++ b/examples/session-handling/src/generated/common/types.d.ts
@@ -508,7 +508,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreFileJoins;
+    innerJoin?: undefined | StoreFileJoins;
   };
+  type StoreFileJoins = {};
   type StoreJobQueryBuilder = {
     where?: undefined | StoreJobWhere;
     orderBy?: undefined | StoreJobOrderBy;
@@ -530,7 +533,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreJobJoins;
+    innerJoin?: undefined | StoreJobJoins;
   };
+  type StoreJobJoins = StoreFileJoins;
   type StoreSessionStoreQueryBuilder = {
     where?: undefined | StoreSessionStoreWhere;
     orderBy?: undefined | StoreSessionStoreOrderBy;
@@ -548,7 +554,45 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreSessionStoreJoins;
+    innerJoin?: undefined | StoreSessionStoreJoins;
     accessTokens?: undefined | StoreSessionStoreTokenQueryBuilder;
+  };
+  type StoreSessionStoreJoins = {
+    accessTokens?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoins;
+          leftJoin?: undefined | StoreSessionStoreTokenJoins;
+          where?: undefined | StoreSessionStoreTokenWhere;
+          shortName?: undefined | string;
+        };
+  };
+  type StoreSessionStoreTokenJoins = {
+    session?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreJoins;
+          leftJoin?: undefined | StoreSessionStoreJoins;
+          where?: undefined | StoreSessionStoreWhere;
+          shortName?: undefined | string;
+        };
+    refreshToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoins;
+          leftJoin?: undefined | StoreSessionStoreTokenJoins;
+          where?: undefined | StoreSessionStoreTokenWhere;
+          shortName?: undefined | string;
+        };
+    accessToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoins;
+          leftJoin?: undefined | StoreSessionStoreTokenJoins;
+          where?: undefined | StoreSessionStoreTokenWhere;
+          shortName?: undefined | string;
+        };
   };
   type StoreSessionStoreTokenQueryBuilder = {
     where?: undefined | StoreSessionStoreTokenWhere;
@@ -567,6 +611,8 @@ declare global {
           | "session"
           | "refreshToken"
         )[];
+    leftJoin?: undefined | StoreSessionStoreTokenJoins;
+    innerJoin?: undefined | StoreSessionStoreTokenJoins;
     session?: undefined | StoreSessionStoreQueryBuilder;
     refreshToken?: undefined | StoreSessionStoreTokenQueryBuilder;
     accessToken?: undefined | StoreSessionStoreTokenQueryBuilder;
@@ -935,7 +981,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreFileJoinsInput;
+    innerJoin?: undefined | StoreFileJoinsInput;
   };
+  type StoreFileJoinsInput = StoreFileJoins;
   type StoreJobQueryBuilderInput = {
     where?: undefined | StoreJobWhereInput;
     orderBy?: undefined | StoreJobOrderByInput;
@@ -957,7 +1006,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreJobJoinsInput;
+    innerJoin?: undefined | StoreJobJoinsInput;
   };
+  type StoreJobJoinsInput = StoreFileJoins;
   type StoreSessionStoreQueryBuilderInput = {
     where?: undefined | StoreSessionStoreWhereInput;
     orderBy?: undefined | StoreSessionStoreOrderByInput;
@@ -975,7 +1027,45 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreSessionStoreJoinsInput;
+    innerJoin?: undefined | StoreSessionStoreJoinsInput;
     accessTokens?: undefined | StoreSessionStoreTokenQueryBuilderInput;
+  };
+  type StoreSessionStoreJoinsInput = {
+    accessTokens?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          where?: undefined | StoreSessionStoreTokenWhereInput;
+          shortName?: undefined | string;
+        };
+  };
+  type StoreSessionStoreTokenJoinsInput = {
+    session?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreJoinsInput;
+          where?: undefined | StoreSessionStoreWhereInput;
+          shortName?: undefined | string;
+        };
+    refreshToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          where?: undefined | StoreSessionStoreTokenWhereInput;
+          shortName?: undefined | string;
+        };
+    accessToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          where?: undefined | StoreSessionStoreTokenWhereInput;
+          shortName?: undefined | string;
+        };
   };
   type StoreSessionStoreTokenQueryBuilderInput = {
     where?: undefined | StoreSessionStoreTokenWhereInput;
@@ -994,6 +1084,8 @@ declare global {
           | "session"
           | "refreshToken"
         )[];
+    leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+    innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
     session?: undefined | StoreSessionStoreQueryBuilderInput;
     refreshToken?: undefined | StoreSessionStoreTokenQueryBuilderInput;
     accessToken?: undefined | StoreSessionStoreTokenQueryBuilderInput;

--- a/examples/session-handling/src/generated/database/file.js
+++ b/examples/session-handling/src/generated/database/file.js
@@ -394,7 +394,7 @@ export const fileQueryBuilderSpec = {
     "createdAt",
     "updatedAt",
   ],
-  relations: [],
+  relations: {},
 };
 /**
  * Query Builder for file

--- a/examples/session-handling/src/generated/database/job.js
+++ b/examples/session-handling/src/generated/database/job.js
@@ -438,7 +438,7 @@ export const jobQueryBuilderSpec = {
     "createdAt",
     "updatedAt",
   ],
-  relations: [],
+  relations: {},
 };
 /**
  * Query Builder for job

--- a/examples/session-handling/src/generated/database/sessionStore.js
+++ b/examples/session-handling/src/generated/database/sessionStore.js
@@ -397,15 +397,15 @@ export const sessionStoreQueryBuilderSpec = {
   orderBy: sessionStoreOrderBy,
   where: sessionStoreWhereSpec,
   columns: ["data", "checksum", "revokedAt", "id", "createdAt", "updatedAt"],
-  relations: [
-    {
+  relations: {
+    accessTokens: {
       builderKey: "accessTokens",
       ownKey: "id",
       referencedKey: "session",
       returnsMany: true,
       entityInformation: () => sessionStoreTokenQueryBuilderSpec,
     },
-  ],
+  },
 };
 /**
  * Query Builder for sessionStore

--- a/examples/session-handling/src/generated/database/sessionStoreToken.js
+++ b/examples/session-handling/src/generated/database/sessionStoreToken.js
@@ -466,29 +466,29 @@ export const sessionStoreTokenQueryBuilderSpec = {
     "session",
     "refreshToken",
   ],
-  relations: [
-    {
+  relations: {
+    session: {
       builderKey: "session",
       ownKey: "session",
       referencedKey: "id",
       returnsMany: false,
       entityInformation: () => sessionStoreQueryBuilderSpec,
     },
-    {
+    refreshToken: {
       builderKey: "refreshToken",
       ownKey: "refreshToken",
       referencedKey: "id",
       returnsMany: false,
       entityInformation: () => sessionStoreTokenQueryBuilderSpec,
     },
-    {
+    accessToken: {
       builderKey: "accessToken",
       ownKey: "id",
       referencedKey: "refreshToken",
       returnsMany: false,
       entityInformation: () => sessionStoreTokenQueryBuilderSpec,
     },
-  ],
+  },
 };
 /**
  * Query Builder for sessionStoreToken

--- a/examples/session-handling/src/generated/store/validators.js
+++ b/examples/session-handling/src/generated/store/validators.js
@@ -4,11 +4,14 @@
 import {
   anonymousValidator1105075285,
   anonymousValidator1196685479,
+  anonymousValidator1245980333,
   anonymousValidator1257773835,
   anonymousValidator1334934277,
   anonymousValidator1337490931,
   anonymousValidator1345595702,
+  anonymousValidator1346727779,
   anonymousValidator1414433474,
+  anonymousValidator1418696316,
   anonymousValidator1430489818,
   anonymousValidator1516794677,
   anonymousValidator163358845,
@@ -18,6 +21,7 @@ import {
   anonymousValidator1795948632,
   anonymousValidator1856722848,
   anonymousValidator1864958291,
+  anonymousValidator2062700716,
   anonymousValidator2074494218,
   anonymousValidator2086080888,
   anonymousValidator2093168415,
@@ -943,6 +947,32 @@ export function validateStoreFileQueryBuilder(value, propertyPath = "$") {
   return { value: result.value };
 }
 /**
+ * @param {undefined|any|StoreFileJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreFileJoins>}
+ */
+export function validateStoreFileJoins(value, propertyPath = "$") {
+  const result = anonymousValidator2062700716(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreFileJoins}} */
+  return { value: result.value };
+}
+/**
  * @param {undefined|any|StoreJobQueryBuilderInput} value
  * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreJobQueryBuilder>}
@@ -966,6 +996,32 @@ export function validateStoreJobQueryBuilder(value, propertyPath = "$") {
     };
   }
   /** @type {{ value: StoreJobQueryBuilder}} */
+  return { value: result.value };
+}
+/**
+ * @param {undefined|any|StoreJobJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreJobJoins>}
+ */
+export function validateStoreJobJoins(value, propertyPath = "$") {
+  const result = anonymousValidator1245980333(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreJobJoins}} */
   return { value: result.value };
 }
 /**
@@ -998,6 +1054,32 @@ export function validateStoreSessionStoreQueryBuilder(
   return { value: result.value };
 }
 /**
+ * @param {undefined|any|StoreSessionStoreJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreSessionStoreJoins>}
+ */
+export function validateStoreSessionStoreJoins(value, propertyPath = "$") {
+  const result = anonymousValidator1346727779(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreSessionStoreJoins}} */
+  return { value: result.value };
+}
+/**
  * @param {undefined|any|StoreSessionStoreTokenQueryBuilderInput} value
  * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreSessionStoreTokenQueryBuilder>}
@@ -1024,5 +1106,31 @@ export function validateStoreSessionStoreTokenQueryBuilder(
     };
   }
   /** @type {{ value: StoreSessionStoreTokenQueryBuilder}} */
+  return { value: result.value };
+}
+/**
+ * @param {undefined|any|StoreSessionStoreTokenJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreSessionStoreTokenJoins>}
+ */
+export function validateStoreSessionStoreTokenJoins(value, propertyPath = "$") {
+  const result = anonymousValidator1418696316(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreSessionStoreTokenJoins}} */
   return { value: result.value };
 }

--- a/packages/code-gen/src/generator/sql/utils.js
+++ b/packages/code-gen/src/generator/sql/utils.js
@@ -363,6 +363,8 @@ function checkReservedRelationNames(context, type, relation) {
     "orderBySpec",
     "select",
     "where",
+    "innerJoin",
+    "leftJoin",
   ];
 
   if (reservedRelationNames.includes(relation.ownKey)) {

--- a/packages/store/src/generated/common/anonymous-validators.d.ts
+++ b/packages/store/src/generated/common/anonymous-validators.d.ts
@@ -2246,7 +2246,25 @@ export function anonymousValidator1532767426(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("bucketName"|"contentLength"|"contentType"|"name"|"meta"|"id"|"createdAt"|"updatedAt")[], }>}
+ * @returns {EitherN<{}>}
+ */
+export function anonymousValidator2062700716(
+  value: any,
+  propertyPath: string,
+): EitherN<{}>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreFileJoins>}
+ */
+export function anonymousValidator77636329(
+  value: any,
+  propertyPath: string,
+): EitherN<undefined | StoreFileJoins>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("bucketName"|"contentLength"|"contentType"|"name"|"meta"|"id"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreFileJoins, "innerJoin"?: undefined|StoreFileJoins, }>}
  */
 export function anonymousValidator310044624(
   value: any,
@@ -2268,6 +2286,8 @@ export function anonymousValidator310044624(
     | "createdAt"
     | "updatedAt"
   )[];
+  leftJoin?: undefined | StoreFileJoins;
+  innerJoin?: undefined | StoreFileJoins;
 }>;
 /**
  * @param {*} value
@@ -2321,7 +2341,25 @@ export function anonymousValidator582777968(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "orderBy"?: undefined|StoreJobOrderBy, "orderBySpec"?: undefined|StoreJobOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("id"|"isComplete"|"priority"|"scheduledAt"|"name"|"data"|"retryCount"|"handlerTimeout"|"createdAt"|"updatedAt")[], }>}
+ * @returns {EitherN<{}>}
+ */
+export function anonymousValidator1245980333(
+  value: any,
+  propertyPath: string,
+): EitherN<{}>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreJobJoins>}
+ */
+export function anonymousValidator622747874(
+  value: any,
+  propertyPath: string,
+): EitherN<undefined | StoreJobJoins>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "orderBy"?: undefined|StoreJobOrderBy, "orderBySpec"?: undefined|StoreJobOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("id"|"isComplete"|"priority"|"scheduledAt"|"name"|"data"|"retryCount"|"handlerTimeout"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreJobJoins, "innerJoin"?: undefined|StoreJobJoins, }>}
  */
 export function anonymousValidator343387919(
   value: any,
@@ -2345,6 +2383,8 @@ export function anonymousValidator343387919(
     | "createdAt"
     | "updatedAt"
   )[];
+  leftJoin?: undefined | StoreJobJoins;
+  innerJoin?: undefined | StoreJobJoins;
 }>;
 /**
  * @param {*} value
@@ -2375,6 +2415,128 @@ export function anonymousValidator1791620536(
 ): EitherN<
   ("data" | "checksum" | "revokedAt" | "id" | "createdAt" | "updatedAt")[]
 >;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<string>}
+ */
+export function anonymousValidator929307826(
+  value: any,
+  propertyPath: string,
+): EitherN<string>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|{"innerJoin"?: undefined|StoreSessionStoreJoins, "leftJoin"?: undefined|StoreSessionStoreJoins, "where"?: undefined|StoreSessionStoreWhere, "shortName": string, }>}
+ */
+export function anonymousValidator927057687(
+  value: any,
+  propertyPath: string,
+): EitherN<
+  | undefined
+  | {
+      innerJoin?: undefined | StoreSessionStoreJoins;
+      leftJoin?: undefined | StoreSessionStoreJoins;
+      where?: undefined | StoreSessionStoreWhere;
+      shortName: string;
+    }
+>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"session"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreJoins, "leftJoin"?: undefined|StoreSessionStoreJoins, "where"?: undefined|StoreSessionStoreWhere, "shortName": string, }, "refreshToken"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, "accessToken"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, }>}
+ */
+export function anonymousValidator1418696316(
+  value: any,
+  propertyPath: string,
+): EitherN<{
+  session?:
+    | undefined
+    | {
+        innerJoin?: undefined | StoreSessionStoreJoins;
+        leftJoin?: undefined | StoreSessionStoreJoins;
+        where?: undefined | StoreSessionStoreWhere;
+        shortName: string;
+      };
+  refreshToken?:
+    | undefined
+    | {
+        innerJoin?: undefined | StoreSessionStoreTokenJoins;
+        leftJoin?: undefined | StoreSessionStoreTokenJoins;
+        where?: undefined | StoreSessionStoreTokenWhere;
+        shortName: string;
+      };
+  accessToken?:
+    | undefined
+    | {
+        innerJoin?: undefined | StoreSessionStoreTokenJoins;
+        leftJoin?: undefined | StoreSessionStoreTokenJoins;
+        where?: undefined | StoreSessionStoreTokenWhere;
+        shortName: string;
+      };
+}>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreSessionStoreTokenJoins>}
+ */
+export function anonymousValidator2053722097(
+  value: any,
+  propertyPath: string,
+): EitherN<undefined | StoreSessionStoreTokenJoins>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<string>}
+ */
+export function anonymousValidator1905115744(
+  value: any,
+  propertyPath: string,
+): EitherN<string>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }>}
+ */
+export function anonymousValidator588258860(
+  value: any,
+  propertyPath: string,
+): EitherN<
+  | undefined
+  | {
+      innerJoin?: undefined | StoreSessionStoreTokenJoins;
+      leftJoin?: undefined | StoreSessionStoreTokenJoins;
+      where?: undefined | StoreSessionStoreTokenWhere;
+      shortName: string;
+    }
+>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"accessTokens"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, }>}
+ */
+export function anonymousValidator1346727779(
+  value: any,
+  propertyPath: string,
+): EitherN<{
+  accessTokens?:
+    | undefined
+    | {
+        innerJoin?: undefined | StoreSessionStoreTokenJoins;
+        leftJoin?: undefined | StoreSessionStoreTokenJoins;
+        where?: undefined | StoreSessionStoreTokenWhere;
+        shortName: string;
+      };
+}>;
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreSessionStoreJoins>}
+ */
+export function anonymousValidator1594490360(
+  value: any,
+  propertyPath: string,
+): EitherN<undefined | StoreSessionStoreJoins>;
 /**
  * @param {*} value
  * @param {string} propertyPath
@@ -2423,7 +2585,7 @@ export function anonymousValidator1827379372(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("expiresAt"|"revokedAt"|"createdAt"|"id"|"session"|"refreshToken")[], "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("expiresAt"|"revokedAt"|"createdAt"|"id"|"session"|"refreshToken")[], "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "innerJoin"?: undefined|StoreSessionStoreTokenJoins, "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator1856722848(
   value: any,
@@ -2443,6 +2605,8 @@ export function anonymousValidator1856722848(
     | "session"
     | "refreshToken"
   )[];
+  leftJoin?: undefined | StoreSessionStoreTokenJoins;
+  innerJoin?: undefined | StoreSessionStoreTokenJoins;
   session?: undefined | StoreSessionStoreQueryBuilder;
   refreshToken?: undefined | StoreSessionStoreTokenQueryBuilder;
   accessToken?: undefined | StoreSessionStoreTokenQueryBuilder;
@@ -2459,7 +2623,7 @@ export function anonymousValidator145903947(
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("data"|"checksum"|"revokedAt"|"id"|"createdAt"|"updatedAt")[], "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("data"|"checksum"|"revokedAt"|"id"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreSessionStoreJoins, "innerJoin"?: undefined|StoreSessionStoreJoins, "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator2093168415(
   value: any,
@@ -2479,6 +2643,8 @@ export function anonymousValidator2093168415(
     | "createdAt"
     | "updatedAt"
   )[];
+  leftJoin?: undefined | StoreSessionStoreJoins;
+  innerJoin?: undefined | StoreSessionStoreJoins;
   accessTokens?: undefined | StoreSessionStoreTokenQueryBuilder;
 }>;
 export type InternalError = {

--- a/packages/store/src/generated/common/anonymous-validators.js
+++ b/packages/store/src/generated/common/anonymous-validators.js
@@ -288,7 +288,10 @@ const objectKeys310044624 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
 ]);
+const objectKeys2062700716 = new Set([""]);
 const objectKeys343387919 = new Set([
   "where",
   "orderBy",
@@ -297,7 +300,10 @@ const objectKeys343387919 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
 ]);
+const objectKeys1245980333 = new Set([""]);
 const objectKeys2093168415 = new Set([
   "where",
   "orderBy",
@@ -306,7 +312,27 @@ const objectKeys2093168415 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
   "accessTokens",
+]);
+const objectKeys1346727779 = new Set(["accessTokens"]);
+const objectKeys588258860 = new Set([
+  "innerJoin",
+  "leftJoin",
+  "where",
+  "shortName",
+]);
+const objectKeys1418696316 = new Set([
+  "session",
+  "refreshToken",
+  "accessToken",
+]);
+const objectKeys927057687 = new Set([
+  "innerJoin",
+  "leftJoin",
+  "where",
+  "shortName",
 ]);
 const objectKeys1856722848 = new Set([
   "where",
@@ -316,6 +342,8 @@ const objectKeys1856722848 = new Set([
   "limit",
   "offset",
   "select",
+  "leftJoin",
+  "innerJoin",
   "session",
   "refreshToken",
   "accessToken",
@@ -9406,7 +9434,72 @@ export function anonymousValidator1532767426(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("bucketName"|"contentLength"|"contentType"|"name"|"meta"|"id"|"createdAt"|"updatedAt")[], }>}
+ * @returns {EitherN<{}>}
+ */
+export function anonymousValidator2062700716(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys2062700716.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys2062700716],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreFileJoins>}
+ */
+export function anonymousValidator77636329(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator2062700716(value, propertyPath);
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"where"?: undefined|StoreFileWhere, "orderBy"?: undefined|StoreFileOrderBy, "orderBySpec"?: undefined|StoreFileOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("bucketName"|"contentLength"|"contentType"|"name"|"meta"|"id"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreFileJoins, "innerJoin"?: undefined|StoreFileJoins, }>}
  */
 export function anonymousValidator310044624(value, propertyPath) {
   if (isNil(value)) {
@@ -9529,6 +9622,28 @@ export function anonymousValidator310044624(value, propertyPath) {
       result["select"] = validatorResult.value;
     }
   }
+  {
+    const validatorResult = anonymousValidator77636329(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator77636329(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
   if (errors.length > 0) {
     return { errors };
   }
@@ -9636,7 +9751,72 @@ export function anonymousValidator582777968(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "orderBy"?: undefined|StoreJobOrderBy, "orderBySpec"?: undefined|StoreJobOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("id"|"isComplete"|"priority"|"scheduledAt"|"name"|"data"|"retryCount"|"handlerTimeout"|"createdAt"|"updatedAt")[], }>}
+ * @returns {EitherN<{}>}
+ */
+export function anonymousValidator1245980333(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys1245980333.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys1245980333],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreJobJoins>}
+ */
+export function anonymousValidator622747874(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator1245980333(value, propertyPath);
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"where"?: undefined|StoreJobWhere, "orderBy"?: undefined|StoreJobOrderBy, "orderBySpec"?: undefined|StoreJobOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("id"|"isComplete"|"priority"|"scheduledAt"|"name"|"data"|"retryCount"|"handlerTimeout"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreJobJoins, "innerJoin"?: undefined|StoreJobJoins, }>}
  */
 export function anonymousValidator343387919(value, propertyPath) {
   if (isNil(value)) {
@@ -9759,6 +9939,28 @@ export function anonymousValidator343387919(value, propertyPath) {
       result["select"] = validatorResult.value;
     }
   }
+  {
+    const validatorResult = anonymousValidator622747874(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator622747874(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
   if (errors.length > 0) {
     return { errors };
   }
@@ -9840,6 +10042,410 @@ export function anonymousValidator1791620536(value, propertyPath) {
     return { errors };
   }
   return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<string>}
+ */
+export function anonymousValidator929307826(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: "ss" };
+  }
+  if (typeof value !== "string") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.string.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (value.length === 0) {
+    return { value: "ss" };
+  }
+  return { value };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|{"innerJoin"?: undefined|StoreSessionStoreJoins, "leftJoin"?: undefined|StoreSessionStoreJoins, "where"?: undefined|StoreSessionStoreWhere, "shortName": string, }>}
+ */
+export function anonymousValidator927057687(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys927057687.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys927057687],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1582696858(
+      value["where"],
+      `${propertyPath}.where`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["where"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator929307826(
+      value["shortName"],
+      `${propertyPath}.shortName`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["shortName"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"session"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreJoins, "leftJoin"?: undefined|StoreSessionStoreJoins, "where"?: undefined|StoreSessionStoreWhere, "shortName": string, }, "refreshToken"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, "accessToken"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, }>}
+ */
+export function anonymousValidator1418696316(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys1418696316.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys1418696316],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator927057687(
+      value["session"],
+      `${propertyPath}.session`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["session"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator588258860(
+      value["refreshToken"],
+      `${propertyPath}.refreshToken`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["refreshToken"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator588258860(
+      value["accessToken"],
+      `${propertyPath}.accessToken`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["accessToken"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreSessionStoreTokenJoins>}
+ */
+export function anonymousValidator2053722097(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator1418696316(value, propertyPath);
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<string>}
+ */
+export function anonymousValidator1905115744(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: "sst" };
+  }
+  if (typeof value !== "string") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.string.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (value.length === 0) {
+    return { value: "sst" };
+  }
+  return { value };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }>}
+ */
+export function anonymousValidator588258860(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys588258860.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys588258860],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2053722097(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2053722097(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2065515599(
+      value["where"],
+      `${propertyPath}.where`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["where"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1905115744(
+      value["shortName"],
+      `${propertyPath}.shortName`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["shortName"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<{"accessTokens"?: undefined|{"innerJoin"?: undefined|StoreSessionStoreTokenJoins, "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "where"?: undefined|StoreSessionStoreTokenWhere, "shortName": string, }, }>}
+ */
+export function anonymousValidator1346727779(value, propertyPath) {
+  if (isNil(value)) {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.undefined",
+          info: {},
+        },
+      ],
+    };
+  }
+  if (typeof value !== "object") {
+    /** @type {{ errors: InternalError[] }} */
+    return {
+      errors: [
+        {
+          propertyPath,
+          key: "validator.object.type",
+          info: {},
+        },
+      ],
+    };
+  }
+  const result = Object.create(null);
+  let errors = [];
+  for (const key of Object.keys(value)) {
+    if (!objectKeys1346727779.has(key)) {
+      /** @type {{ errors: InternalError[] }} */
+      return {
+        errors: [
+          {
+            propertyPath,
+            key: "validator.object.strict",
+            info: {
+              expectedKeys: [...objectKeys1346727779],
+              foundKeys: [...Object.keys(value)],
+            },
+          },
+        ],
+      };
+    }
+  }
+  {
+    const validatorResult = anonymousValidator588258860(
+      value["accessTokens"],
+      `${propertyPath}.accessTokens`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["accessTokens"] = validatorResult.value;
+    }
+  }
+  if (errors.length > 0) {
+    return { errors };
+  }
+  return { value: result };
+}
+/**
+ * @param {*} value
+ * @param {string} propertyPath
+ * @returns {EitherN<undefined|StoreSessionStoreJoins>}
+ */
+export function anonymousValidator1594490360(value, propertyPath) {
+  if (isNil(value)) {
+    return { value: undefined };
+  }
+  return anonymousValidator1346727779(value, propertyPath);
 }
 /**
  * @param {*} value
@@ -9939,7 +10545,7 @@ export function anonymousValidator1827379372(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("expiresAt"|"revokedAt"|"createdAt"|"id"|"session"|"refreshToken")[], "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreTokenWhere, "orderBy"?: undefined|StoreSessionStoreTokenOrderBy, "orderBySpec"?: undefined|StoreSessionStoreTokenOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("expiresAt"|"revokedAt"|"createdAt"|"id"|"session"|"refreshToken")[], "leftJoin"?: undefined|StoreSessionStoreTokenJoins, "innerJoin"?: undefined|StoreSessionStoreTokenJoins, "session"?: undefined|StoreSessionStoreQueryBuilder, "refreshToken"?: undefined|StoreSessionStoreTokenQueryBuilder, "accessToken"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator1856722848(value, propertyPath) {
   if (isNil(value)) {
@@ -10063,6 +10669,28 @@ export function anonymousValidator1856722848(value, propertyPath) {
     }
   }
   {
+    const validatorResult = anonymousValidator2053722097(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator2053722097(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
+    }
+  }
+  {
     const validatorResult = anonymousValidator1827379372(
       value["session"],
       `${propertyPath}.session`,
@@ -10114,7 +10742,7 @@ export function anonymousValidator145903947(value, propertyPath) {
 /**
  * @param {*} value
  * @param {string} propertyPath
- * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("data"|"checksum"|"revokedAt"|"id"|"createdAt"|"updatedAt")[], "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
+ * @returns {EitherN<{"where"?: undefined|StoreSessionStoreWhere, "orderBy"?: undefined|StoreSessionStoreOrderBy, "orderBySpec"?: undefined|StoreSessionStoreOrderBySpec, "as"?: undefined|string, "limit"?: undefined|number, "offset"?: undefined|number, "select": ("data"|"checksum"|"revokedAt"|"id"|"createdAt"|"updatedAt")[], "leftJoin"?: undefined|StoreSessionStoreJoins, "innerJoin"?: undefined|StoreSessionStoreJoins, "accessTokens"?: undefined|StoreSessionStoreTokenQueryBuilder, }>}
  */
 export function anonymousValidator2093168415(value, propertyPath) {
   if (isNil(value)) {
@@ -10235,6 +10863,28 @@ export function anonymousValidator2093168415(value, propertyPath) {
       errors.push(...validatorResult.errors);
     } else {
       result["select"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["leftJoin"],
+      `${propertyPath}.leftJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["leftJoin"] = validatorResult.value;
+    }
+  }
+  {
+    const validatorResult = anonymousValidator1594490360(
+      value["innerJoin"],
+      `${propertyPath}.innerJoin`,
+    );
+    if (validatorResult.errors) {
+      errors.push(...validatorResult.errors);
+    } else {
+      result["innerJoin"] = validatorResult.value;
     }
   }
   {

--- a/packages/store/src/generated/database/file.d.ts
+++ b/packages/store/src/generated/database/file.d.ts
@@ -112,7 +112,7 @@ export namespace fileQueryBuilderSpec {
   export { fileOrderBy as orderBy };
   export { fileWhereSpec as where };
   export const columns: string[];
-  export const relations: never[];
+  export const relations: {};
 }
 /**
  * @param {Postgres} sql

--- a/packages/store/src/generated/database/file.js
+++ b/packages/store/src/generated/database/file.js
@@ -394,7 +394,7 @@ export const fileQueryBuilderSpec = {
     "createdAt",
     "updatedAt",
   ],
-  relations: [],
+  relations: {},
 };
 /**
  * Query Builder for file

--- a/packages/store/src/generated/database/job.d.ts
+++ b/packages/store/src/generated/database/job.d.ts
@@ -114,7 +114,7 @@ export namespace jobQueryBuilderSpec {
   export { jobOrderBy as orderBy };
   export { jobWhereSpec as where };
   export const columns: string[];
-  export const relations: never[];
+  export const relations: {};
 }
 /**
  * @param {Postgres} sql

--- a/packages/store/src/generated/database/job.js
+++ b/packages/store/src/generated/database/job.js
@@ -438,7 +438,7 @@ export const jobQueryBuilderSpec = {
     "createdAt",
     "updatedAt",
   ],
-  relations: [],
+  relations: {},
 };
 /**
  * Query Builder for job

--- a/packages/store/src/generated/database/sessionStore.d.ts
+++ b/packages/store/src/generated/database/sessionStore.d.ts
@@ -114,13 +114,59 @@ export namespace sessionStoreQueryBuilderSpec {
   export { sessionStoreOrderBy as orderBy };
   export { sessionStoreWhereSpec as where };
   export const columns: string[];
-  export const relations: {
-    builderKey: string;
-    ownKey: string;
-    referencedKey: string;
-    returnsMany: boolean;
-    entityInformation: () => any;
-  }[];
+  export namespace relations {
+    namespace accessTokens {
+      const builderKey: string;
+      const ownKey: string;
+      const referencedKey: string;
+      const returnsMany: boolean;
+      function entityInformation(): {
+        name: string;
+        shortName: string;
+        orderBy: typeof import("./sessionStoreToken.js").sessionStoreTokenOrderBy;
+        where: any;
+        columns: string[];
+        relations: {
+          session: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => {
+              name: string;
+              shortName: string;
+              orderBy: typeof sessionStoreOrderBy;
+              where: any;
+              columns: string[];
+              relations: {
+                accessTokens: {
+                  builderKey: string;
+                  ownKey: string;
+                  referencedKey: string;
+                  returnsMany: boolean;
+                  entityInformation: () => any;
+                };
+              };
+            };
+          };
+          refreshToken: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => any;
+          };
+          accessToken: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => any;
+          };
+        };
+      };
+    }
+  }
 }
 /**
  * @param {Postgres} sql

--- a/packages/store/src/generated/database/sessionStore.js
+++ b/packages/store/src/generated/database/sessionStore.js
@@ -397,15 +397,15 @@ export const sessionStoreQueryBuilderSpec = {
   orderBy: sessionStoreOrderBy,
   where: sessionStoreWhereSpec,
   columns: ["data", "checksum", "revokedAt", "id", "createdAt", "updatedAt"],
-  relations: [
-    {
+  relations: {
+    accessTokens: {
       builderKey: "accessTokens",
       ownKey: "id",
       referencedKey: "session",
       returnsMany: true,
       entityInformation: () => sessionStoreTokenQueryBuilderSpec,
     },
-  ],
+  },
 };
 /**
  * Query Builder for sessionStore

--- a/packages/store/src/generated/database/sessionStoreToken.d.ts
+++ b/packages/store/src/generated/database/sessionStoreToken.d.ts
@@ -110,7 +110,178 @@ export namespace sessionStoreTokenQueries {
   export { sessionStoreTokenUpsertOnId };
   export { sessionStoreTokenUpdate };
 }
-export const sessionStoreTokenQueryBuilderSpec: any;
+export namespace sessionStoreTokenQueryBuilderSpec {
+  export const name: string;
+  export const shortName: string;
+  export { sessionStoreTokenOrderBy as orderBy };
+  export { sessionStoreTokenWhereSpec as where };
+  export const columns: string[];
+  export namespace relations {
+    namespace session {
+      const builderKey: string;
+      const ownKey: string;
+      const referencedKey: string;
+      const returnsMany: boolean;
+      function entityInformation(): {
+        name: string;
+        shortName: string;
+        orderBy: typeof import("./sessionStore.js").sessionStoreOrderBy;
+        where: any;
+        columns: string[];
+        relations: {
+          accessTokens: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => {
+              name: string;
+              shortName: string;
+              orderBy: typeof sessionStoreTokenOrderBy;
+              where: any;
+              columns: string[];
+              relations: {
+                session: {
+                  builderKey: string;
+                  ownKey: string;
+                  referencedKey: string;
+                  returnsMany: boolean;
+                  entityInformation: () => any;
+                };
+                refreshToken: {
+                  builderKey: string;
+                  ownKey: string;
+                  referencedKey: string;
+                  returnsMany: boolean;
+                  entityInformation: () => any;
+                };
+                accessToken: {
+                  builderKey: string;
+                  ownKey: string;
+                  referencedKey: string;
+                  returnsMany: boolean;
+                  entityInformation: () => any;
+                };
+              };
+            };
+          };
+        };
+      };
+    }
+    namespace refreshToken {
+      const builderKey_1: string;
+      export { builderKey_1 as builderKey };
+      const ownKey_1: string;
+      export { ownKey_1 as ownKey };
+      const referencedKey_1: string;
+      export { referencedKey_1 as referencedKey };
+      const returnsMany_1: boolean;
+      export { returnsMany_1 as returnsMany };
+      export function entityInformation_1(): {
+        name: string;
+        shortName: string;
+        orderBy: typeof sessionStoreTokenOrderBy;
+        where: any;
+        columns: string[];
+        relations: {
+          session: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => {
+              name: string;
+              shortName: string;
+              orderBy: typeof import("./sessionStore.js").sessionStoreOrderBy;
+              where: any;
+              columns: string[];
+              relations: {
+                accessTokens: {
+                  builderKey: string;
+                  ownKey: string;
+                  referencedKey: string;
+                  returnsMany: boolean;
+                  entityInformation: () => any;
+                };
+              };
+            };
+          };
+          refreshToken: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => any;
+          };
+          accessToken: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => any;
+          };
+        };
+      };
+      export { entityInformation_1 as entityInformation };
+    }
+    namespace accessToken {
+      const builderKey_2: string;
+      export { builderKey_2 as builderKey };
+      const ownKey_2: string;
+      export { ownKey_2 as ownKey };
+      const referencedKey_2: string;
+      export { referencedKey_2 as referencedKey };
+      const returnsMany_2: boolean;
+      export { returnsMany_2 as returnsMany };
+      export function entityInformation_2(): {
+        name: string;
+        shortName: string;
+        orderBy: typeof sessionStoreTokenOrderBy;
+        where: any;
+        columns: string[];
+        relations: {
+          session: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => {
+              name: string;
+              shortName: string;
+              orderBy: typeof import("./sessionStore.js").sessionStoreOrderBy;
+              where: any;
+              columns: string[];
+              relations: {
+                accessTokens: {
+                  builderKey: string;
+                  ownKey: string;
+                  referencedKey: string;
+                  returnsMany: boolean;
+                  entityInformation: () => any;
+                };
+              };
+            };
+          };
+          refreshToken: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => any;
+          };
+          accessToken: {
+            builderKey: string;
+            ownKey: string;
+            referencedKey: string;
+            returnsMany: boolean;
+            entityInformation: () => any;
+          };
+        };
+      };
+      export { entityInformation_2 as entityInformation };
+    }
+  }
+}
 /**
  * @param {Postgres} sql
  * @param {StoreSessionStoreTokenWhere} [where]

--- a/packages/store/src/generated/database/sessionStoreToken.js
+++ b/packages/store/src/generated/database/sessionStoreToken.js
@@ -466,29 +466,29 @@ export const sessionStoreTokenQueryBuilderSpec = {
     "session",
     "refreshToken",
   ],
-  relations: [
-    {
+  relations: {
+    session: {
       builderKey: "session",
       ownKey: "session",
       referencedKey: "id",
       returnsMany: false,
       entityInformation: () => sessionStoreQueryBuilderSpec,
     },
-    {
+    refreshToken: {
       builderKey: "refreshToken",
       ownKey: "refreshToken",
       referencedKey: "id",
       returnsMany: false,
       entityInformation: () => sessionStoreTokenQueryBuilderSpec,
     },
-    {
+    accessToken: {
       builderKey: "accessToken",
       ownKey: "id",
       referencedKey: "refreshToken",
       returnsMany: false,
       entityInformation: () => sessionStoreTokenQueryBuilderSpec,
     },
-  ],
+  },
 };
 /**
  * Query Builder for sessionStoreToken

--- a/packages/store/src/generated/store/validators.d.ts
+++ b/packages/store/src/generated/store/validators.d.ts
@@ -316,6 +316,15 @@ export function validateStoreFileQueryBuilder(
   propertyPath?: string | undefined,
 ): Either<StoreFileQueryBuilder>;
 /**
+ * @param {undefined|any|StoreFileJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreFileJoins>}
+ */
+export function validateStoreFileJoins(
+  value: undefined | any | StoreFileJoinsInput,
+  propertyPath?: string | undefined,
+): Either<StoreFileJoins>;
+/**
  * @param {undefined|any|StoreJobQueryBuilderInput} value
  * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreJobQueryBuilder>}
@@ -324,6 +333,15 @@ export function validateStoreJobQueryBuilder(
   value: undefined | any | StoreJobQueryBuilderInput,
   propertyPath?: string | undefined,
 ): Either<StoreJobQueryBuilder>;
+/**
+ * @param {undefined|any|StoreJobJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreJobJoins>}
+ */
+export function validateStoreJobJoins(
+  value: undefined | any | StoreJobJoinsInput,
+  propertyPath?: string | undefined,
+): Either<StoreJobJoins>;
 /**
  * @param {undefined|any|StoreSessionStoreQueryBuilderInput} value
  * @param {string|undefined} [propertyPath]
@@ -334,6 +352,15 @@ export function validateStoreSessionStoreQueryBuilder(
   propertyPath?: string | undefined,
 ): Either<StoreSessionStoreQueryBuilder>;
 /**
+ * @param {undefined|any|StoreSessionStoreJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreSessionStoreJoins>}
+ */
+export function validateStoreSessionStoreJoins(
+  value: undefined | any | StoreSessionStoreJoinsInput,
+  propertyPath?: string | undefined,
+): Either<StoreSessionStoreJoins>;
+/**
  * @param {undefined|any|StoreSessionStoreTokenQueryBuilderInput} value
  * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreSessionStoreTokenQueryBuilder>}
@@ -342,6 +369,15 @@ export function validateStoreSessionStoreTokenQueryBuilder(
   value: undefined | any | StoreSessionStoreTokenQueryBuilderInput,
   propertyPath?: string | undefined,
 ): Either<StoreSessionStoreTokenQueryBuilder>;
+/**
+ * @param {undefined|any|StoreSessionStoreTokenJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreSessionStoreTokenJoins>}
+ */
+export function validateStoreSessionStoreTokenJoins(
+  value: undefined | any | StoreSessionStoreTokenJoinsInput,
+  propertyPath?: string | undefined,
+): Either<StoreSessionStoreTokenJoins>;
 export type Either<T> = import("@compas/stdlib").Either<T, AppError>;
 import { AppError } from "@compas/stdlib";
 //# sourceMappingURL=validators.d.ts.map

--- a/packages/store/src/generated/store/validators.js
+++ b/packages/store/src/generated/store/validators.js
@@ -4,11 +4,14 @@
 import {
   anonymousValidator1105075285,
   anonymousValidator1196685479,
+  anonymousValidator1245980333,
   anonymousValidator1257773835,
   anonymousValidator1334934277,
   anonymousValidator1337490931,
   anonymousValidator1345595702,
+  anonymousValidator1346727779,
   anonymousValidator1414433474,
+  anonymousValidator1418696316,
   anonymousValidator1430489818,
   anonymousValidator1516794677,
   anonymousValidator163358845,
@@ -18,6 +21,7 @@ import {
   anonymousValidator1795948632,
   anonymousValidator1856722848,
   anonymousValidator1864958291,
+  anonymousValidator2062700716,
   anonymousValidator2074494218,
   anonymousValidator2086080888,
   anonymousValidator2093168415,
@@ -943,6 +947,32 @@ export function validateStoreFileQueryBuilder(value, propertyPath = "$") {
   return { value: result.value };
 }
 /**
+ * @param {undefined|any|StoreFileJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreFileJoins>}
+ */
+export function validateStoreFileJoins(value, propertyPath = "$") {
+  const result = anonymousValidator2062700716(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreFileJoins}} */
+  return { value: result.value };
+}
+/**
  * @param {undefined|any|StoreJobQueryBuilderInput} value
  * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreJobQueryBuilder>}
@@ -966,6 +996,32 @@ export function validateStoreJobQueryBuilder(value, propertyPath = "$") {
     };
   }
   /** @type {{ value: StoreJobQueryBuilder}} */
+  return { value: result.value };
+}
+/**
+ * @param {undefined|any|StoreJobJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreJobJoins>}
+ */
+export function validateStoreJobJoins(value, propertyPath = "$") {
+  const result = anonymousValidator1245980333(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreJobJoins}} */
   return { value: result.value };
 }
 /**
@@ -998,6 +1054,32 @@ export function validateStoreSessionStoreQueryBuilder(
   return { value: result.value };
 }
 /**
+ * @param {undefined|any|StoreSessionStoreJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreSessionStoreJoins>}
+ */
+export function validateStoreSessionStoreJoins(value, propertyPath = "$") {
+  const result = anonymousValidator1346727779(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreSessionStoreJoins}} */
+  return { value: result.value };
+}
+/**
  * @param {undefined|any|StoreSessionStoreTokenQueryBuilderInput} value
  * @param {string|undefined} [propertyPath]
  * @returns {Either<StoreSessionStoreTokenQueryBuilder>}
@@ -1024,5 +1106,31 @@ export function validateStoreSessionStoreTokenQueryBuilder(
     };
   }
   /** @type {{ value: StoreSessionStoreTokenQueryBuilder}} */
+  return { value: result.value };
+}
+/**
+ * @param {undefined|any|StoreSessionStoreTokenJoinsInput} value
+ * @param {string|undefined} [propertyPath]
+ * @returns {Either<StoreSessionStoreTokenJoins>}
+ */
+export function validateStoreSessionStoreTokenJoins(value, propertyPath = "$") {
+  const result = anonymousValidator1418696316(value, propertyPath);
+  if (result.errors) {
+    const info = {};
+    for (const err of result.errors) {
+      if (isNil(info[err.propertyPath])) {
+        info[err.propertyPath] = err;
+      } else if (Array.isArray(info[err.propertyPath])) {
+        info[err.propertyPath].push(err);
+      } else {
+        info[err.propertyPath] = [info[err.propertyPath], err];
+      }
+    }
+    /** @type {{ error: AppError }} */
+    return {
+      error: AppError.validationError("validator.error", info),
+    };
+  }
+  /** @type {{ value: StoreSessionStoreTokenJoins}} */
   return { value: result.value };
 }

--- a/packages/store/src/generator-helpers.d.ts
+++ b/packages/store/src/generator-helpers.d.ts
@@ -45,13 +45,13 @@
  *   options?: { skipValidator?: boolean|undefined },
  *   ) => import("../types/advanced-types").QueryPart} orderBy
  * @property {EntityWhere} where
- * @property {{
+ * @property {Record<string,{
  *   builderKey: string,
  *   ownKey: string,
  *   referencedKey: string,
  *   returnsMany: boolean,
  *   entityInformation: () => EntityQueryBuilder,
- * }[]} relations
+ * }>} relations
  */
 /**
  * Builds a where clause based on the generated 'where' information.
@@ -106,6 +106,28 @@ export function generatedQueryBuilderHelper(
     nestedIndex?: number;
   },
 ): import("../types/advanced-types").QueryPart<any[]>;
+/**
+ * Helper to recursively resolve the joins for a query builder.
+ *
+ * @param {EntityQueryBuilder} entity
+ * @param {*} builder
+ * @param {{
+ *   shortName?: string,
+ * }} options
+ * @returns {{ strings: string[], args: *[] }}
+ */
+export function generatedJoinsHelper(
+  entity: EntityQueryBuilder,
+  builder: any,
+  {
+    shortName,
+  }: {
+    shortName?: string;
+  },
+): {
+  strings: string[];
+  args: any[];
+};
 export type EntityWhere = {
   fieldSpecification: {
     tableKey: string;
@@ -175,12 +197,15 @@ export type EntityQueryBuilder = {
     },
   ) => import("../types/advanced-types").QueryPart;
   where: EntityWhere;
-  relations: {
-    builderKey: string;
-    ownKey: string;
-    referencedKey: string;
-    returnsMany: boolean;
-    entityInformation: () => EntityQueryBuilder;
-  }[];
+  relations: Record<
+    string,
+    {
+      builderKey: string;
+      ownKey: string;
+      referencedKey: string;
+      returnsMany: boolean;
+      entityInformation: () => EntityQueryBuilder;
+    }
+  >;
 };
 //# sourceMappingURL=generator-helpers.d.ts.map

--- a/types/generated/common/types.d.ts
+++ b/types/generated/common/types.d.ts
@@ -498,7 +498,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreFileJoins;
+    innerJoin?: undefined | StoreFileJoins;
   };
+  type StoreFileJoins = {};
   type StoreJobQueryBuilder = {
     where?: undefined | StoreJobWhere;
     orderBy?: undefined | StoreJobOrderBy;
@@ -520,7 +523,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreJobJoins;
+    innerJoin?: undefined | StoreJobJoins;
   };
+  type StoreJobJoins = StoreFileJoins;
   type StoreSessionStoreQueryBuilder = {
     where?: undefined | StoreSessionStoreWhere;
     orderBy?: undefined | StoreSessionStoreOrderBy;
@@ -538,7 +544,45 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreSessionStoreJoins;
+    innerJoin?: undefined | StoreSessionStoreJoins;
     accessTokens?: undefined | StoreSessionStoreTokenQueryBuilder;
+  };
+  type StoreSessionStoreJoins = {
+    accessTokens?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoins;
+          leftJoin?: undefined | StoreSessionStoreTokenJoins;
+          where?: undefined | StoreSessionStoreTokenWhere;
+          shortName?: undefined | string;
+        };
+  };
+  type StoreSessionStoreTokenJoins = {
+    session?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreJoins;
+          leftJoin?: undefined | StoreSessionStoreJoins;
+          where?: undefined | StoreSessionStoreWhere;
+          shortName?: undefined | string;
+        };
+    refreshToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoins;
+          leftJoin?: undefined | StoreSessionStoreTokenJoins;
+          where?: undefined | StoreSessionStoreTokenWhere;
+          shortName?: undefined | string;
+        };
+    accessToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoins;
+          leftJoin?: undefined | StoreSessionStoreTokenJoins;
+          where?: undefined | StoreSessionStoreTokenWhere;
+          shortName?: undefined | string;
+        };
   };
   type StoreSessionStoreTokenQueryBuilder = {
     where?: undefined | StoreSessionStoreTokenWhere;
@@ -557,6 +601,8 @@ declare global {
           | "session"
           | "refreshToken"
         )[];
+    leftJoin?: undefined | StoreSessionStoreTokenJoins;
+    innerJoin?: undefined | StoreSessionStoreTokenJoins;
     session?: undefined | StoreSessionStoreQueryBuilder;
     refreshToken?: undefined | StoreSessionStoreTokenQueryBuilder;
     accessToken?: undefined | StoreSessionStoreTokenQueryBuilder;
@@ -919,7 +965,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreFileJoinsInput;
+    innerJoin?: undefined | StoreFileJoinsInput;
   };
+  type StoreFileJoinsInput = StoreFileJoins;
   type StoreJobQueryBuilderInput = {
     where?: undefined | StoreJobWhereInput;
     orderBy?: undefined | StoreJobOrderByInput;
@@ -941,7 +990,10 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreJobJoinsInput;
+    innerJoin?: undefined | StoreJobJoinsInput;
   };
+  type StoreJobJoinsInput = StoreFileJoins;
   type StoreSessionStoreQueryBuilderInput = {
     where?: undefined | StoreSessionStoreWhereInput;
     orderBy?: undefined | StoreSessionStoreOrderByInput;
@@ -959,7 +1011,45 @@ declare global {
           | "createdAt"
           | "updatedAt"
         )[];
+    leftJoin?: undefined | StoreSessionStoreJoinsInput;
+    innerJoin?: undefined | StoreSessionStoreJoinsInput;
     accessTokens?: undefined | StoreSessionStoreTokenQueryBuilderInput;
+  };
+  type StoreSessionStoreJoinsInput = {
+    accessTokens?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          where?: undefined | StoreSessionStoreTokenWhereInput;
+          shortName?: undefined | string;
+        };
+  };
+  type StoreSessionStoreTokenJoinsInput = {
+    session?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreJoinsInput;
+          where?: undefined | StoreSessionStoreWhereInput;
+          shortName?: undefined | string;
+        };
+    refreshToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          where?: undefined | StoreSessionStoreTokenWhereInput;
+          shortName?: undefined | string;
+        };
+    accessToken?:
+      | undefined
+      | {
+          innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+          where?: undefined | StoreSessionStoreTokenWhereInput;
+          shortName?: undefined | string;
+        };
   };
   type StoreSessionStoreTokenQueryBuilderInput = {
     where?: undefined | StoreSessionStoreTokenWhereInput;
@@ -978,6 +1068,8 @@ declare global {
           | "session"
           | "refreshToken"
         )[];
+    leftJoin?: undefined | StoreSessionStoreTokenJoinsInput;
+    innerJoin?: undefined | StoreSessionStoreTokenJoinsInput;
     session?: undefined | StoreSessionStoreQueryBuilderInput;
     refreshToken?: undefined | StoreSessionStoreTokenQueryBuilderInput;
     accessToken?: undefined | StoreSessionStoreTokenQueryBuilderInput;


### PR DESCRIPTION
TODO:
- [ ] Tests
- [ ] Docs

These joins can be used for two main reasons;
- For a custom `orderBy` that needs to order based on the values of another table.
- To hoist a duplicate `where.via` for better performance.

Closes #1889

BREAKING CHANGES:
- The existing generated output for query builders is incompatible with the updated query builder helpers from @compas/store. Make sure that the packages are updated and have been regenerated before your applications.