### PR TITLE
feat(stdlib): completer Axios and Postgres error formatting by AppError#format

### DIFF
--- a/packages/server/src/app.test.js
+++ b/packages/server/src/app.test.js
@@ -112,11 +112,10 @@ test("server/app", (t) => {
     } catch (e) {
       const formatted = AppError.format(e);
       t.equal(formatted.name, "AxiosError");
-      t.ok(isPlainObject(formatted.axios.responseHeaders));
-      t.ok(isPlainObject(formatted.axios.responseBody));
-      t.equal(formatted.axios.responseStatus, 500);
-      t.equal(formatted.axios.requestPath, "/wrap-500");
-      t.equal(formatted.axios.requestMethod, "GET");
+      t.ok(isPlainObject(formatted.axios.response.body));
+      t.equal(formatted.axios.response.status, 500);
+      t.equal(formatted.axios.request.path, "/wrap-500");
+      t.equal(formatted.axios.request.method, "GET");
     }
   });
 

--- a/packages/stdlib/src/error.js
+++ b/packages/stdlib/src/error.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-import { Readable } from "stream";
 import { inspect } from "util";
 import { isNil, isPlainObject } from "./lodash.js";
 

--- a/packages/stdlib/src/error.js
+++ b/packages/stdlib/src/error.js
@@ -1,5 +1,6 @@
 // @ts-nocheck
 
+import { Readable } from "stream";
 import { inspect } from "util";
 import { isNil, isPlainObject } from "./lodash.js";
 
@@ -172,19 +173,52 @@ export class AppError extends Error {
           code: e?.code,
           position: e?.position,
           routine: e?.routine,
+          severity_local: e?.severity_local,
+          file: e?.file,
+          line: e?.line,
+
+          detail: e?.detail,
+          hint: e?.hint,
+          internal_position: e?.internal_position,
+          internal_query: e?.internal_query,
+          where: e?.where,
+          schema_name: e?.schema_name,
+          table_name: e?.table_name,
+          column_name: e?.column_name,
+          data: e?.data,
+          type_name: e?.type_name,
+          constraint_name: e?.constraint_name,
+
+          query: e?.query,
+          parameters: e?.parameters,
         },
         stack,
       };
     } else if (e.isAxiosError) {
+      // Dumping is most of the time not what the user expects, so prevent these from
+      // being added to the result.
+      const body =
+        typeof e.response?.data?.pipe === "function" && // @ts-ignore
+        typeof e.response?.data?._read === "function"
+          ? {
+              message:
+                "Response was a stream, which can not be serialized by AppError#format. Use a try-catch and 'streamToBuffer(e.response?.data)' to get the provided response.",
+            }
+          : e.response?.data;
+
       return {
         name: e.name,
         message: e.message,
         axios: {
-          requestPath: e.request?.path,
-          requestMethod: e.request?.method,
-          responseStatus: e.response?.status,
-          responseHeaders: e.response?.headers,
-          responseBody: e.response?.data,
+          request: {
+            path: e.request?.path,
+            method: e.request?.method,
+            baseUrl: e.request?.baseURL,
+          },
+          response: {
+            status: e.response?.status,
+            body,
+          },
         },
         stack,
       };


### PR DESCRIPTION


Added all possible fields of Postgres errors, a bunch of them will be undefined, which are skipped when serialized to JSON. When running in debug mode, the query & parameters will be added by the Postgres library, so these will be added as well.

The formatted Axios error is reshaped, adding request headers and preventing response streams from being added. The request headers are added and the Au

BREAKING CHANGE:
- `axios.requestPath` and `axios.requestMethod` are replaced by `axios.request.path` and `axios.request.method`.
- `axios.responseStatus`and `axios.responseBody` are replaced by `axios.response.status`, `axios.response.body`.
- `axios.responseHeaders` is removed from the error to prevent session tokens in the logs by default.