### PR TITLE
feat(cli,eslint-plugin): bump Prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6052,9 +6052,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -7421,7 +7421,7 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-jsdoc": "39.6.2",
-        "prettier": "2.7.1"
+        "prettier": "2.8.0"
       },
       "engines": {
         "node": ">=16"
@@ -8978,7 +8978,7 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-jsdoc": "39.6.2",
-        "prettier": "2.7.1"
+        "prettier": "2.8.0"
       }
     },
     "@compas/server": {
@@ -12026,9 +12026,9 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
     },
     "prismjs": {
       "version": "1.28.0",

--- a/packages/cli/src/compas/commands/lint.js
+++ b/packages/cli/src/compas/commands/lint.js
@@ -52,7 +52,8 @@ export async function cliExecutor(logger, state) {
 
     /** @type {string} */
     // @ts-ignore
-    const cacheLocation = state.flags.eslintCacheLocation ?? "./.cache/eslint/";
+    const eslintCacheLocation =
+      state.flags.eslintCacheLocation ?? "./.cache/eslint/";
 
     const { exitCode: lint } = await spawn("npx", [
       "eslint",
@@ -63,7 +64,7 @@ export async function cliExecutor(logger, state) {
       "--cache-strategy",
       "content",
       "--cache-location",
-      cacheLocation,
+      eslintCacheLocation,
     ]);
 
     exitCode = lint;
@@ -72,8 +73,20 @@ export async function cliExecutor(logger, state) {
   if (state.flags.skipPrettier !== true) {
     logger.info("Running Prettier...");
 
+    const prettierCacheLocation = "./.cache/prettier/.cache";
+
     const prettierCommand =
-      environment.CI === "true" ? ["--check"] : ["--write", "--list-different"];
+      environment.CI === "true"
+        ? ["--check"]
+        : [
+            "--write",
+            "--list-different",
+            "--cache",
+            "--cache-strategy",
+            "content",
+            "--cache-location",
+            prettierCacheLocation,
+          ];
 
     const { exitCode: pretty } = await spawn("npx", [
       "prettier",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -26,7 +26,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsdoc": "39.6.2",
-    "prettier": "2.7.1"
+    "prettier": "2.8.0"
   },
   "author": {
     "name": "Dirk de Visser",


### PR DESCRIPTION
This enables the new `--cache` and `--cache-location` features for Prettier. We already use these for a bit with ESLint.

In this repo we get the following results (on only a few runs), runs without cache already use the ESLint cache features:

- `compas generate`:
  - Before: ~18.5 seconds
  - Building cache: ~20.5 seconds
  - With cache: ~13.5 seconds
- `compas lint`:
  - Before: ~7.8 seconds
  - Building cache: ~10 seconds
  - With cache: ~1.8 seconds