### PR TITLE
fix(store): flush file deletion batches while iterating in `jobFileCleanup`

### DIFF
--- a/packages/store/src/file.js
+++ b/packages/store/src/file.js
@@ -351,18 +351,34 @@ export async function fileSyncDeletedWithObjectStorage(sql, s3Client, options) {
     $raw: query`meta->>'transformedFromOriginal' IS NOT NULL AND NOT EXISTS (SELECT FROM "file" f2 WHERE f2.id = (f.meta->>'transformedFromOriginal')::uuid)`,
   });
 
-  const objectsInStore = (
-    await queryFile({
-      select: ["id"],
-      where: {
-        bucketName: options.bucketName,
-      },
-    }).execRaw(sql)
-  ).map((it) => it.id);
+  const objectsInStore = new Set(
+    (
+      await queryFile({
+        select: ["id"],
+        where: {
+          bucketName: options.bucketName,
+        },
+      }).execRaw(sql)
+    ).map((it) => it.id),
+  );
 
   // S3 supports up to 1000 deletions in a single request
-  const maxSetSize = 999;
-  const deletingSet = [];
+  const maxSetSize = 1000;
+  let pending = [];
+
+  const flush = async () => {
+    if (pending.length === 0) return;
+    await s3Client.send(
+      new DeleteObjectsCommand({
+        Bucket: options.bucketName,
+        Delete: {
+          Objects: pending,
+          Quiet: true,
+        },
+      }),
+    );
+    pending = [];
+  };
 
   for await (const part of objectStorageListObjects(s3Client, {
     bucketName: options.bucketName,
@@ -372,31 +388,19 @@ export async function fileSyncDeletedWithObjectStorage(sql, s3Client, options) {
         continue;
       }
 
-      if (objectsInStore.includes(obj.Key)) {
+      if (objectsInStore.has(obj.Key)) {
         continue;
       }
 
-      deletingSet.push({
-        Key: obj.Key,
-      });
+      pending.push({ Key: obj.Key });
+
+      if (pending.length >= maxSetSize) {
+        await flush();
+      }
     }
   }
 
-  if (deletingSet.length === 0) {
-    return;
-  }
-
-  while (deletingSet.length) {
-    await s3Client.send(
-      new DeleteObjectsCommand({
-        Bucket: options.bucketName,
-        Delete: {
-          Objects: deletingSet.splice(0, maxSetSize),
-          Quiet: true,
-        },
-      }),
-    );
-  }
+  await flush();
 }
 
 /**

--- a/packages/store/src/file.test.js
+++ b/packages/store/src/file.test.js
@@ -383,6 +383,41 @@ test("store/file", (t) => {
         t.equal(e.name, "NotFound");
       }
     });
+
+    t.test("removes orphans, keeps tracked files", async (t) => {
+      const orphanIds = [uuid(), uuid(), uuid()];
+      const keptId = uuid();
+
+      for (const fileId of [...orphanIds, keptId]) {
+        await fileCreateOrUpdate(
+          sql,
+          s3Client,
+          { bucketName: testBucketName },
+          { id: fileId, name: "image.png" },
+          imagePath,
+        );
+      }
+
+      await queries.fileDelete(sql, { idIn: orphanIds });
+
+      await fileSyncDeletedWithObjectStorage(sql, s3Client, {
+        bucketName: testBucketName,
+      });
+
+      for (const orphanId of orphanIds) {
+        try {
+          await s3Client.send(
+            new HeadObjectCommand({
+              Key: orphanId,
+              Bucket: testBucketName,
+            }),
+          );
+          t.fail(`orphan ${orphanId} still present in S3`);
+        } catch (e) {
+          t.equal(e.name, "NotFound");
+        }
+      }
+    });
   });
 
   t.test("fileFormatMetadata", (t) => {


### PR DESCRIPTION
Additionally, flush DeleteObjects batches while streaming, not after.

Fixes https://github.com/compasjs/compas/issues/4057.