### PR TITLE
fix(code-gen): remove axiosInstance as param on `useFooBar.invalidate` calls

### DIFF
--- a/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
+++ b/packages/code-gen/src/generator/reactQuery/templates/reactQueryFn.tmpl
@@ -166,7 +166,6 @@ data: {
  */
 {{= funcName }}.invalidate = (
 queryClient: QueryClient,
-axiosInstance: AxiosInstance,
 {{ if (item.params || item.query || item.body) { }}
 keyInput: {
 {{= item.params ? `params: ${paramsType},` : "" }}


### PR DESCRIPTION
Closes #2114

BREAKING CHANGE:
- `useFooBar.invalidate()` does not accept an `AxiosInstance` anymore.