### PR TITLE
fix(examples): with-auth added axios as dev package

### DIFF
--- a/examples/with-auth/package.json
+++ b/examples/with-auth/package.json
@@ -11,7 +11,8 @@
   },
   "devDependencies": {
     "@compas/code-gen": "*",
-    "@compas/eslint-plugin": "*"
+    "@compas/eslint-plugin": "*",
+    "axios": "0.27.2"
   },
   "prettier": "@compas/eslint-plugin/prettierrc",
   "exampleMetadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,8 @@
       },
       "devDependencies": {
         "@compas/code-gen": "*",
-        "@compas/eslint-plugin": "*"
+        "@compas/eslint-plugin": "*",
+        "axios": "0.27.2"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -12966,6 +12967,7 @@
         "@compas/server": "*",
         "@compas/stdlib": "*",
         "@compas/store": "*",
+        "axios": "0.27.2",
         "bcrypt": "5.0.1"
       }
     },


### PR DESCRIPTION
with-auth was missing axios in packages, required for testing.

Closes https://github.com/compasjs/compas/issues/2106